### PR TITLE
Add "one" to the wallet command when staking.

### DIFF
--- a/docs/mine-hnt/validators/testnet/deployment-guide.mdx
+++ b/docs/mine-hnt/validators/testnet/deployment-guide.mdx
@@ -391,7 +391,7 @@ The resulting output will look like this (except with your specific validator ad
 We can now use this address with the Helium Wallet CLI `validators stake` command to formally stake the `10000` TNT required. Here's the full command using the Validator address from above as an example. (**Make sure you replace it with yours.**)
 
 ```
-helium-wallet validators stake 1YwLbGTCEhVbwKEehRVQRC8N3q35ydXTH1B6BQys5FB1paHssdR 10000 --commit
+helium-wallet validators stake one 1YwLbGTCEhVbwKEehRVQRC8N3q35ydXTH1B6BQys5FB1paHssdR 10000 --commit
 ```
 
 After running this, you'll need to input your wallet passphrase to sign the transaction.


### PR DESCRIPTION
It wouldn't work for me without the "one" option.