### PR TITLE
Add Nodevalidators hnt staking service provider

### DIFF
--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -113,3 +113,4 @@ Links to these Staking Providers are provided as is. Helium, Inc. is not directl
 * [Bison Trails](https://www.bisontrails.co)
 * [Vanager](https://vanager.io)
 * [StakeJoy](https://stakejoy.com)
+* [NodeValidators](https://nodevalidators.com)


### PR DESCRIPTION
Nodevalidators.com is a new service provider who is offering HNT staking services. It is good to have diversity and decentralisation in the number of providers to help improve the safety of the HNT network. 