### PR TITLE
APY -> APR

### DIFF
--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -51,7 +51,7 @@ Despite the warnings above, some community members will decide to run their vali
 
 ### Rewards 
 
-**What is the expected APY of running Helium validator?**
+**What is the expected APR of running Helium validator?**
 
 It depends on the number of validators and how often a validator is randomly chosen to participate in the consensus group. Validators split the Consensus Group reward, [which is 6% of all HNT mined](/blockchain/mining/#hnt-distributions-per-epoch).
 


### PR DESCRIPTION
> APY takes into account compounding, but APR does not. 
https://www.investopedia.com/personal-finance/apr-apy-bank-hopes-cant-tell-difference/

HNT rewards accrued from running a validator are not automatically compounded