### PR TITLE
Fixes for validator deployment docs, adding docs for new validators API

### DIFF
--- a/docs/api/blockchain/accounts.mdx
+++ b/docs/api/blockchain/accounts.mdx
@@ -295,6 +295,184 @@ The hotspot list for an account
 </Tabs>
 
 ---
+## Validators for Account
+
+```
+GET https://api.helium.io/v1/accounts/:address/validators
+```
+
+Fetches validators owned by a given account address. The list of returned
+validators is paged. If a `cursor` field is present more results are available.
+
+Note: The cursor for accounts is valid for a limited time. If you receive a
+`400` http response code for a cursor based request, you will need to start
+fetching accounts from the beginning of the list.
+
+<Tabs
+  block={true}
+  defaultValue="request"
+  values={[{"label":"Request","value":"request"},{"label":"Response","value":"response"}]}>
+<TabItem value="request">
+
+_Path Parameters_
+
+| param              | Type     | Note                                     |
+| ------------------ | -------- | ---------------------------------------- |
+| address (required) | _string_ | Account B58 address to fetch details for |
+
+_Query Parameters_
+
+| param             | Type     | Note                                          |
+| ----------------- | -------- | --------------------------------------------- |
+| cursor (optional) | _string_ | Cursor for the next page of hotspots to fetch |
+
+</TabItem>
+<TabItem value="response">
+
+200: OK
+
+The validator list for an account
+
+```json
+{
+  "data": [
+    {
+      "version_heartbeat": 10048,
+      "status": {
+        "online": "online",
+        "listen_addrs": ["/ip4/51.222.222.17/tcp/2154"],
+        "height": 57692
+      },
+      "stake_status": "staked",
+      "stake": 1000000000000,
+      "penalty": 0.99200439453125,
+      "penalties": [
+        {
+          "type": "performance",
+          "height": 57777,
+          "amount": 0
+        },
+        {
+          "type": "tenure",
+          "height": 57777,
+          "amount": 1
+        }
+      ],
+      "owner": "1aTZ28SE9BHkiLehdxaDGLVE6tyEEDvtj8YHjvYY6wmX1ANB25H",
+      "name": "shallow-butter-shark",
+      "last_heartbeat": 57777,
+      "block_added": 50636,
+      "block": 57780,
+      "address": "1Z9zkkswtjmrHsu7XK21rdxprwhNmhqpX4NirghEynauaohVjYu"
+    },
+    {
+      "version_heartbeat": 10048,
+      "status": {
+        "online": "online",
+        "listen_addrs": ["/ip4/51.222.222.16/tcp/2154"],
+        "height": 57662
+      },
+      "stake_status": "staked",
+      "stake": 1000000000000,
+      "penalty": 1.3520050048828125,
+      "penalties": [
+        {
+          "type": "performance",
+          "height": 57483,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57498,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57530,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57545,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57559,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57573,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57585,
+          "amount": 0
+        },
+        {
+          "type": "performance",
+          "height": 57684,
+          "amount": 0
+        },
+        {
+          "type": "tenure",
+          "height": 57483,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57498,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57530,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57545,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57559,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57573,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57585,
+          "amount": 1
+        },
+        {
+          "type": "tenure",
+          "height": 57684,
+          "amount": 1
+        }
+      ],
+      "owner": "1aTZ28SE9BHkiLehdxaDGLVE6tyEEDvtj8YHjvYY6wmX1ANB25H",
+      "name": "amusing-sepia-caterpillar",
+      "last_heartbeat": 57771,
+      "block_added": 50614,
+      "block": 57780,
+      "address": "1Y8Rr9WaEcQBWn7Jh7QnXrctZ99a15PQEpoLQHCNTeZcDY5ziA7"
+    }
+  ],
+  "cursor": "eyJoZWlnaHQiOjU3NzgwLCJiZWZvcmVfYmxvY2siOjM3ODQ4LCJiZWZvcmVfYWRkcmVzcyI6IjFiSEwxblFQNWdSSHFKRVN2VFJXWHAzZTg5RnVYNXZwWnFBdGl1NlUxaVZlSERxenU4TiJ9"
+}
+```
+
+</TabItem>
+</Tabs>
+
+---
 
 ## OUIs for Account
 

--- a/docs/api/blockchain/accounts.mdx
+++ b/docs/api/blockchain/accounts.mdx
@@ -304,10 +304,6 @@ GET https://api.helium.io/v1/accounts/:address/validators
 Fetches validators owned by a given account address. The list of returned
 validators is paged. If a `cursor` field is present more results are available.
 
-Note: The cursor for accounts is valid for a limited time. If you receive a
-`400` http response code for a cursor based request, you will need to start
-fetching accounts from the beginning of the list.
-
 <Tabs
   block={true}
   defaultValue="request"
@@ -316,15 +312,15 @@ fetching accounts from the beginning of the list.
 
 _Path Parameters_
 
-| param              | Type     | Note                                     |
-| ------------------ | -------- | ---------------------------------------- |
-| address (required) | _string_ | Account B58 address to fetch details for |
+| param              | Type     | Note                                        |
+| ------------------ | -------- | ------------------------------------------- |
+| address (required) | _string_ | Account B58 address to fetch validators for |
 
 _Query Parameters_
 
-| param             | Type     | Note                                          |
-| ----------------- | -------- | --------------------------------------------- |
-| cursor (optional) | _string_ | Cursor for the next page of hotspots to fetch |
+| param             | Type     | Note                                            |
+| ----------------- | -------- | ----------------------------------------------- |
+| cursor (optional) | _string_ | Cursor for the next page of validators to fetch |
 
 </TabItem>
 <TabItem value="response">

--- a/docs/mine-hnt/validators/testnet/deployment-guide.mdx
+++ b/docs/mine-hnt/validators/testnet/deployment-guide.mdx
@@ -532,7 +532,7 @@ Getting back on chain is easy now that you've got everything installed:
 #### Fund the Wallet
 
 - You do not need to delete and re-create the wallet.  The wallet balance will show `0`, since this is a new blockchain and you have no TNT.  If you happen to run `helium-wallet balance` and receive an error, give it a few minutes.  The API may still be restarting after pointing to the new chain.  Your wallet password is the same.
-- When the balance shows `0`, add funds to your wallet from the [Faucet](https://faucet.helium.wtf/) exactly how you performed the task earlier.  Follow the [Acquire TNT from the Testnet Faucet](/mine-hnt/validators/validator-deployment-guide#acquire-tnt-from-the-testnet-faucet) directions.
+- When the balance shows `0`, add funds to your wallet from the [Faucet](https://faucet.helium.wtf/) exactly how you performed the task earlier.  Follow the [Acquire TNT from the Testnet Faucet](#acquire-tnt-from-the-testnet-faucet) directions.
 
 #### Reset the Validator - Docker Edition
 
@@ -540,7 +540,7 @@ Getting back on chain is easy now that you've got everything installed:
 - `cd` into the `validator_data` directory you setup earlier in the Deploy step above.  Then run `sudo rm -rf blockchain* ledger.db state_channels.db log checkpoints`  This will delete everything in this folder except for the `miner` folder. Please be sure you're in the correct folder before running `rm` commands.
 - The `miner` folder contains a single `swarm_key` file.  If you want to keep the 3-word name of your miner, keep this file.  If you want a new one, you can delete this file as well. 
 - There will be a new validator version when the chain is relaunched, so force pull the new docker image version prior to starting the validator.  `docker pull quay.io/team-helium/validator:latest-val-amd64`
-- Restart the validator with your `docker run` command that you used [during the install](/mine-hnt/validators/validator-deployment-guide#deploy-the-validator-using-docker---recommended).
+- Restart the validator with your `docker run` command that you used [during the install](#deploy-the-validator-using-docker---recommended).
 - Watchtower should still be running from our install and will continue to update the docker image automatically.
 
 #### Reset the Validator - From Source
@@ -550,7 +550,7 @@ Getting back on chain is easy now that you've got everything installed:
 
 #### Restake 
 
-- Follow the same process from [Stake Tokens to Your Validator](/mine-hnt/validators/validator-deployment-guide#stake-tokens-to-your-validator) to stake the 10,000 TNT received from the faucet for your Testnet validator.  If you kept the `swarm_key` file above, your validator node address will be the same.  If you deleted that file, you'll have to ensure you have the new node address by running `miner peer addr` as outlined in that section.
+- Follow the same process from [Stake Tokens to Your Validator](#stake-tokens-to-your-validator) to stake the 10,000 TNT received from the faucet for your Testnet validator.  If you kept the `swarm_key` file above, your validator node address will be the same.  If you deleted that file, you'll have to ensure you have the new node address by running `miner peer addr` as outlined in that section.
 
-That's it!  You're back on the new chain and should see similar output as defined in [Verifying Validator Victory](/mine-hnt/validators/validator-deployment-guide#verifying-validator-victory).
+That's it!  You're back on the new chain and should see similar output as defined in [Verifying Validator Victory](#verifying-validator-victory).
 

--- a/docs/mine-hnt/validators/testnet/deployment-guide.mdx
+++ b/docs/mine-hnt/validators/testnet/deployment-guide.mdx
@@ -391,7 +391,7 @@ The resulting output will look like this (except with your specific validator ad
 We can now use this address with the Helium Wallet CLI `validators stake` command to formally stake the `10000` TNT required. Here's the full command using the Validator address from above as an example. (**Make sure you replace it with yours.**)
 
 ```
-helium-wallet validators stake 1YwLbGTCEhVbwKEehRVQRC8N3q35ydXTH1B6BQys5FB1paHssdR 10000 --commit
+helium-wallet validators stake one 1YwLbGTCEhVbwKEehRVQRC8N3q35ydXTH1B6BQys5FB1paHssdR 10000 --commit
 ```
 
 After running this, you'll need to input your wallet passphrase to sign the transaction.


### PR DESCRIPTION
I noticed these when looking for a better way to find validators for an account, and while handling the recent testnet restart. Description of changes is in the commit messages. If this would be better submitted in a different form let me know.
