### PR TITLE
Update build-a-packet-forwarder.mdx

### DIFF
--- a/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -11,8 +11,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 :::warning
 
-The ability to earn from [PoC](https://docs.helium.com/blockchain/proof-of-coverage) with anything other than an [Approved Hotspots](https://helium.com/mine) 
-is not supported. Packet forwarders are designed for sensor developers to test usage without needing a hotspot. If your interested in using the Helium network and earning from data transfer from your existing hardware, please check out the [Light Gateways Roadmap](https://docs.helium.com/mine-hnt/light-hotspots/)
+The ability to earn from [PoC](https://docs.helium.com/blockchain/proof-of-coverage) with anything other than an [Approved Hotspot](https://helium.com/mine) 
+is not supported. Packet forwarders are designed for sensor developers to test usage without needing a hotspot. If your interested in using the Helium network and earning from data transfer from your existing hardware, please check out the [Light Gateways Roadmap](https://docs.helium.com/mine-hnt/light-hotspots/).
 
 :::
 

--- a/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -11,10 +11,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 :::warning
 
-Packet forwarders will only earn from data transfer. Do not attempt to build one unless 
-you wish to run sensors or convert existing hardware to use data on the helium network.
-The ability to mine fully mine HNT with anything other than an [Approved Hotspots](https://helium.com/mine) 
-is not supported.
+The ability to earn from [PoC]https://docs.helium.com/blockchain/proof-of-coverage with anything other than an [Approved Hotspots](https://helium.com/mine) 
+is not supported. Packet forwarders are designed for sensor developers to test usage without needing a hotspot. If your interested in using the Helium network and earning from data transfer from your existing hardware, please check out the [Light Gateways Roadmap]https://docs.helium.com/mine-hnt/light-hotspots/
 
 :::
 

--- a/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -11,8 +11,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 :::warning
 
-The ability to earn from [PoC]https://docs.helium.com/blockchain/proof-of-coverage with anything other than an [Approved Hotspots](https://helium.com/mine) 
-is not supported. Packet forwarders are designed for sensor developers to test usage without needing a hotspot. If your interested in using the Helium network and earning from data transfer from your existing hardware, please check out the [Light Gateways Roadmap]https://docs.helium.com/mine-hnt/light-hotspots/
+The ability to earn from [PoC](https://docs.helium.com/blockchain/proof-of-coverage) with anything other than an [Approved Hotspots](https://helium.com/mine) 
+is not supported. Packet forwarders are designed for sensor developers to test usage without needing a hotspot. If your interested in using the Helium network and earning from data transfer from your existing hardware, please check out the [Light Gateways Roadmap](https://docs.helium.com/mine-hnt/light-hotspots/)
 
 :::
 

--- a/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/mine-hnt/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -11,10 +11,10 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 :::warning
 
-The ability to mine HNT with anything other than
-[Approved Hotspots](https://helium.com/mine) is not supported. Please join the
-#diy-packet-forwarder in the [Helium Discord Server](https://discord.gg/helium)
-for the latest updates.
+Packet forwarders will only earn from data transfer. Do not attempt to build one unless 
+you wish to run sensors or convert existing hardware to use data on the helium network.
+The ability to mine fully mine HNT with anything other than an [Approved Hotspots](https://helium.com/mine) 
+is not supported.
 
 :::
 


### PR DESCRIPTION
changed the warning to hopefully make it clearer to hosts about earnings, and killed the discord link to stop feedback and folks finding older posts that are not relevant anymore.