### PR TITLE
Remove Hide Title Field From Validator Doc Headers

### DIFF
--- a/docs/mine-hnt/validators/requirements.mdx
+++ b/docs/mine-hnt/validators/requirements.mdx
@@ -1,7 +1,6 @@
 ---
 id: requirements
 title: Validator Requirements
-hide_title: true
 sidebar_label: Technical Requirements
 slug: /mine-hnt/validators/requirements
 ---

--- a/docs/mine-hnt/validators/testcases.mdx
+++ b/docs/mine-hnt/validators/testcases.mdx
@@ -1,7 +1,6 @@
 ---
 id: validator-testcases
 title: Test Cases
-hide_title: true
 sidebar_label: Test Cases
 slug: /mine-hnt/validators/validator-testcases
 ---

--- a/docs/mine-hnt/validators/troubleshoot.mdx
+++ b/docs/mine-hnt/validators/troubleshoot.mdx
@@ -1,7 +1,6 @@
 ---
 id: validator-troubleshooting
 title: Troubleshooting
-hide_title: true
 sidebar_label: Troubleshooting
 slug: /mine-hnt/validators/validator-troubleshooting
 ---

--- a/docs/mine-hnt/validators/validator-faqs-resources.mdx
+++ b/docs/mine-hnt/validators/validator-faqs-resources.mdx
@@ -1,7 +1,6 @@
 ---
 id: validator-faqs-resources
 title: FAQs, Resources, and Providers
-hide_title: true
 sidebar_label: FAQs, Resources, and Providers
 slug: /mine-hnt/validators/validator-faqs-resources
 ---

--- a/docs/mine-hnt/validators/validator-score.mdx
+++ b/docs/mine-hnt/validators/validator-score.mdx
@@ -1,7 +1,6 @@
 ---
 id: validator-score
 title: Validator Penalties and Impact on Rewards
-hide_title: true
 sidebar_label: Penalties
 slug: /mine-hnt/validators/validator-score
 ---

--- a/docs/mine-hnt/validators/wallet.mdx
+++ b/docs/mine-hnt/validators/wallet.mdx
@@ -1,7 +1,6 @@
 ---
 id: validator-wallet
 title: Configure a Wallet
-hide_title: true
 sidebar_label: Configure a Wallet
 slug: /mine-hnt/validators/validator-wallet
 ---


### PR DESCRIPTION
Titles were not showing due to new behavior of the `hide_title` field in the doc front matter. 