### PR TITLE
Add Development Device Quickstart Guides Doc

### DIFF
--- a/docs/use-the-network/devices/development/quickstart-guides.mdx
+++ b/docs/use-the-network/devices/development/quickstart-guides.mdx
@@ -1,0 +1,33 @@
+---
+id: quickstart-guides
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Quickstart Guides
+slug: /use-the-network/devices/development/quickstart-guides
+---
+
+## Development Device Quickstart Guides
+
+Quickstart guides are provided for some of the most popular development boards.  
+The guides will cover every step needed to program and send packets on the network.
+
+#### [ST B-L072Z-LRWAN1](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1)
+- [Arduino](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/arduino)
+- [Platform IO](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/platformio)
+
+#### [Sparkfun Pro RF](/use-the-network/devices/development/sparkfun/pro-rf)
+- [Arduino](/use-the-network/devices/development/sparkfun/pro-rf/arduino)
+
+#### [Adafruit Feather MO](/use-the-network/devices/development/adafruit/adafruit-feather-m0-rfm95)
+- [Arduino](/use-the-network/devices/development/adafruit/adafruit-feather-m0-rfm95/arduino)
+
+#### [Heltec Cubecell](/use-the-network/devices/development/heltec/cubecell-dev-board)
+- [Arduino](/use-the-network/devices/development/heltec/cubecell-dev-board/arduino)
+- [Platform IO](/use-the-network/devices/development/heltec/cubecell-dev-board/platformio)
+
+#### [Heltec WiFi LoRa 32 V2](/use-the-network/devices/development/heltec/wifi-lora-32-v2)
+- [Arduino](/use-the-network/devices/development/heltec/wifi-lora-32-v2/arduino)
+
+#### [RAK Wireless WisBlock Starter](/use-the-network/devices/development/rakwireless/wisblock-4631)
+- [Arduino](/use-the-network/devices/development/rakwireless/wisblock-4631/arduino)
+- [Platform IO](/use-the-network/devices/development/rakwireless/wisblock-4631/platformio)

--- a/docs/use-the-network/devices/development/quickstart-guides.mdx
+++ b/docs/use-the-network/devices/development/quickstart-guides.mdx
@@ -9,7 +9,7 @@ slug: /use-the-network/devices/development/quickstart-guides
 ## Development Device Quickstart Guides
 
 Quickstart guides are provided for some of the most popular development boards.  
-The guides will cover every step needed to program and send packets on the network.
+The guides cover every step needed to program and send packets on the network.
 
 #### [ST B-L072Z-LRWAN1](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1)
 - [Arduino](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/arduino)

--- a/docs/use-the-network/devices/development/rakwireless/wisblock-4631/arduino.mdx
+++ b/docs/use-the-network/devices/development/rakwireless/wisblock-4631/arduino.mdx
@@ -2,7 +2,7 @@
 id: arduino
 hide_title: true
 sidebar_label: Arduino
-slug: /use-the-network/devices/development/rak-wisblock-starter/arduino
+slug: /use-the-network/devices/development/rakwireless/wisblock-4631/arduino
 ---
 
 import useBaseUrl from "@docusaurus/useBaseUrl";

--- a/docs/use-the-network/devices/development/rakwireless/wisblock-4631/platformio.mdx
+++ b/docs/use-the-network/devices/development/rakwireless/wisblock-4631/platformio.mdx
@@ -2,7 +2,7 @@
 id: platformio
 hide_title: true
 sidebar_label: PlatformIO
-slug: /use-the-network/devices/development/rak-wisblock-starter/platformio
+slug: /use-the-network/devices/development/rakwireless/wisblock-4631/platformio
 ---
 
 import useBaseUrl from "@docusaurus/useBaseUrl";

--- a/docs/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/st-b-l072z-lrwan1.mdx
+++ b/docs/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/st-b-l072z-lrwan1.mdx
@@ -36,5 +36,5 @@ board, please see one of the guides below.
 
 ### Firmware Quickstart Guides
 
-[Arduino Guide](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/arduino)  
-[PlatformIO Guide](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/platformio)
+- [Arduino Guide](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/arduino)  
+- [PlatformIO Guide](/use-the-network/devices/development/stmicroelectronics/st-b-l072z-lrwan1/platformio)

--- a/docs/use-the-network/devices/devices.mdx
+++ b/docs/use-the-network/devices/devices.mdx
@@ -31,7 +31,7 @@ For those looking to create a solution with purpose built end devices, our ready
 to use section provides device references and onboarding guides for some of the
 most well known manufactures.
 
-[Browse Devices](/use-the-network/devices/ready-to-use)
+[Browse Devices](/use-the-network/devices/ready-to-use)  
 
 ### Development Devices
 
@@ -39,4 +39,5 @@ If you are looking to develop a device for a new application, then our
 development section provides references and onboarding guides for some of the
 most popular development boards and modules available.
 
-[Browse Devices](/use-the-network/devices/development)
+- [Browse Devices](/use-the-network/devices/development)
+- [Quickstart Guides](/use-the-network/devices/development/quickstart-guides)

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -155,6 +155,21 @@ module.exports = {
       collapsed: false,
     },
   ],
+  devquickstart: [
+   {
+      type: 'link',
+      label: '<- Devices',
+      href: '/use-the-network/devices'
+    },
+    {
+      type: 'category',
+      label: 'Development Quickstart',
+      items: [
+        'use-the-network/devices/development/quickstart-guides'
+      ],
+      collapsed: false,
+    },
+  ],
   adafruit: [
    {
       type: 'link',


### PR DESCRIPTION
After adding the ability to browse devices by manufacture, there is no longer a quick way to see what devices have quickstart guides. This PR add a quickstart guides doc at `/use-the-network/devices/development/quickstart-guides` with all the available guides listed.