### PR TITLE
Update build-a-packet-forwarder.mdx with new miner log location

### DIFF
--- a/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -392,14 +392,14 @@ If you want to make it easier, you can always create an an alias such as:
 This is always helpful to get some idea of what's going on:
 
 ```text
-docker exec miner tail -F /var/log/miner/console.log
+docker exec miner tail -F /var/data/log/console.log
 ```
 
 Also, if you are particularly interested in radio traffic, it can be helpful to
 filter for `lora` as so:
 
 ```text
-docker exec miner tail -f /var/log/miner/console.log | grep lora
+docker exec miner tail -f /var/data/log/console.log | grep lora
 ```
 
 ### Checking the P2P Network


### PR DESCRIPTION
Based on https://discord.com/channels/404106811252408320/730246424666832947/799040542658789437, this log is in a new spot. Had to re-build my DIY and ran into this issue. Please update docs, thanks!