### PR TITLE
Ensure Helium network is selected with Cayenne

### DIFF
--- a/docs/use-the-network/console/integrations/mydevices-cayenne.mdx
+++ b/docs/use-the-network/console/integrations/mydevices-cayenne.mdx
@@ -80,6 +80,12 @@ From the Cayenne dashboard, click **Add New** &gt; **Device / Widget**.
 From the list of devices & widgets that appears, click **LoRa** and select the
 **Helium** Network option to view a list of Helium supported devices.
 
+
+:::warning
+**Ensure you have selected the Helium Network**  
+You must select the Helium Network **before** searching for your device, else you may add your device on the wrong network and will not receive data.
+:::
+
 <img
   src={useBaseUrl(
     "img/use-the-network/console/integrations/integrations-mydevices-cayenne-search.png"


### PR DESCRIPTION
This caught me out, see:
https://community.mydevices.com/t/make-lora-network-more-explicit-when-adding-new-device-via-search/16163