### PR TITLE
Add missing punctuation

### DIFF
--- a/docs/mine-hnt/validators/monitoring.mdx
+++ b/docs/mine-hnt/validators/monitoring.mdx
@@ -13,7 +13,7 @@ The Docker commands will assume you have the same prefix to get you executing a 
 
 Perform a health check to see if your validator node can see other validators. 
 
-Once your validator is running perform an initial health check to verify you're connected to peers, your NAT type has been correctly identified, and that you have listen addresses:
+Once your validator is running, perform an initial health check to verify you're connected to peers, your NAT type has been correctly identified, and that you have listen addresses:
 
 Source: ```miner peer book -s```
 
@@ -35,7 +35,7 @@ Source: ```miner info height```
 
 Docker: ```docker exec validator miner info height```
 
-If you’re syncing something similar to the following should appear:
+If you’re syncing, something similar to the following should appear:
 ```
 ~$ docker exec validator miner info height
 14        449


### PR DESCRIPTION
> The Docker commands will assume you have the same prefix to get you executing a command within the docker: ```docker exec validator``` .

This sentence is difficult to read. Can we re-word it? I'm not entirely sure what it's trying to say.