### PR TITLE
Update home.mdx remove Insiders link

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -148,13 +148,6 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 	    		 	<p>Packet forwarder for the Helium-enabled Gateways.</p>
 	    		 </div>
 	    	</div>
-	    	<div className="tech--item">
-	    		 <img className="techicon" src={useBaseUrl("img/home/mappers.svg")} />
-	    		 <div className="tech--item_text">
-	    		 	<a href="https://helium.com/insider"><h4>Insiders</h4></a>
-	    		 	<p>Raise awareness in your city</p>
-	    		 </div>
-	    	</div>
 	    </div>
 	</div>
 </div>


### PR DESCRIPTION
The insiders icon link at the bottom is now a 404 This page could not be found.