### PR TITLE
Add `--init` to the Docker cmdline

### DIFF
--- a/docs/mine-hnt/validators/validator-deployment-guide.mdx
+++ b/docs/mine-hnt/validators/validator-deployment-guide.mdx
@@ -185,7 +185,7 @@ mkdir $HOME/validator_data
 You can then use the `run` command to start your container for the first time:
 
 ```
-docker run -d --init\
+docker run -d --init \
 --restart always \
 --publish 2154:2154/tcp \
 --name validator \

--- a/docs/mine-hnt/validators/validator-deployment-guide.mdx
+++ b/docs/mine-hnt/validators/validator-deployment-guide.mdx
@@ -185,7 +185,7 @@ mkdir $HOME/validator_data
 You can then use the `run` command to start your container for the first time:
 
 ```
-docker run -d \
+docker run -d --init\
 --restart always \
 --publish 2154:2154/tcp \
 --name validator \


### PR DESCRIPTION
Doing this has been discussed by folks running their own Docker miners. The typical reasons for not using tini (the --init flag) are if the code in the container is doing signal handling itself, if it is reaping zombies itself, or something else odd to PID 1 or the init system. From what I can tell, the validator/miner code is not doing those things, so I think adding `--init` to the recommended cmdline is useful.