### PR TITLE
Update wallet.mdx

### DIFF
--- a/docs/mine-hnt/validators/testnet/wallet.mdx
+++ b/docs/mine-hnt/validators/testnet/wallet.mdx
@@ -62,8 +62,8 @@ As part of the staking process the validator node address needs to be in the sta
 
   In this example the part following the final slash is the validator node's public address: `112sSfUCQrVNAfFKVZWUSCeLs67wH8o1xz4yj4nKSPJKBT8bUkXi`.
 
-- Stake the TNT:
-  - `./helium-wallet validators stake <public-address> 10000`
+- Stake single Validator with the TNT:
+  - `./helium-wallet validators stake one <public-address> 10000`
 
 Use `--commit` after preview to submit the transaction to network.
 


### PR DESCRIPTION
New (required) subcommand for staking 

Added:

- Stake single Validator with the TNT:
  - `./helium-wallet validators stake one <public-address> 10000`

Removed:

- Stake the TNT:
  - `./helium-wallet validators stake <public-address> 10000`