### PR TITLE
Update Norway's frequency plans

### DIFF
--- a/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
+++ b/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
@@ -308,7 +308,7 @@ Also known as **US902-928**
 | Nigeria         |                       |                                                                                                                                                            |
 | North Macedonia | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                            |
 | North Korea     |                       |                                                                                                                                                            |
-| Norway          | unknown, limited CEPT | CEPT Rec. 70-03                                                                                                                                            |
+| Norway          | EU863-870 EU433       | CEPT Rec. 70-03                                                                                                                                            |
 
 #### O <a id="o"></a>
 


### PR DESCRIPTION
Proof of free-use license can be found here:
https://frekvens.nkom.no/#/main

Search for "433" / "862" to find the docs and permits