### PR TITLE
Add space after period in /validators endpoint

### DIFF
--- a/docs/api/blockchain/validators.mdx
+++ b/docs/api/blockchain/validators.mdx
@@ -29,7 +29,7 @@ https://testnet-api.helium.wtf/v1/
 GET https://api.helium.io/v1/validators
 ```
 
-List known validators as registered on the blockchain.The results are paged. If a
+List known validators as registered on the blockchain. The results are paged. If a
 `cursor` field is present in the response, more results are available.
 
 <Tabs


### PR DESCRIPTION
In List Validators description did
s/the blockchain.The results/the blockchain. The results/

Noticed this while looking something up to answer a question on Discord.