### PR TITLE
refactor to match the miner frequencies

### DIFF
--- a/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
+++ b/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
@@ -109,322 +109,373 @@ Also known as **US902-928**
 
 ## Frequency Plans by Country
 
+The following table provides a summary of the main chosen frequency plan for each country that the [Helium Miner](https://github.com/helium/miner/) supports and is based on the [LoRa Alliance Specification RP002-1.0.3](https://lora-alliance.org/wp-content/uploads/2021/05/RP-2-1.0.3.pdf). A community member has also created a useful tool called ["What Helium Region"](https://whatheliumregion.xyz/) based on this table to more easily determine what frequency you need.
+
 #### A <a id="a"></a>
 
-| Country             | Frequency Plan   | Regulatory document                                                                                                        |
-| :------------------ | :--------------- | :------------------------------------------------------------------------------------------------------------------------- |
-| Afghanistan         |                  |                                                                                                                            |
-| Albania             | EU863-870 EU433  | CEPT Rec. 70-03                                                                                                            |
-| Algeria             |                  | [CONDITIONS D’UTILISATION DES EQUIPEMENTS D’IDENTIFICATION PAR RADIOFREQUENCES - RFID](http://www.anf.dz/pdf/caf/RFID.pdf) |
-| Andorra             | EU863-870 EU433  | CEPT Rec. 70-03                                                                                                            |
-| Angola              | EU863-870 EU433  | CRASA follows CEPT Rec. 70-03                                                                                              |
-| Antigua and Barbuda |                  |                                                                                                                            |
-| Argentina           | AU915-928        | [RESOL-2018-581-APN-MM](https://www.enacom.gob.ar/multimedia/normativas/2018/res581MM.pdf)                                 |
-| Armenia             |                  | EN 302 208                                                                                                                 |
-| Australia           | AU915-928        |                                                                                                                            |
-| Austria             | EU863-870 EU433  | CEPT Rec. 70-03                                                                                                            |
-| Azerbaijan          | unknown, no CEPT | EN 302 208, CEPT Rec. 70-03                                                                                                |
+| Country                   | Frequency Plan   | Regulatory document                                                                                                        |
+| :------------------------ | :--------------- | :------------------------------------------------------------------------------------------------------------------------- |
+| Afghanistan \(AF\)        |                  |                                                                                                                            |
+| Albania \(AL\)            | EU868            | CEPT Rec. 70-03                                                                                                            |
+| Algeria \(DZ\)            | AS923-3          | [CONDITIONS D’UTILISATION DES EQUIPEMENTS D’IDENTIFICATION PAR RADIOFREQUENCES - RFID](http://www.anf.dz/pdf/caf/RFID.pdf) |
+| American Samoa \(AS\)     | US915            |                                                                                                                            |
+| Andorra \(AD\)            | EU868            | CEPT Rec. 70-03                                                                                                            |
+| Angola \(AO\)             |                  |                                                                                                                            |
+| Anguilla \(AI\)           | AU915            |                                                                                                                            |
+| Antarctica \(AQ\)         |                  |                                                                                                                            |
+| Antigua and Barbuda \(AG\)|                  |                                                                                                                            |
+| Argentina \(AR\)          | AU915            | [RESOL-2018-581-APN-MM](https://www.enacom.gob.ar/multimedia/normativas/2018/res581MM.pdf)                                 |
+| Armenia \(AM\)            | EU868            | EN 302 208                                                                                                                 |
+| Aruba \(AW\)              |                  |                                                                                                                            |
+| Australia \(AU\)          | AU915            |                                                                                                                            |
+| Austria \(AT\)            | EU868            | CEPT Rec. 70-03                                                                                                            |
+| Azerbaijan \(AZ\)         | EU433            | EN 302 208, CEPT Rec. 70-03                                                                                                |
 
 #### B <a id="b"></a>
 
-| Country                | Frequency Plan        | Regulatory document                                                                                                                                                                                                                                                                                                                                                                                                  |
-| :--------------------- | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bahamas                |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Bahrain                | EU863-870 EU433       | [Kingdom Of Bahrain National Frequency Plan](http://www.tra.org.bh/media/document/The%202009%20National%20Frequency%20Plan.pdf)                                                                                                                                                                                                                                                                                      |
-| Bangladesh             |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Barbados               |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Belarus                | unknown, limited CEPT | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Belgium                | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Belize                 |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Benin                  |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Bhutan                 |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Bolivia                | US902-928             |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Bosnia and Herzegovina | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Botswana               | EU863-870 EU433       | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                        |
-| Brazil                 | AU915-928             | [National Telecommunications Agency \(ANATEL\) Resolution No. 680, from June 27, 2017 - Portuguese only](http://www.anatel.gov.br/legislacao/resolucoes/2017/936-resolucao-680), Article 10 [National Telecommunications Agency \(ANATEL\) Act No. 14448, from December 4, 2017 - Portuguese only](http://www.anatel.gov.br/legislacao/atos-de-requisitos-tecnicos-de-certificacao/2017/1139-ato-14448) Section 10.3 |
-| Brunei                 | AS923-925 \(“AS2”\)   |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Bulgaria               | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Burkina Faso           |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Burundi                |                       |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Country                              | Frequency Plan        | Regulatory document                                                                                                                                                                                                                                                                                                                                                                                                    |
+| :----------------------------------- | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bahamas \(BS\)                       | US915                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Bahrain \(BH\)                       | EU868                 | [Kingdom Of Bahrain National Frequency Plan](http://www.tra.org.bh/media/document/The%202009%20National%20Frequency%20Plan.pdf)                                                                                                                                                                                                            |
+| Bangladesh \(BD\)                    | AS923-1               |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Barbados \(BB\)                      | AU915                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Belarus \(BY\)                       | EU868                 | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Belgium \(BE\)                       | EU868                 | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Belize \(BZ\)                        | AU915                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Benin \(BJ\)                         | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Bermuda \(BM\)                       | US915                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Bhutan \(BT\)                        | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Bolivia \(BO\)                       | AU915                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Bosnia and Herzegovina \(BA\)        | EU868                 | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Botswana \(BW\)                      | EU868                 | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                        |
+| Bouvet Island \(BV\)                 | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Brazil \(BR\)                        | AU915                 | [National Telecommunications Agency \(ANATEL\) Resolution No. 680, from June 27, 2017 - Portuguese only](http://www.anatel.gov.br/legislacao/resolucoes/2017/936-resolucao-680), Article 10 [National Telecommunications Agency \(ANATEL\) Act No. 14448, from December 4, 2017 - Portuguese only](http://www.anatel.gov.br/legislacao/atos-de-requisitos-tecnicos-de-certificacao/2017/1139-ato-14448) Section 10.3 |
+| British Indian Ocean Territory \(IO\)|                  | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                           |
+| British Virgin Islands \(VG\)        | AU915            | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                           |
+| Brunei \(BN\)                        | AS923-1          |                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Bulgaria \(BG\)                      | EU868            | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Burkina Faso \(BF\)                  |                  |                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Burundi \(BI\)                       | EU868            |                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 #### C <a id="c"></a>
 
-| Country                          | Frequency Plan      | Regulatory document                                                                                                           |
-| :------------------------------- | :------------------ | :---------------------------------------------------------------------------------------------------------------------------- |
-| Cabo Verde                       |                     |                                                                                                                               |
-| Cambodia                         | AS923-925 \(“AS2”\) |                                                                                                                               |
-| Cameroon                         |                     |                                                                                                                               |
-| Canada                           | US902-928           |                                                                                                                               |
-| Central African Republic \(CAR\) |                     |                                                                                                                               |
-| Chad                             |                     |                                                                                                                               |
-| Chile                            | AU915-928           | [FIJA NORMA TECNICA DE EQUIPOS DE ALCANCE REDUCIDO](https://www.leychile.cl/Consulta/m/norma_plana?org=&idNorma=240404)       |
-| China                            | CN470-510 CN779-787 |                                                                                                                               |
-| Colombia                         | US902-928           |                                                                                                                               |
-| Comoros                          |                     |                                                                                                                               |
-| Democratic Republic of the Congo | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                 |
-| Republic of the Congo            |                     |                                                                                                                               |
-| Costa Rica                       | US902-928           |                                                                                                                               |
-| Cote d’Ivoire                    |                     |                                                                                                                               |
-| Croatia                          | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                               |
-| Cuba                             |                     |                                                                                                                               |
-| Curaçao                          |                     | [Ministeriële regeling vrijstelling telecommunicatiemachtiging 2015](http://btnp.org/images/stories/pdf/telecom/PB_20153.pdf) |
-| Cyprus                           | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                               |
-| Czech Republic                   | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                               |
+| Country                        | Frequency Plan | Regulatory document                                                                                                           |
+| :----------------------------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| Cambodia \(KH\)                | AS923-1        |                                                                                                                               |
+| Cameroon \(CM\)                | EU433          |                                                                                                                               |
+| Canada \(CA\)                  | US915          |                                                                                                                               |
+| Cape Verde \(CV\)              |                |                                                                                                                               |
+| Cayman Islands \(KY\)          | US915          |                                                                                                                               |
+| Central African Republic \(CF\)|                |                                                                                                                               |
+| Chad \(TD\)                    |                |                                                                                                                               |
+| Chile \(CL\)                   | AU915          | [FIJA NORMA TECNICA DE EQUIPOS DE ALCANCE REDUCIDO](https://www.leychile.cl/Consulta/m/norma_plana?org=&idNorma=240404)       |
+| China \(CN\)                   | CN470          |                                                                                                                               |
+| Christmas Island \(CN\)        | AU915          |                                                                                                                               |
+| Cocos [Keeling] Islands \(CC\) | AU915          |                                                                                                                               |
+| Colombia \(CO\)                | AU915          |                                                                                                                               |
+| Comoros \(KM\)                 | EU868          |                                                                                                                               |
+| Congo [DRC] \(CD\)             |                | CRASA follows CEPT Rec. 70-03                                                                                                 |
+| Congo [Republic] \(CG\)        |                |                                                                                                                               |
+| Cook Islands \(CK\)            | AU915          |                                                                                                                               |
+| Costa Rica \(CR\)              | AS923-1        |                                                                                                                               |
+| Côte d’Ivoire \(CI\)           | EU868          |                                                                                                                               |
+| Croatia \(HR\)                 | EU868          | CEPT Rec. 70-03                                                                                                               |
+| Cuba \(CU\)                    | AS923-3        |                                                                                                                               |
+| Cyprus \(CY\)                  | EU868          | CEPT Rec. 70-03                                                                                                               |
+| Czech Republic \(CZ\)          | EU868          | CEPT Rec. 70-03                                                                                                               |
 
 #### D <a id="d"></a>
 
-| Country            | Frequency Plan  | Regulatory document |
-| :----------------- | :-------------- | :------------------ |
-| Denmark            | EU863-870 EU433 | CEPT Rec. 70-03     |
-| Djibouti           |                 |                     |
-| Dominica           |                 |                     |
-| Dominican Republic | US902-928       |                     |
+| Country                  | Frequency Plan | Regulatory document |
+| :----------------------- | :------------- | :------------------ |
+| Denmark \(DK\)           | EU868          | CEPT Rec. 70-03     |
+| Djibouti \(DJ\)          |                |                     |
+| Dominica \(DM\)          | AU915          |                     |
+| Dominican Republic \(DO\)| AU915          |                     |
 
 #### E <a id="e"></a>
 
 | Country                         | Frequency Plan  | Regulatory document           |
 | :------------------------------ | :-------------- | :---------------------------- |
-| Ecuador                         | US902-928       |                               |
-| Egypt                           |                 |                               |
-| El Salvador                     |                 |                               |
-| Equatorial Guinea               |                 |                               |
-| Eritrea                         |                 |                               |
-| Estonia                         | EU863-870 EU433 | CEPT Rec. 70-03               |
-| Eswatini \(formerly Swaziland\) | EU863-870 EU433 | CRASA follows CEPT Rec. 70-03 |
-| Ethiopia                        |                 |                               |
+| Ecuador \(EC\)                  | AU915           |                               |
+| Egypt \(EG\)                    | EU868           |                               |
+| El Salvador \(SV\)              | AU915           |                               |
+| Equatorial Guinea \(GQ\)        | EU868           |                               |
+| Eritrea \(ER\)                  |                 |                               |
+| Estonia \(EE\)                  | EU868           | CEPT Rec. 70-03               |
+| Eswatini [Swaziland] \(SZ\)     |                 | CRASA follows CEPT Rec. 70-03 |
+| Ethiopia \(ET\)                 |                 |                               |
 
 #### F <a id="f"></a>
 
-| Country | Frequency Plan  | Regulatory document |
-| :------ | :-------------- | :------------------ |
-| Fiji    |                 |                     |
-| Finland | EU863-870 EU433 | CEPT Rec. 70-03     |
-| France  | EU863-870 EU433 | CEPT Rec. 70-03     |
+| Country                            | Frequency Plan  | Regulatory document |
+| :--------------------------------- | :-------------- | :------------------ |
+| Falkland Islands \(FK\)            | EU868           |                     |
+| Faroe Islands \(FO\)               | EU868           |                     |
+| Fifi \(FJ\)                        |                 |                     |
+| Finland \(FI\)                     | EU868           | CEPT Rec. 70-03     |
+| France \(FR\)                      | EU868           | CEPT Rec. 70-03     |
+| French Guiana \(GF\)               | EU868           |                     |
+| French Polynesia \(PF\)            | EU868           |                     |
+| French Southern Territories \(TF\) | EU868           |                     |
 
 #### G <a id="g"></a>
 
 | Country       | Frequency Plan        | Regulatory document                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | :------------ | :-------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Gabon         |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Gambia        |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Georgia       | unknown, limited CEPT | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Germany       | EU863-870 EU433       | [Non-specific Short Range Devices \(SRD\) regulations](http://www.bnetza.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Allgemeinzuteilungen/2018_05_SRD_pdf.html), CEPT Rec. 70-03                                                                                                                                                                                                                                                   |
-| Ghana         |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Greece        | EU863-870 EU433       | [Radio frequency regulations](http://www.eett.gr/opencms/export/sites/default/admin/downloads/Announcments/AP399_034.pdf), [433MHz SRD regulations](http://www.eett.gr/opencms/export/sites/default/EETT/Electronic_Communications/Radio_Communications/TelecommunicationsEquipment/104v2.pdf), [868MHz SRD regulations](http://www.eett.gr/opencms/export/sites/default/EETT/Electronic_Communications/Radio_Communications/TelecommunicationsEquipment/105v2.pdf), CEPT Rec. 70-03 |
-| Grenada       |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Guatemala     |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Guinea        |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Guinea-Bissau |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| Guyana        | US902-928             |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Gabon \(GA\)        |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Gambia \(GM\)       | EU433                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Gaza Strip \(GZ\)   |                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Georgia \(GE\)      | EU868                 | CEPT Rec. 70-03                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Germany \(DE\)      | EU868                 | [Non-specific Short Range Devices \(SRD\) regulations](http://www.bnetza.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Allgemeinzuteilungen/2018_05_SRD_pdf.html), CEPT Rec. 70-03                                                                                                                                                                    |
+| Ghana \(GH\)        | EU433                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Gibraltar \(GI\)    | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Greece \(GR\)       | EU868                 | [Radio frequency regulations](http://www.eett.gr/opencms/export/sites/default/admin/downloads/Announcments/AP399_034.pdf), [433MHz SRD regulations](http://www.eett.gr/opencms/export/sites/default/EETT/Electronic_Communications/Radio_Communications/TelecommunicationsEquipment/104v2.pdf), [868MHz SRD regulations](http://www.eett.gr/opencms/export/sites/default/EETT/Electronic_Communications/Radio_Communications/TelecommunicationsEquipment/105v2.pdf), CEPT Rec. 70-03 |
+| Greenland \(GL\)    | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Grenada \(GD\)      | AU915                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guadeloupe \(GP\)   | EU868                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guam \(GU\)         | US915                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guatemala \(GT\)    | AU915                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guinea \(GN\)       | EU433                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guinea-Bissau \(GW\)|                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Guyana \(GY\)       | US915                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 #### H <a id="h"></a>
 
-| Country                            | Frequency Plan      | Regulatory document |
-| :--------------------------------- | :------------------ | :------------------ |
-| Haiti                              |                     |                     |
-| Honduras                           |                     |                     |
-| Hong Kong \(different than China\) | AS923-925 \(“AS2”\) |                     |
-| Hungary                            | EU863-870 EU433     | CEPT Rec. 70-03     |
+| Country                                 | Frequency Plan      | Regulatory document |
+| :-------------------------------------- | :------------------ | :------------------ |
+| Haiti \(HT\)                            |                     |                     |
+| Heard Island and McDonald Islands \(HM\)| AU915               |                     |
+| Honduras \(HN\)                         | AU915               |                     |
+| Hong Kong \(HK\)                        | AS923-1             |                     |
+| Hungary \(HU\)                          | EU868               | CEPT Rec. 70-03     |
 
 #### I <a id="i"></a>
 
-| Country   | Frequency Plan      | Regulatory document                                                                                                                                         |
-| :-------- | :------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Iceland   | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                             |
-| India     | IN865-867           | [Use of low power wireless equipments in the frequency band 865-867MHz for RFID](http://www.wpc.gov.in/WriteReadData/userfiles/file/RFID%20Delicensing.doc) |
-| Indonesia | AS923-925 \(“AS2”\) |                                                                                                                                                             |
-| Iran      |                     | EN 302 208                                                                                                                                                  |
-| Iraq      |                     |                                                                                                                                                             |
-| Ireland   | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                             |
-| Israel    |                     | EN 302 208                                                                                                                                                  |
-| Italy     | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                             |
+| Country            | Frequency Plan      | Regulatory document                                                                                                                                         |
+| :----------------- | :------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Iceland \(IS\)     | EU868               | CEPT Rec. 70-03                                                                                                                                             |
+| India \(IN\)       | IN865               | [Use of low power wireless equipments in the frequency band 865-867MHz for RFID](http://www.wpc.gov.in/WriteReadData/userfiles/file/RFID%20Delicensing.doc) |
+| Indonesia \(ID\)   | AS923-2             |                                                                                                                                                             |
+| Iran \(IR\)        | EU868               | EN 302 208                                                                                                                                                   |
+| Iraq \(IQ\)        |                     |                                                                                                                                                             |
+| Ireland \(IE\)     | EU868               | CEPT Rec. 70-03                                                                                                                                             |
+| Isle of Man \(IM\) | EU868               | CEPT Rec. 70-03                                                                                                                                             |
+| Israel \(IL\)      | AS923-4             | EN 302 208                                                                                                                                                   |
+| Italy \(IT\)       | EU868               | CEPT Rec. 70-03                                                                                                                                             |
 
 #### J <a id="j"></a>
 
-| Country | Frequency Plan      | Regulatory document                                                                     |
-| :------ | :------------------ | :-------------------------------------------------------------------------------------- |
-| Jamaica |                     |                                                                                         |
-| Japan   | AS920-923 \(“AS1”\) | [ARIB STD-T108](https://www.arib.or.jp/english/html/overview/doc/5-STD-T108v1_0-E1.pdf) |
-| Jordan  |                     |                                                                                         |
+| Country       | Frequency Plan      | Regulatory document                                                                     |
+| :------------ | :------------------ | :-------------------------------------------------------------------------------------- |
+| Jamaica \(JM\)| AU915               |                                                                                         |
+| Japan \(JP\)  | AS923-1             | [ARIB STD-T108](https://www.arib.or.jp/english/html/overview/doc/5-STD-T108v1_0-E1.pdf) |
+| Jersey \(JE\) | EU868               |                                                                                         |
+| Jordan \(JO\) | IN865               |                                                                                         |
 
 #### K <a id="k"></a>
 
-| Country    | Frequency Plan | Regulatory document |
-| :--------- | :------------- | :------------------ |
-| Kazakhstan |                |                     |
-| Kenya      |                |                     |
-| Kiribati   |                |                     |
-| Kosovo     |                |                     |
-| Kuwait     |                |                     |
-| Kyrgyzstan |                |                     |
+| Country           | Frequency Plan | Regulatory document |
+| :---------------- | :------------- | :------------------ |
+| Kazakhstan \(KZ\) | EU433          |                     |
+| Kenya \(KE\)      | EU868          |                     |
+| Kiribati \(KI\)   |                |                     |
+| Kosovo \(XK\)     |                |                     |
+| Kuwait \(KW\)     | EU868          |                     |
+| Kyrgyzstan \(KG\) |                |                     |
 
 #### L <a id="l"></a>
 
-| Country       | Frequency Plan      | Regulatory document                                                                                                                                                                                      |
-| :------------ | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Laos          | AS923-925 \(“AS2”\) |                                                                                                                                                                                                          |
-| Latvia        | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                          |
-| Lebanon       |                     |                                                                                                                                                                                                          |
-| Lesotho       | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03, [Radio Spectrum Management Guidelines and Procedures 2014](http://www.lca.org.ls/images/documents/Radio%20Spectrum%20Management%20Guidelines%20and%20Procedures_2014.pdf) |
-| Liberia       |                     |                                                                                                                                                                                                          |
-| Libya         |                     |                                                                                                                                                                                                          |
-| Liechtenstein | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                          |
-| Lithuania     | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                          |
-| Luxembourg    | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                          |
+| Country             | Frequency Plan      | Regulatory document                                                                                                                                                                                      |
+| :------------------ | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Laos \(LA\)         | AS923-1             |                                                                                                                                                                                                          |
+| Latvia \(LV\)       | EU868               | CEPT Rec. 70-03                                                                                                                                                                                          |
+| Lebanon \(LB\)      | EU868               |                                                                                                                                                                                                          |
+| Lesotho \(LS\)      | EU433               | CRASA follows CEPT Rec. 70-03, [Radio Spectrum Management Guidelines and Procedures 2014](http://www.lca.org.ls/images/documents/Radio%20Spectrum%20Management%20Guidelines%20and%20Procedures_2014.pdf) |
+| Liberia \(LR\)      |                     |                                                                                                                                                                                                          |
+| Libya \(LY\)        |                     |                                                                                                                                                                                                          |
+| Liechtenstein \(LI\)| EU868               | CEPT Rec. 70-03                                                                                                                                                                                          |
+| Lithuania \(LT\)    | EU868               | CEPT Rec. 70-03                                                                                                                                                                                          |
+| Luxembourg \(LU\)   | EU868               | CEPT Rec. 70-03                                                                                                                                                                                          |
 
 #### M <a id="m"></a>
 
-| Country           | Frequency Plan      | Regulatory document                                                                                                                                        |
-| :---------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Madagascar        | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
-| Malawi            | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
-| Malaysia          | AS920-923 \(“AS1”\) |                                                                                                                                                            |
-| Maldives          |                     |                                                                                                                                                            |
-| Mali              |                     |                                                                                                                                                            |
-| Malta             | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                            |
-| Marshall Islands  |                     |                                                                                                                                                            |
-| Mauritania        |                     |                                                                                                                                                            |
-| Mauritius         | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
-| Mexico            | US902-928           |                                                                                                                                                            |
-| Micronesia        |                     |                                                                                                                                                            |
-| Moldova           | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                            |
-| Monaco            |                     |                                                                                                                                                            |
-| Mongolia          |                     |                                                                                                                                                            |
-| Montenegro        | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                            |
-| Morocco           |                     | [Decision ANRT/DG/Nº08/13 - 20th June 2013](https://www.anrt.ma/sites/default/files/2013-08-13-condit-tech-install-radioelect-app-faible-puissance-fr.pdf) |
-| Mozambique        | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
-| Myanmar \(Burma\) |                     |                                                                                                                                                            |
+| Country                 | Frequency Plan      | Regulatory document                                                                                                                                        |
+| :---------------------  | :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Macau \(MO\)            | AS923-1             | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| North Macedonia \(MK\)  | EU868               | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Madagascar \(MG\)       | EU868               | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Malawi \(MW\)           |                     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Malaysia \(MY\)         | AS923-1             |                                                                                                                                                            |
+| Maldives \(MV\)         |                     |                                                                                                                                                            |
+| Mali \(ML\)             | EU433               |                                                                                                                                                            |
+| Malta \(MT\)            | EU868               | CEPT Rec. 70-03                                                                                                                                            |
+| Marshall Islands \(MH\) |                     |                                                                                                                                                            |
+| Martinique \(MQ\)       | EU868               |                                                                                                                                                            |
+| Mauritania \(MR\)       | EU868               |                                                                                                                                                            |
+| Mauritius \(MU\)        | EU433               | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Mayotte \(YT\)          | EU868               |                                                                                                                                                            |
+| Mexico \(MX\)           | US915               |                                                                                                                                                            |
+| Micronesia \(FM\)       |                     |                                                                                                                                                            |
+| Moldova \(MD\)          | EU868               | CEPT Rec. 70-03                                                                                                                                            |
+| Monaco \(MC\)           | EU868               |                                                                                                                                                            |
+| Mongolia \(MN\)         |                     |                                                                                                                                                            |
+| Montenegro \(ME\)       | EU868               | CEPT Rec. 70-03                                                                                                                                            |
+| Montserrat \(MS\)       | AU915               |                                                                                                                                                            |
+| Morocco \(MA\)          | EU433               | [Decision ANRT/DG/Nº08/13 - 20th June 2013](https://www.anrt.ma/sites/default/files/2013-08-13-condit-tech-install-radioelect-app-faible-puissance-fr.pdf) |
+| Mozambique \(MZ\)       |                     | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Myanmar [Burma] \(MM\)  | AS923-1             |                                                                                                                                                            |
 
 #### N <a id="n"></a>
 
-| Country         | Frequency Plan        | Regulatory document                                                                                                                                        |
-| :-------------- | :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Namibia         | EU863-870 EU433       | CRASA follows CEPT Rec. 70-03                                                                                                                              |
-| Nauru           |                       |                                                                                                                                                            |
-| Nepal           |                       |                                                                                                                                                            |
-| Netherlands     | EU863-870 EU433       | [Regeling gebruik van frequentieruimte zonder vergunning en zonder meldingsplicht 2015](http://wetten.overheid.nl/BWBR0036378/2016-12-28), CEPT Rec. 70-03 |
-| New Zealand     | AU915-928             | [Radio Spectrum Management](https://www.rsm.govt.nz/about-rsm/spectrum-policy/gazette/gurl/short-range-devices)                                            |
-| Nicaragua       |                       |                                                                                                                                                            |
-| Niger           |                       |                                                                                                                                                            |
-| Nigeria         |                       |                                                                                                                                                            |
-| North Macedonia | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                            |
-| North Korea     |                       |                                                                                                                                                            |
-| Norway          | unknown, limited CEPT | CEPT Rec. 70-03                                                                                                                                            |
+| Country                     | Frequency Plan        | Regulatory document                                                                                                                                        |
+| :-------------------------- | :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Namibia \(NA\)                 | EU868                 | CRASA follows CEPT Rec. 70-03                                                                                                                              |
+| Nauru \(NR\)                   |                       |                                                                                                                                                            |
+| Nepal \(NP\)                   |                       |                                                                                                                                                            |
+| Netherlands \(NL\)             | EU868                 | [Regeling gebruik van frequentieruimte zonder vergunning en zonder meldingsplicht 2015](http://wetten.overheid.nl/BWBR0036378/2016-12-28), CEPT Rec. 70-03 |
+| Netherlands Antilles \(AN\)    |                       |                                                                                                                                                            |
+| New Caledonia \(NC\)           | EU868                 |                                                                                                                                                            |
+| New Zealand \(NZ\)             | AU915                 | [Radio Spectrum Management](https://www.rsm.govt.nz/about-rsm/spectrum-policy/gazette/gurl/short-range-devices)                                            |
+| Nicaragua \(NI\)               | AU915                 |                                                                                                                                                            |
+| Niger \(NE\)                   | IN865                 |                                                                                                                                                            |
+| Nigeria \(NG\)                 | EU868                 |                                                                                                                                                            |
+| Niue \(NU\)                    | AU915                 | CEPT Rec. 70-03                                                                                                                                            |
+| Norfolk Island \(NF\)          | AU915                 |                                                                                                                                                            |
+| North Korea \(KP\)             |                       |                                                                                                                                                            |
+| Northern Mariana Islands \(MP\)| US915                 |                                                                                                                                                            |
+| Norway \(NO\)                  | EU868                 | CEPT Rec. 70-03                                                                                                                                            |
 
 #### O <a id="o"></a>
 
-| Country | Frequency Plan | Regulatory document |
-| :------ | :------------- | :------------------ |
-| Oman    |                | EN 302 208          |
+| Country     | Frequency Plan | Regulatory document |
+| :---------- | :------------- | :------------------ |
+| Oman \(OM\) | EU868          | EN 302 208          |
 
 #### P <a id="p"></a>
 
-| Country          | Frequency Plan  | Regulatory document                                                                                                                                                                                                 |
-| :--------------- | :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Pakistan         |                 |                                                                                                                                                                                                                     |
-| Palau            |                 |                                                                                                                                                                                                                     |
-| Palestine        |                 |                                                                                                                                                                                                                     |
-| Panama           | US902-928       |                                                                                                                                                                                                                     |
-| Papua New Guinea |                 |                                                                                                                                                                                                                     |
-| Paraguay         | US902-928       |                                                                                                                                                                                                                     |
-| Peru             | US902-928       |                                                                                                                                                                                                                     |
-| Philippines      | EU863-870 EU433 | **NOTE:** This is not a license free band. If you connect to a commercial telecoms operator you are however allowed to use thier frequencies. Please check the rules and obtain a license before running a gateway. |
-| Poland           | EU863-870 EU433 | CEPT Rec. 70-03                                                                                                                                                                                                     |
-| Portugal         | EU863-870 EU433 | CEPT Rec. 70-03                                                                                                                                                                                                     |
-| Puerto Rico      | US902-928       |                                                                                                                                                                                                                     |
+| Country                 | Frequency Plan  | Regulatory document                                                                                                                                                                                                 |
+| :---------------------- | :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pakistan \(PK\)         | IN865           |                                                                                                                                                                                                                     |
+| Palau \(PW\)            |                 |                                                                                                                                                                                                                     |
+| Palestine \(PS\)        |                 |                                                                                                                                                                                                                     |
+| Panama \(PA\)           | AU915           |                                                                                                                                                                                                                     |
+| Papua New Guinea \(PG\) | AU915           |                                                                                                                                                                                                                     |
+| Paraguay \(PY\)         | AU915           |                                                                                                                                                                                                                     |
+| Peru \(PE\)             | AU915           |                                                                                                                                                                                                                     |
+| Philippines \(PH\)      | AS923-3         | **NOTE:** This is not a license free band. If you connect to a commercial telecoms operator you are however allowed to use thier frequencies. Please check the rules and obtain a license before running a gateway. |
+| Pitcairn Islands \(PN\) |                 | CEPT Rec. 70-03                                                                                                                                                                                                     |
+| Poland \(PL\)           | EU868           | CEPT Rec. 70-03                                                                                                                                                                                                     |
+| Portugal \(PT\)         | EU868           | CEPT Rec. 70-03                                                                                                                                                                                                     |
+| Puerto Rico \(PR\)      | US915           |                                                                                                                                                                                                                     |
 
 #### Q <a id="q"></a>
 
-| Country | Frequency Plan | Regulatory document |
-| :------ | :------------- | :------------------ |
-| Qatar   |                |                     |
+| Country      | Frequency Plan | Regulatory document |
+| :----------- | :------------- | :------------------ |
+| Qatar \(QA\) | EU868          |                     |
 
 #### R <a id="r"></a>
 
-| Country | Frequency Plan  | Regulatory document                                                                               |
-| :------ | :-------------- | :------------------------------------------------------------------------------------------------ |
-| Romania | EU863-870 EU433 | CEPT Rec. 70-03                                                                                   |
-| Russia  | EU863-870 EU433 | CEPT Rec. 70-03, [Decision ГКРЧ 07-20-03-001](http://minsvyaz.ru/ru/documents/4039/), Appendix 10 |
-| Rwanda  |                 |                                                                                                   |
+| Country        | Frequency Plan  | Regulatory document                                                                               |
+| :------------- | :-------------- | :------------------------------------------------------------------------------------------------ |
+| Réunion \(RE\) | EU868           |                                                                                                   |
+| Romania \(RO\) | EU868           | CEPT Rec. 70-03                                                                                   |
+| Russia \(RU\)  | RU864           | CEPT Rec. 70-03, [Decision ГКРЧ 07-20-03-001](http://minsvyaz.ru/ru/documents/4039/), Appendix 10 |
+| Rwanda \(RW\)  | EU868           |                                                                                                   |
 
 #### S <a id="s"></a>
 
-| Country                          | Frequency Plan      | Regulatory document                                                                                                                                                                                                               |
-| :------------------------------- | :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Saint Kitts and Nevis            |                     |                                                                                                                                                                                                                                   |
-| Saint Lucia                      |                     |                                                                                                                                                                                                                                   |
-| Saint Vincent and the Grenadines |                     |                                                                                                                                                                                                                                   |
-| Samoa                            |                     |                                                                                                                                                                                                                                   |
-| San Marino                       |                     |                                                                                                                                                                                                                                   |
-| Sao Tome and Principe            |                     |                                                                                                                                                                                                                                   |
-| Saudi Arabia                     | EU863-870 EU433     | [National frequency plan in the kingdom of Saudi Arabia](http://www.citc.gov.sa/en/RulesandSystems/RegulatoryDocuments/FrequencySpectrum/Documents/SM%20002%20E-NFP.pdf)                                                          |
-| Senegal                          |                     |                                                                                                                                                                                                                                   |
-| Serbia                           | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                   |
-| Seychelles                       | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                     |
-| Sierra Leone                     |                     |                                                                                                                                                                                                                                   |
-| Singapore                        | AS920-923 \(“AS1”\) |                                                                                                                                                                                                                                   |
-| Slovakia                         | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                   |
-| Slovenia                         | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                   |
-| Solomon Islands                  |                     |                                                                                                                                                                                                                                   |
-| Somalia                          |                     |                                                                                                                                                                                                                                   |
-| South Africa                     | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03, [The Radio Frequency Spectrum Regulations 2015](http://www.amateurradio.org.za/Government%20Gazzette%2038641_30-3_IcasaCV01%20-%20Radio%20Frequency%20Spectrum%20Regulations%202015%20%282%29.pdf) |
-| South Korea                      | KR920-923           |                                                                                                                                                                                                                                   |
-| South Sudan                      |                     |                                                                                                                                                                                                                                   |
-| Spain                            | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                   |
-| Sri Lanka                        |                     |                                                                                                                                                                                                                                   |
-| Sudan                            |                     |                                                                                                                                                                                                                                   |
-| Suriname                         | US902-928           |                                                                                                                                                                                                                                   |
-| Sweden                           | EU863-870 EU433     | [Svenska frekvensplanen](https://etjanster.pts.se/radio/frekvensplanen), CEPT Rec. 70-03                                                                                                                                          |
-| Switzerland                      | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                   |
-| Syria                            |                     |                                                                                                                                                                                                                                   |
+| Country                                             | Frequency Plan      | Regulatory document                                                                                                                                                                                                               |
+| :-------------------------------------------------- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Saint Helena \(SH\)                                 |                     |                                                                                                                                                                                                                                   |
+| Saint Kitts and Nevis \(KN\)                        | AU915               |                                                                                                                                                                                                                                   |
+| Saint Lucia \(LC\)                                  | AU915               |                                                                                                                                                                                                                                   |
+| Saint Pierreand Miquelon \(PM\)                     | EU868               |                                                                                                                                                                                                                                   |
+| Saint Vincent and the Grenadines \(VC\)             | AU915               |                                                                                                                                                                                                                                   |
+| Samoa \(WS\)                                        | EU868               |                                                                                                                                                                                                                                   |
+| San Marino \(SM\)                                   | EU868               |                                                                                                                                                                                                                                   |
+| São Tomé and Príncipe \(ST\)                        |                     |                                                                                                                                                                                                                                   |
+| Saudi Arabia \(SA\)                                 | EU868               | [National frequency plan in the kingdom of Saudi Arabia](http://www.citc.gov.sa/en/RulesandSystems/RegulatoryDocuments/FrequencySpectrum/Documents/SM%20002%20E-NFP.pdf)            |
+| Senegal \(SN\)                                      | EU868               |                                                                                                                                                                                                                                   |
+| Serbia \(RS\)                                       | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                   |
+| Seychelles \(SC\)                                   | EU433               | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                     |
+| Sierra Leone \(SL\)                                 |                     |                                                                                                                                                                                                                                   |
+| Singapore \(SG\)                                    | AS923-1             |                                                                                                                                                                                                                                   |
+| Slovakia \(SK\)                                     | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                   |
+| Slovenia \(SI\)                                     | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                   |
+| Solomon Islands \(SB\)                              | AS923-1             |                                                                                                                                                                                                                                   |
+| Somalia \(SO\)                                      | EU868               |                                                                                                                                                                                                                                   |
+| South Africa \(ZA\)                                 | EU868               | CRASA follows CEPT Rec. 70-03, [The Radio Frequency Spectrum Regulations 2015](http://www.amateurradio.org.za/Government%20Gazzette%2038641_30-3_IcasaCV01%20-%20Radio%20Frequency%20Spectrum%20Regulations%202015%20%282%29.pdf) |
+| South Georgia and the South Sandwich Islands \(GS\) | EU868               |                                                                                                                                                                                                                                   |
+| South Korea \(KR\)                                  | KR920               |                                                                                                                                                                                                                                   |
+| Spain \(ES\)                                        | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                   |
+| Sri Lanka \(LK\)                                    | AS923-1             |                                                                                                                                                                                                                                   |
+| Sudan \(SD\)                                        |                     |                                                                                                                                                                                                                                   |
+| Suriname \(SR\)                                     | AU915               |                                                                                                                                                                                                                                   |
+| Svalbard and Jan Mayen \(SJ\)                       | EU868               |                                                                                                                                                                                                                                   |
+| Sweden \(SE\)                                       | EU868               | [Svenska frekvensplanen](https://etjanster.pts.se/radio/frekvensplanen), CEPT Rec. 70-03                                                                                                                                         |
+| Switzerland \(CH\)                                  | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                   |
+| Syria \(SY\)                                        | EU868               |                                                                                                                                                                                                                                   |
 
 #### T <a id="t"></a>
 
-| Country             | Frequency Plan      | Regulatory document                                                                                                                                                                                                                                        |
-| :------------------ | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Taiwan              | AS923-925 \(“AS2”\) | [LP0002 2016](http://www.rootlaw.com.tw/Attach/L-Doc/A040110071000200-1050823-1000-001.pdf) or [LP0002 2011](http://www.ncc.gov.tw/chinese/law_detail.aspx?site_content_sn=3441&is_history=0&sn_f=1807), section 4, “Radio Frequency Identification, RFID” |
-| Tajikistan          |                     |                                                                                                                                                                                                                                                            |
-| Tanzania            | EU863-870 EU433     | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                              |
-| Thailand            | AS923-925 \(“AS2”\) |                                                                                                                                                                                                                                                            |
-| Timor-Leste         |                     |                                                                                                                                                                                                                                                            |
-| Togo                |                     |                                                                                                                                                                                                                                                            |
-| Tonga               |                     |                                                                                                                                                                                                                                                            |
-| Trinidad and Tobago |                     |                                                                                                                                                                                                                                                            |
-| Tunisia             |                     | EN 302 208                                                                                                                                                                                                                                                 |
-| Turkey              | EU863-870 EU433     | CEPT Rec. 70-03                                                                                                                                                                                                                                            |
-| Turkmenistan        |                     |                                                                                                                                                                                                                                                            |
-| Tuvalu              |                     |                                                                                                                                                                                                                                                            |
+| Country                         | Frequency Plan      | Regulatory document                                                                                                                                                                                                                                        |
+| :------------------------------ | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Taiwan \(TW\)                   | AS923-1             | [LP0002 2016](http://www.rootlaw.com.tw/Attach/L-Doc/A040110071000200-1050823-1000-001.pdf) or [LP0002 2011](http://www.ncc.gov.tw/chinese/law_detail.aspx?site_content_sn=3441&is_history=0&sn_f=1807), section 4, “Radio Frequency Identification, RFID” |
+| Tajikistan \(TJ\)               |                     |                                                                                                                                                                                                                                                            |
+| Tanzania \(TZ\)                 | AS923-1             | CRASA follows CEPT Rec. 70-03                                                                                                                                                                                                                              |
+| Thailand \(TH\)                 | AS923-1             |                                                                                                                                                                                                                                                            |
+| Timor-Leste \(TL\)              |                     |                                                                                                                                                                                                                                                            |
+| Togo \(TG\)                     | EU433               |                                                                                                                                                                                                                                                            |
+| Tokelau \(TK\)                  | AU915               |                                                                                                                                                                                                                                                            |
+| Tonga \(TO\)                    | AU915               |                                                                                                                                                                                                                                                            |
+| Trinidad and Tobago \(TT\)      | AU915               |                                                                                                                                                                                                                                                            |
+| Tunisia \(TN\)                  | EU868               | EN 302 208                                                                                                                                                                                                                                                |
+| Turkey \(TR\)                   | EU868               | CEPT Rec. 70-03                                                                                                                                                                                                                                            |
+| Turkmenistan \(TM\)             |                     |                                                                                                                                                                                                                                                            |
+| Turks and Caicos Islands \(TC\) | AU915               |                                                                                                                                                                                                                                                            |
+| Tuvalu \(TV\)                   |                     |                                                                                                                                                                                                                                                            |
 
 #### U <a id="u"></a>
 
-| Country                          | Frequency Plan        | Regulatory document                                                                                                                   |
-| :------------------------------- | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
-| Uganda                           |                       |                                                                                                                                       |
-| Ukraine                          | unknown, limited CEPT | CEPT Rec. 70-03                                                                                                                       |
-| United Arab Emirates \(UAE\)     | EU863-870 EU433       | EN 302 208, [TRA Regulations](https://www.tra.gov.ae/assets/YXsb1a9i.pdf.aspx)                                                        |
-| United Kingdom \(UK\)            | EU863-870 EU433       | [Forum thread about requirements](https://www.thethingsnetwork.org/forum/t/uk-legal-requirements-for-equipment/6239), CEPT Rec. 70-03 |
-| United States of America \(USA\) | US902-928             |                                                                                                                                       |
-| Uruguay                          | US902-928             |                                                                                                                                       |
-| Uzbekistan                       |                       |                                                                                                                                       |
+| Country                               | Frequency Plan        | Regulatory document                                                                                                                   |
+| :------------------------------------ | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| U.S. Minor Outlying Islands \(UM\)    | US915                 |                                                                                                                                       |
+| U.S. Virgin Islands \(VI\)            | US915                 |                                                                                                                                       |
+| Uganda \(UG\)                         | IN865                 |                                                                                                                                       |
+| Ukraine \(UA\)                        | EU868                 | CEPT Rec. 70-03                                                                                                                       |
+| United Arab Emirates [UAE] \(AE\)     | EU868                 | EN 302 208, [TRA Regulations](https://www.tra.gov.ae/assets/YXsb1a9i.pdf.aspx)                                                       |
+| United Kingdom [UK] \(GB\)            | EU868                 | [Forum thread about requirements](https://www.thethingsnetwork.org/forum/t/uk-legal-requirements-for-equipment/6239), CEPT Rec. 70-03 |
+| United States of America [USA] \(US\) | US915                 |                                                                                                                                       |
+| Uruguay \(UY\)                        | AU915                 |                                                                                                                                       |
+| Uzbekistan \(UZ\)                     | EU433                 |                                                                                                                                       |
 
 #### V <a id="v"></a>
 
-| Country                   | Frequency Plan      | Regulatory document |
-| :------------------------ | :------------------ | :------------------ |
-| Vanuatu                   |                     |                     |
-| Vatican City \(Holy See\) | EU863-870 EU433     |                     |
-| Venezuela                 | US902-928           |                     |
-| Vietnam                   | AS923-925 \(“AS2”\) |                     |
+| Country                        | Frequency Plan      | Regulatory document |
+| :----------------------------- | :------------------ | :------------------ |
+| Vanuatu \(VU\)                 | AS923-3             |                     |
+| Vatican City [Holy See] \(VA\) | EU868               |                     |
+| Venezuela \(VE\)               | AS923-1             |                     |
+| Vietnam \(VN\)                 | AS923-2             |                     |
+
+#### W <a id="w"></a>
+
+| Country                  | Frequency Plan | Regulatory document |
+| :----------------------- | :------------- | :------------------ |
+| Wallis and Futuna \(WF\) | EU868          |                     |
+| Western Sahara \(EH\)    |                |                     |
 
 #### Y <a id="y"></a>
 
-| Country | Frequency Plan | Regulatory document |
-| :------ | :------------- | :------------------ |
-| Yemen   |                |                     |
+| Country      | Frequency Plan | Regulatory document |
+| :----------- | :------------- | :------------------ |
+| Yemen \(YE\) |                |                     |
 
 #### Z <a id="z"></a>
 
-| Country  | Frequency Plan  | Regulatory document           |
-| :------- | :-------------- | :---------------------------- |
-| Zambia   | EU863-870 EU433 | CRASA follows CEPT Rec. 70-03 |
-| Zimbabwe | EU863-870 EU433 | CRASA follows CEPT Rec. 70-03 |
+| Country         | Frequency Plan  | Regulatory document           |
+| :-------------- | :-------------- | :---------------------------- |
+| Zambia \(ZM\)   | EU868           | CRASA follows CEPT Rec. 70-03 |
+| Zimbabwe \(ZW\) | EU433           | CRASA follows CEPT Rec. 70-03 |


### PR DESCRIPTION
have refactored the frequencies by country section to match the frequencies listed in the miner countries_reg_domains.csv as updated in https://github.com/helium/miner/pull/772 and also added 2 digit ISO codes next to country names

Change-type: minor
Signed-off-by: Aaron Shaw <shawaj@gmail.com>