### PR TITLE
fix wirness/challengees percentage + example 1

### DIFF
--- a/docs/blockchain/mining/mining.mdx
+++ b/docs/blockchain/mining/mining.mdx
@@ -79,8 +79,8 @@ the following reward types:
 | Reward Type           | Percentage    | HNT Earned by Reward Type |
 | :-------------------- | :------------ | :------------------------ |
 | PoC Challenger        | .95%          | 32.53427                  |
-| PoC Challengees       | 18%           | 616.43880                 |
-| Witnesses             | 8.55%         | 292.80843                 |
+| PoC Challengees       | 8.55%         | 292.80843                 |
+| Witnesses             | 18%           | 616.43880                 |
 | Consensus Group       | 6%            | 205.4796                  |
 | Security Tokens       | 34%           | 1164.3844                 |
 | Network Data Transfer | _Up to 32.5%_ | _Up to 1113.0145_         |
@@ -120,9 +120,9 @@ Here are a few examples to illustrate how this works in practice:
   routing packets at the 1:1 rate.
 - The remaining `1103.0145 HNT` from the Network Data Transfer reward would be
   distributed ratably among the Challengers, Witnesses and Challengees.
-  - `38.10413727` to the Challenger group
-  - `342.9372355` to the Witness group
-  - `721.9731273` to the Challengee group
+  - `10.47863775` to the Challenger group
+  - `198.54261` to the Witness group
+  - `94.30773975` to the Challengee group
 
 **Example 2: DC Burn exceeds 32.5% HNT**
 


### PR DESCRIPTION
I believe witnesses earn more than challengees, which is not what was documented
the example 1 contained calculations with the wrong percentages