### PR TITLE
add platform paths to CubeCell runtime libs

### DIFF
--- a/docs/use-the-network/devices/development/heltec-cubecell-htcc-ab01/arduino.mdx
+++ b/docs/use-the-network/devices/development/heltec-cubecell-htcc-ab01/arduino.mdx
@@ -100,27 +100,34 @@ Next, to install this board support package:
 
 ### Manual updates to the Heltec runtime libraries
 
+Some versions of Heltec's runtime libraries have set default configuration variables to values that are incompatible with the Helium network, especially when the Heltec device is configured targeting the North American market. 
+
+The following discusses two Heltec runtime files that must be inspected to ensure compatiblity. The exact location of these files will depend on which operating system you are using, Windows, Linux, or Mac as well as where the Arduino IDE is installed.
+
+The typical top level locations of the runtime libraries is shown below for each operating system. From there the following discussions will present to you the file locations within these top level directories/folders. Please note the Heltec library version numbers are expected to change as time goes on.
+
+XXXXX denotes your specfic user id.
+
+##### Arduino IDE library location
+* Windows
+```text
+C:\Users\XXXX\AppData\Local\Arduino15\packages\CubeCell\hardware\CubeCell\1.0.0
+```
+* Linux
+```text
+/home/XXXXX/.arduino15/packages/CubeCell/hardware/CubeCell/1.0.0
+```
+* Mac
+```text
+/Users/XXXXX/Library/Arduino15/packages/CubeCell/hardware/CubeCell/1.0.0
+```
 #### Verify Data Rate
-
-Some versions of Heltec's runtime libraries have set a default configuration variable to a value that is incompatible with the Helium network, especially when the Heltec device is configured for the North American market. Before attempting to use the libraries it is best to verify the value of the variable.
-
-The location of the file of interest depends on the library installation directory of the IDE you are using, Arduino IDE vs Platformio IDE, as well as the host platform, Windows vs Linux vs Mac. With the Arduino IDE location, the library version number may also be different depending on when you download the package.
-
-For example on a Linux platform the files should be located at:
-
-Arduino IDE library version 1.0.0:
-
+Within an editor of your choice open the file path formed by prepending the above described platform specific top level directory structure to the following file:
 ```text
-~/.arduino15/packages/CubeCell/hardware/CubeCell/1.0.0/libraries/LoRa/src/LoRaWan_APP.cpp
+libraries/LoRa/src/LoRaWan_APP.cpp    (Linux/Mac)
+libraries\LoRa\src\LoRaWan_APP.cpp     (Windows)
 ```
-
-Platformio IDE:
-
-```text
-~/.platformio/packages/framework-arduinoasrmicro650x/libraries/LoRa/src/LoRaWan_APP.cpp
-```
-
-In LoRaWan\_APP.cpp look for \#define LORAWAN\_DEFAULT\_DATARATE  
+Within this file look for \#define LORAWAN\_DEFAULT\_DATARATE  
 Depending on the version of the Heltec runtime that is installed this default may be set to DR\_0, DR\_3, DR\_5 or some other value. Note: DR\_5 is not valid for US915, the North American market.
 
 The LORAWAN\_DEFAULT\_DATARATE setting is tied directly to the maximum size of the data packet you are transferring. While other runtime versions may allow programatic overide of this default, the Heltec implementation does not currently support overriding.
@@ -144,21 +151,18 @@ The above values are valid for the US902-928MHz region\(North America\), the val
 
 There are some versions of the Heltec runtime libraries that may set a LoRaWAN preamble size that is incompatible with the current LoRaWan specification. If the preamble size is not set correctly your device cannot join the network.
 
-This should be verified in the following file corresponding to your target LoRaWan region. For region US915 this file is RegionUS915.c:
+This should be verified in the region specific file corresponding to the region your device is targeting. 
+Be sure to prepend the above described platform specific top level directory structure.
 
-For Arduino IDE library version 1.0.0 the file is located:
-
-```text
-~/.arduino15/packages/CubeCell/hardware/CubeCell/1.0.0/cores/asr650x/loramac/mac/region/RegionUS915.c
-```
-
-Platformio IDE:
+The following is the file that must be checked if targeting region US915.
+Within an editor of your choice open the file path formed by prepending the above described platform specific top level directory structure to the following file:
 
 ```text
-~/.platformio/packages/framework-arduinoasrmicro650x/cores/asr650x/loramac/mac/region/RegionUS915.c
+cores/asr650x/loramac/mac/region/RegionUS915.c     (Linux/Mac)
+cores\asr650x\loramac\mac\region\RegionUS915.c     (Windows)
 ```
 
-In this file locate the line below, the 7th parameter which might be 14 should be changed to either 8 or 16. Either value will work. Later versions of the runtime may have this value set to 14 which should work just fine.
+Within this file locate the line below, the 7th parameter which might be 14 should be changed to either 8 or 16. Either value will work. Earlier versions of the runtime may have this value set to 14 which is "not" correct.
 
 Change:
 
@@ -178,21 +182,29 @@ Heltec support has been notified of these issues, hopefully a future release of 
 
 Find Directions on Heltec's website [here](https://heltec-automation-docs.readthedocs.io/en/latest/general/establish_serial_connection.html).
 
-### Select Board
+### Set Project Configuration Options
+The following options are set via the Arduino IDE Tools menu:
 
-Arduino IDE:
+#### Select Board
 
-If you are using the HTCC-AB02 flavor of Heltec board 1. Select Tools -&gt; Board: -&gt;CubeCell-Board \(HTCC-AB02\)
+If you are using the HTCC-AB02 flavor of Heltec board
+- Select Tools -&gt; Board: -&gt;CubeCell-Board \(HTCC-AB02\)
 
-If you are using the HTCC-AB02S GPS enabled flavor of Heltec board 1. Select Tools -&gt; Board: -&gt;CubeCell-GPS \(HTCC-AB02S\)
+If you are using the HTCC-AB02S GPS enabled flavor of Heltec board
+- Select Tools -&gt; Board: -&gt;CubeCell-GPS \(HTCC-AB02S\)
 
-### Select Region
+#### Select LoraWAN Configuration Options
 
-Arduino IDE: Until you are familiar with their configuration behavior it is recommended you set the board options as follows: 1. Select Tools -&gt; LORAWAN_REGION: -&gt; REGION\_US915 2. Select Tools -&gt; LORAWAN\_CLASS: -&gt; CLASS\_A 3. Select Tools -&gt; LORAWAN\_NETMODE: -&gt; OTTA 4. Select Tools -&gt; LORAWAN\_ADR: -&gt; OFF 5. Select Tools -&gt; LORAWAN\_UPLINKMODE: -&gt; UNCONFIRMED 6. Select Tools -&gt; LORAWAN\_Net\_Reservation: -&gt; OFF 7. Select Tools -&gt; LORAWAN\_AT\_SUPPORT: -&gt; OFF 8. Select Tools -&gt; LORAWAN\_AT\_RGB : -&gt; ACTIVE 9. Select Tools -&gt; LoRaWan_ Debug Level : -&gt; FREQ&&DIO \(for most verbose messages\)
-
-### Select **Uplink Mode**
-
-The last step before we upload our sketch is to select the LoRaWAN Uplink Mode, navigate to **\(Tools &gt; LoRaWAN Uplink Mode: &gt; UNCONFIRMED\).**
+Arduino IDE: Until you are familiar with their configuration behavior it is recommended you set the board options as follows:
+- Select Tools -&gt; LORAWAN_REGION: -&gt; REGION\_US915
+- Select Tools -&gt; LORAWAN\_CLASS: -&gt; CLASS\_A
+- Select Tools -&gt; LORAWAN\_NETMODE: -&gt; OTTA
+- Select Tools -&gt; LORAWAN\_ADR: -&gt; OFF
+- Select Tools -&gt; LORAWAN\_UPLINKMODE: -&gt; UNCONFIRMED
+- Select Tools -&gt; LORAWAN\_Net\_Reservation: -&gt; OFF
+- Select Tools -&gt; LORAWAN\_AT\_SUPPORT: -&gt; OFF
+- Select Tools -&gt; LORAWAN\_AT\_RGB : -&gt; ACTIVE
+- Select Tools -&gt; LoRaWan_ Debug Level : -&gt; FREQ&&DIO \(for most verbose messages\)
 
 ### Programming **Example Sketch**
 


### PR DESCRIPTION
Adding platform specific library paths to the Heltec runtimes. 
Also updated the Arduino IDE project configuration to include all LoRaWAN params.
Removed any reference to PlatformIO