### PR TITLE
Updates Discord channel for coverage mapping

### DIFF
--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -15,7 +15,7 @@ The Mappers coverage mapping project is a crowd-sourced effort to build a cohesi
 Mapping data is viewable at [mappers.helium.com](https://mappers.helium.com/). The Mappers tool allows you to see the areas that 
 have been explored by voluntary community mappers and the Helium hotspots that have provided coverage to those areas.
 
-Be sure to check out the ongoing conversation in the dedicated #coverage-mapping and #mappers channels on the [Helium Discord 
+Be sure to check out the ongoing conversation in the dedicated #mappers channel on the [Helium Discord 
 Server](https://discord.gg/helium).
 
 ## Mappers Newsletter


### PR DESCRIPTION
Dropping the double channels in favor of one main #mappers channel.

<kbd><img width="992" alt="Screen Shot 2021-06-29 at 4 08 29 PM" src="https://user-images.githubusercontent.com/1965053/123878664-656a0980-d8f4-11eb-8631-58e36cde7ed3.png"></kbd>
