### PR TITLE
Fix Missing Titles

### DIFF
--- a/docs/api/blockchain/accounts.mdx
+++ b/docs/api/blockchain/accounts.mdx
@@ -1,6 +1,5 @@
 ---
 id: accounts
-hide_title: true
 sidebar_label: Accounts
 slug: /api/blockchain/accounts
 ---

--- a/docs/api/blockchain/blocks.mdx
+++ b/docs/api/blockchain/blocks.mdx
@@ -1,6 +1,5 @@
 ---
 id: blocks
-hide_title: true
 sidebar_label: Blocks
 slug: /api/blockchain/blocks
 ---

--- a/docs/api/blockchain/chain-variables.mdx
+++ b/docs/api/blockchain/chain-variables.mdx
@@ -1,6 +1,5 @@
 ---
 id: chain-variables
-hide_title: true
 sidebar_label: Chain Variables
 slug: /api/blockchain/chain-variables
 ---

--- a/docs/api/blockchain/cities.mdx
+++ b/docs/api/blockchain/cities.mdx
@@ -1,6 +1,5 @@
 ---
 id: cities
-hide_title: true
 sidebar_label: Cities
 slug: /api/blockchain/cities
 ---

--- a/docs/api/blockchain/hotspots.mdx
+++ b/docs/api/blockchain/hotspots.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspots
-hide_title: true
 sidebar_label: Hotspots
 slug: /api/blockchain/hotspots
 ---

--- a/docs/api/blockchain/introduction.mdx
+++ b/docs/api/blockchain/introduction.mdx
@@ -1,6 +1,5 @@
 ---
 id: introduction
-hide_title: true
 sidebar_label: Introduction
 slug: /api/blockchain/introduction
 ---

--- a/docs/api/blockchain/locations.mdx
+++ b/docs/api/blockchain/locations.mdx
@@ -1,6 +1,5 @@
 ---
 id: locations
-hide_title: true
 sidebar_label: Locations
 slug: /api/blockchain/locations
 ---

--- a/docs/api/blockchain/oracle-prices.mdx
+++ b/docs/api/blockchain/oracle-prices.mdx
@@ -1,6 +1,5 @@
 ---
 id: oracle-prices
-hide_title: true
 sidebar_label: Oracle Prices
 slug: /api/blockchain/oracle-prices
 ---

--- a/docs/api/blockchain/ouis.mdx
+++ b/docs/api/blockchain/ouis.mdx
@@ -1,6 +1,5 @@
 ---
 id: ouis
-hide_title: true
 sidebar_label: OUIs
 slug: /api/blockchain/ouis
 ---

--- a/docs/api/blockchain/pending-transactions.mdx
+++ b/docs/api/blockchain/pending-transactions.mdx
@@ -1,6 +1,5 @@
 ---
 id: pending-transactions
-hide_title: true
 sidebar_label: Pending Transactions
 slug: /api/blockchain/pending-transactions
 ---

--- a/docs/api/blockchain/rewards.mdx
+++ b/docs/api/blockchain/rewards.mdx
@@ -1,6 +1,5 @@
 ---
 id: rewards
-hide_title: true
 sidebar_label: Rewards
 slug: /api/blockchain/rewards
 ---

--- a/docs/api/blockchain/stats.mdx
+++ b/docs/api/blockchain/stats.mdx
@@ -1,6 +1,5 @@
 ---
 id: stats
-hide_title: true
 sidebar_label: Stats
 slug: /api/blockchain/stats
 ---

--- a/docs/api/blockchain/transactions.mdx
+++ b/docs/api/blockchain/transactions.mdx
@@ -1,6 +1,5 @@
 ---
 id: transactions
-hide_title: true
 sidebar_label: Transactions
 slug: /api/blockchain/transactions
 ---

--- a/docs/api/blockchain/validators.mdx
+++ b/docs/api/blockchain/validators.mdx
@@ -1,6 +1,5 @@
 ---
 id: validators
-hide_title: true
 sidebar_label: Validators
 slug: /api/blockchain/validators
 ---

--- a/docs/api/home.mdx
+++ b/docs/api/home.mdx
@@ -1,6 +1,5 @@
 ---
 id: home
-hide_title: true
 sidebar_label: Home
 slug: /api
 ---

--- a/docs/faq/build-on-network.mdx
+++ b/docs/faq/build-on-network.mdx
@@ -1,6 +1,5 @@
 ---
 id: build-on-network 
-hide_title: true
 title: Build On Network FAQ
 sidebar_label: Build On Network
 slug: /faq/build-on-network

--- a/docs/faq/data-credits.mdx
+++ b/docs/faq/data-credits.mdx
@@ -1,6 +1,5 @@
 ---
 id: data-credits 
-hide_title: true
 title: Data Credits FAQ
 sidebar_label: Data Credits
 slug: /faq/data-credits

--- a/docs/faq/helium-network.mdx
+++ b/docs/faq/helium-network.mdx
@@ -1,6 +1,5 @@
 ---
 id: helium-network 
-hide_title: true
 title: Helium Network FAQ
 sidebar_label: Helium Network
 slug: /faq/helium-network

--- a/docs/faq/hotspot-manufacturers.mdx
+++ b/docs/faq/hotspot-manufacturers.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-manufacturers
-hide_title: true
 title: Approved Hotspot Manufacturers FAQ
 sidebar_label: Approved Hotspot Manufacturers
 slug: /faq/hotspot-manufacturers

--- a/docs/faq/security.mdx
+++ b/docs/faq/security.mdx
@@ -1,6 +1,5 @@
 ---
 id: security 
-hide_title: true
 title: Security FAQ
 sidebar_label: Security
 slug: /faq/security

--- a/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
+++ b/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
@@ -1,11 +1,10 @@
 ---
 id: frequency-plans
-hide_title: true
 sidebar_label: Frequency Plans
 slug: /lorawan-on-helium/frequency-plans
 ---
 
-## Frequencies on the Helium Network
+# Frequencies on the Helium Network
 
 Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help
 you confirm the appropriate frequencies for gateway configuration for each

--- a/docs/mine-hnt/hotspot-makers/approved-makers/approved-makers.mdx
+++ b/docs/mine-hnt/hotspot-makers/approved-makers/approved-makers.mdx
@@ -1,6 +1,5 @@
 ---
 id: approved-makers
-hide_title: true
 sidebar_label: Approved Makers
 slug: /mine-hnt/hotspot-makers/approved-makers
 ---

--- a/docs/mine-hnt/hotspot-makers/burn-hnt-to-maker-wallet/burn-hnt-to-maker-wallet.mdx
+++ b/docs/mine-hnt/hotspot-makers/burn-hnt-to-maker-wallet/burn-hnt-to-maker-wallet.mdx
@@ -1,6 +1,5 @@
 ---
 id: burn-hnt-to-maker-wallet
-hide_title: true
 sidebar_label: Burning HNT to Maker Wallet
 slug: /mine-hnt/hotspot-makers/burn-hnt-to-maker-wallet
 ---

--- a/docs/mine-hnt/hotspot-makers/docker-integration/docker-integration.mdx
+++ b/docs/mine-hnt/hotspot-makers/docker-integration/docker-integration.mdx
@@ -1,6 +1,5 @@
 ---
 id: docker-integration
-hide_title: true
 sidebar_label: Docker Integration
 slug: /mine-hnt/hotspot-makers/docker-integration
 ---

--- a/docs/mine-hnt/hotspot-makers/hotspot-ble-services/hotspot-ble-services.mdx
+++ b/docs/mine-hnt/hotspot-makers/hotspot-ble-services/hotspot-ble-services.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-ble-services
-hide_title: true
 sidebar_label: Hotspot BLE Services
 slug: /mine-hnt/hotspot-makers/hotspot-ble-services
 ---

--- a/docs/mine-hnt/hotspot-makers/hotspot-integration-testing/hotspot-integration-testing.mdx
+++ b/docs/mine-hnt/hotspot-makers/hotspot-integration-testing/hotspot-integration-testing.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-integration-testing
-hide_title: true
 sidebar_label: Hotspot Integration Testing
 slug: /mine-hnt/hotspot-makers/hotspot-integration-testing
 ---

--- a/docs/mine-hnt/hotspot-makers/hotspot-makers.mdx
+++ b/docs/mine-hnt/hotspot-makers/hotspot-makers.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-makers
-hide_title: true
 sidebar_label: Hotspot Makers
 slug: /mine-hnt/hotspot-makers
 ---

--- a/docs/mine-hnt/hotspot-makers/hotspot-qr-onboarding/hotspot-qr-onboarding.mdx
+++ b/docs/mine-hnt/hotspot-makers/hotspot-qr-onboarding/hotspot-qr-onboarding.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-qr-onboarding
-hide_title: true
 sidebar_label: Hotspot QR Code Onboarding
 slug: /mine-hnt/hotspot-makers/hotspot-qr-onboarding
 ---

--- a/docs/mine-hnt/hotspot-makers/hotspot-wifi-configuration/hotspot-wifi-configuration.mdx
+++ b/docs/mine-hnt/hotspot-makers/hotspot-wifi-configuration/hotspot-wifi-configuration.mdx
@@ -1,6 +1,5 @@
 ---
 id: hotspot-wifi-configuration
-hide_title: true
 sidebar_label: Hotspot WiFi Configuration
 slug: /mine-hnt/hotspot-makers/hotspot-wifi-configuration
 ---

--- a/docs/mine-hnt/hotspot-makers/maker-approval-auditing/maker-approval-auditing.mdx
+++ b/docs/mine-hnt/hotspot-makers/maker-approval-auditing/maker-approval-auditing.mdx
@@ -1,6 +1,5 @@
 ---
 id: maker-approval-auditing
-hide_title: true
 sidebar_label: Approval and Auditing Process
 slug: /mine-hnt/hotspot-makers/maker-approval-auditing
 ---

--- a/docs/mine-hnt/hotspot-makers/security-requirements/security-requirements.mdx
+++ b/docs/mine-hnt/hotspot-makers/security-requirements/security-requirements.mdx
@@ -1,13 +1,12 @@
 ---
 id: security-requirements
-hide_title: true
 sidebar_label: Security Requirements
 slug: /mine-hnt/hotspot-makers/security-requirements
 ---
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-## Security Requirements
+# Security Requirements
 
 When the Helium Community passed
 [HIP19](https://github.com/helium/HIP/blob/master/0019-third-party-manufacturers.md),

--- a/docs/mine-hnt/light-hotspots/light-hotspots.mdx
+++ b/docs/mine-hnt/light-hotspots/light-hotspots.mdx
@@ -1,7 +1,6 @@
 ---
 id: light-hotspots
 title: Light Hotspots (Beta)
-hide_title: true
 sidebar_label: Light Hotspots (Beta)
 slug: /mine-hnt/light-hotspots
 ---

--- a/docs/use-the-network/build-a-packet-forwarder/build-a-packet-forwarder.mdx
+++ b/docs/use-the-network/build-a-packet-forwarder/build-a-packet-forwarder.mdx
@@ -1,6 +1,5 @@
 ---
 id: build-a-packet-forwarder
-hide_title: true
 sidebar_label: Build a Packet Forwarder
 slug: /use-the-network/build-a-packet-forwarder
 ---

--- a/docs/use-the-network/community-projects/community-projects.mdx
+++ b/docs/use-the-network/community-projects/community-projects.mdx
@@ -1,11 +1,10 @@
 ---
 id: community-projects
-hide_title: true
 sidebar_label: Community Projects
 slug: /use-the-network/community-projects
 ---
 
-## Community Projects 
+# Community Projects 
 
 Developers are using the Helium Network for hundreds of IoT and sensing applications. Here is a snapshot of what's being built. All these projects are hosted on the [Helium Hackster Community](https://www.hackster.io/helium).
 

--- a/docs/use-the-network/console/adding-devices.mdx
+++ b/docs/use-the-network/console/adding-devices.mdx
@@ -1,6 +1,5 @@
 ---
 id: adding-devices
-hide_title: true
 sidebar_label: Adding Devices
 slug: /use-the-network/console/adding-devices
 ---

--- a/docs/use-the-network/console/adr.mdx
+++ b/docs/use-the-network/console/adr.mdx
@@ -1,6 +1,5 @@
 ---
 id: console-adr
-hide_title: true
 sidebar_label: ADR
 slug: /use-the-network/console/adr
 ---

--- a/docs/use-the-network/console/api.mdx
+++ b/docs/use-the-network/console/api.mdx
@@ -1,6 +1,5 @@
 ---
 id: console-api
-hide_title: true
 sidebar_label: API
 slug: /use-the-network/console/api
 ---

--- a/docs/use-the-network/console/cli.mdx
+++ b/docs/use-the-network/console/cli.mdx
@@ -1,6 +1,5 @@
 ---
 id: console-cli
-hide_title: true
 sidebar_label: CLI
 slug: /use-the-network/console/cli
 ---

--- a/docs/use-the-network/console/console.mdx
+++ b/docs/use-the-network/console/console.mdx
@@ -1,6 +1,5 @@
 ---
 id: console
-hide_title: true
 sidebar_label: Helium Console
 slug: /use-the-network/console
 ---

--- a/docs/use-the-network/console/data-credits.mdx
+++ b/docs/use-the-network/console/data-credits.mdx
@@ -1,6 +1,5 @@
 ---
 id: data-credits
-hide_title: true
 sidebar_label: Data Credits
 slug: /use-the-network/console/data-credits
 ---

--- a/docs/use-the-network/console/debug.mdx
+++ b/docs/use-the-network/console/debug.mdx
@@ -1,6 +1,5 @@
 ---
 id: debug
-hide_title: true
 sidebar_label: Debug
 slug: /use-the-network/console/debug
 ---

--- a/docs/use-the-network/console/functions.mdx
+++ b/docs/use-the-network/console/functions.mdx
@@ -1,6 +1,5 @@
 ---
 id: functions
-hide_title: true
 sidebar_label: Functions
 slug: /use-the-network/console/functions
 ---

--- a/docs/use-the-network/console/integrations/adafruitio.mdx
+++ b/docs/use-the-network/console/integrations/adafruitio.mdx
@@ -1,6 +1,5 @@
 ---
 id: adafruitio
-hide_title: true
 sidebar_label: AdafruitIO
 slug: /use-the-network/console/integrations/adafruitio
 ---

--- a/docs/use-the-network/console/integrations/aws-iot-core.mdx
+++ b/docs/use-the-network/console/integrations/aws-iot-core.mdx
@@ -1,6 +1,5 @@
 ---
 id: aws-iot-core
-hide_title: true
 sidebar_label: AWS IoT Core
 slug: /use-the-network/console/integrations/aws-iot-core
 ---

--- a/docs/use-the-network/console/integrations/cargo.mdx
+++ b/docs/use-the-network/console/integrations/cargo.mdx
@@ -1,6 +1,5 @@
 ---
 id: cargo
-hide_title: true
 sidebar_label: Cargo
 slug: /use-the-network/console/integrations/cargo
 ---

--- a/docs/use-the-network/console/integrations/datacake.mdx
+++ b/docs/use-the-network/console/integrations/datacake.mdx
@@ -1,6 +1,5 @@
 ---
 id: datacake
-hide_title: true
 sidebar_label: Datacake
 slug: /use-the-network/console/integrations/datacake
 ---

--- a/docs/use-the-network/console/integrations/google-sheets.mdx
+++ b/docs/use-the-network/console/integrations/google-sheets.mdx
@@ -1,6 +1,5 @@
 ---
 id: google-sheets
-hide_title: true
 sidebar_label: Google Sheets
 slug: /use-the-network/console/integrations/google-sheets
 ---

--- a/docs/use-the-network/console/integrations/http.mdx
+++ b/docs/use-the-network/console/integrations/http.mdx
@@ -1,6 +1,5 @@
 ---
 id: http
-hide_title: true
 sidebar_label: HTTP
 slug: /use-the-network/console/integrations/http
 ---

--- a/docs/use-the-network/console/integrations/integrations.mdx
+++ b/docs/use-the-network/console/integrations/integrations.mdx
@@ -1,6 +1,5 @@
 ---
 id: integrations
-hide_title: true
 sidebar_label: Integrations
 slug: /use-the-network/console/integrations
 ---

--- a/docs/use-the-network/console/integrations/json-schema.mdx
+++ b/docs/use-the-network/console/integrations/json-schema.mdx
@@ -1,6 +1,5 @@
 ---
 id: json-schema
-hide_title: true
 sidebar_label: JSON Schema
 slug: /use-the-network/console/integrations/json-schema
 ---

--- a/docs/use-the-network/console/integrations/mqtt.mdx
+++ b/docs/use-the-network/console/integrations/mqtt.mdx
@@ -1,6 +1,5 @@
 ---
 id: mqtt
-hide_title: true
 sidebar_label: MQTT
 slug: /use-the-network/console/integrations/mqtt
 ---

--- a/docs/use-the-network/console/integrations/mydevices-cayenne.mdx
+++ b/docs/use-the-network/console/integrations/mydevices-cayenne.mdx
@@ -1,6 +1,5 @@
 ---
 id: mydevices-cayenne
-hide_title: true
 sidebar_label: MyDevices Cayenne
 slug: /use-the-network/console/integrations/mydevices-cayenne
 ---

--- a/docs/use-the-network/console/integrations/tago.mdx
+++ b/docs/use-the-network/console/integrations/tago.mdx
@@ -1,6 +1,5 @@
 ---
 id: tago
-hide_title: true
 sidebar_label: Tago.IO
 slug: /use-the-network/console/integrations/tago
 ---

--- a/docs/use-the-network/console/integrations/ubidots.mdx
+++ b/docs/use-the-network/console/integrations/ubidots.mdx
@@ -1,6 +1,5 @@
 ---
 id: ubidots
-hide_title: true
 sidebar_label: Ubidots
 slug: /use-the-network/console/integrations/ubidots
 ---

--- a/docs/use-the-network/console/labels.mdx
+++ b/docs/use-the-network/console/labels.mdx
@@ -1,6 +1,5 @@
 ---
 id: labels
-hide_title: true
 sidebar_label: Labels
 slug: /use-the-network/console/labels
 ---

--- a/docs/use-the-network/console/migrating-devices/migrating-devices.mdx
+++ b/docs/use-the-network/console/migrating-devices/migrating-devices.mdx
@@ -1,6 +1,5 @@
 ---
 id: migrating-devices
-hide_title: true
 sidebar_label: Migrating Devices
 slug: /use-the-network/console/migrating-devices
 ---

--- a/docs/use-the-network/console/migrating-devices/ttn-import.mdx
+++ b/docs/use-the-network/console/migrating-devices/ttn-import.mdx
@@ -1,6 +1,5 @@
 ---
 id: ttn-import
-hide_title: true
 sidebar_label: TTN Import Migration
 slug: /use-the-network/console/migrating-devices/ttn-import
 ---

--- a/docs/use-the-network/console/migrating-devices/ttn-manual.mdx
+++ b/docs/use-the-network/console/migrating-devices/ttn-manual.mdx
@@ -1,6 +1,5 @@
 ---
 id: ttn-manual
-hide_title: true
 sidebar_label: TTN Manual Migration
 slug: /use-the-network/console/migrating-devices/ttn-manual
 ---

--- a/docs/use-the-network/console/my-account.mdx
+++ b/docs/use-the-network/console/my-account.mdx
@@ -1,6 +1,5 @@
 ---
 id: my-account
-hide_title: true
 sidebar_label: My Account
 slug: /use-the-network/console/my-account
 ---

--- a/docs/use-the-network/console/quickstart.mdx
+++ b/docs/use-the-network/console/quickstart.mdx
@@ -1,6 +1,5 @@
 ---
 id: quickstart
-hide_title: true
 sidebar_label: Quickstart
 slug: /use-the-network/console/quickstart
 ---

--- a/docs/use-the-network/console/troubleshooting.mdx
+++ b/docs/use-the-network/console/troubleshooting.mdx
@@ -1,6 +1,5 @@
 ---
 id: troubleshooting
-hide_title: true
 title: Console Troubleshooting
 sidebar_label: Troubleshooting
 slug: /use-the-network/console/troubleshooting

--- a/docs/use-the-network/console/users.mdx
+++ b/docs/use-the-network/console/users.mdx
@@ -1,6 +1,5 @@
 ---
 id: users
-hide_title: true
 sidebar_label: Users and Organizations
 slug: /use-the-network/console/users
 ---

--- a/docs/use-the-network/coverage-mapping/adeunis-mapper.mdx
+++ b/docs/use-the-network/coverage-mapping/adeunis-mapper.mdx
@@ -1,6 +1,5 @@
 ---
 id: adeunis-mapper
-hide_title: true
 sidebar_label: Adeunis Mapper
 slug: /use-the-network/coverage-mapping/adeunis-mapper
 ---

--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -1,6 +1,5 @@
 ---
 id: coverage-mapping
-hide_title: true
 sidebar_label: Coverage Mapping
 slug: /use-the-network/coverage-mapping
 ---

--- a/docs/use-the-network/coverage-mapping/mappers-api.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-api.mdx
@@ -1,6 +1,5 @@
 ---
 id: mappers-api
-hide_title: true
 sidebar_label: Mappers API
 slug: /use-the-network/coverage-mapping/mappers-api
 ---

--- a/docs/use-the-network/coverage-mapping/mappers-quickstart.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-quickstart.mdx
@@ -1,13 +1,12 @@
 ---
 id: mappers-quickstart
-hide_title: true
 sidebar_label: Mappers Quickstart
 slug: /use-the-network/coverage-mapping/mappers-quickstart
 ---
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-## Mappers Quickstart
+# Mappers Quickstart
 
 This guide will show you step by step how to contribute data to the Mappers
 project with an off-the-shelf tracker. This guide will use the

--- a/docs/use-the-network/devices/devices.mdx
+++ b/docs/use-the-network/devices/devices.mdx
@@ -1,13 +1,12 @@
 ---
 id: devices
-hide_title: true
 sidebar_label: Devices
 slug: /use-the-network/devices
 ---
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-## Helium Devices
+# Helium Devices
 
 The Helium network supports any LoRaWAN capable device meeting the
 [v1.0.2 specification](https://lora-alliance.org/resource_hub/lorawan-specification-v1-0-2).

--- a/docs/use-the-network/run-a-network-server/buy-an-oui/buy-an-oui.mdx
+++ b/docs/use-the-network/run-a-network-server/buy-an-oui/buy-an-oui.mdx
@@ -1,6 +1,5 @@
 ---
 id: buy-an-oui
-hide_title: true
 sidebar_label: Buy an OUI
 slug: /use-the-network/buy-an-oui
 ---

--- a/docs/use-the-network/run-a-network-server/run-a-network-server.mdx
+++ b/docs/use-the-network/run-a-network-server/run-a-network-server.mdx
@@ -1,6 +1,5 @@
 ---
 id: run-a-network-server
-hide_title: true
 sidebar_label: Run a Network Server
 slug: /use-the-network/run-a-network-server
 ---

--- a/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
+++ b/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
@@ -1,6 +1,5 @@
 ---
 id: run-console
-hide_title: true
 sidebar_label: Run Console
 slug: /use-the-network/run-console
 ---

--- a/docs/wallets/wallets/ledger.md
+++ b/docs/wallets/wallets/ledger.md
@@ -1,6 +1,5 @@
 ---
 id: ledger
-hide_title: true
 sidebar_label: Ledger
 slug: /wallets/ledger
 ---


### PR DESCRIPTION
After upgrading to the latest Docusaurus the majority of titles are not being rendered in docs because the header field for hiding the title exhibits different behavior now. This PR fixes the titles that are not being rendered.