### PR TITLE
Clarify validator unstaking cooldown semantics

### DIFF
--- a/docs/mine-hnt/validators/wallet.mdx
+++ b/docs/mine-hnt/validators/wallet.mdx
@@ -64,7 +64,7 @@ As part of the staking process the validator node address needs to be in the sta
     * ```./helium-wallet validators stake <public-address> 10000 --commit```
 
 ### Unstake Tokens
-If you unstake tokens the validator node enters a cooldown period. During this cooldown period the validator node will not earn rewards and at the end of the cooldown period (currently 250,000 blocks or approximately 5 months) your initial staking amount will be returned to the wallet. The cooldown period will be shortened for the testnet to 360 blocks (approx. an hour).
+When you unstake tokens they enter a cooldown period. At the end of the cooldown period (currently 250,000 blocks or approximately 5 months) your initial staking amount will be returned to the wallet. A validator node should be terminated once it is unstaked. The cooldown period will be shortened for the testnet to 360 blocks (approx. an hour). 
 
 #### To unstake tokens from a validator node perform the following:
 ```./helium-wallet validators unstake <public-address> --commit```


### PR DESCRIPTION
Make it explicit that the validator node shouldn't be running once it has been unstaked.