### PR TITLE
Update docker-integration page -- grammar fix

### DIFF
--- a/docs/mine-hnt/hotspot-makers/docker-integration/docker-integration.mdx
+++ b/docs/mine-hnt/hotspot-makers/docker-integration/docker-integration.mdx
@@ -54,7 +54,7 @@ day in case there are emergency releases.
 ## Initial Testing of the Docker on Your Host System
 
 The Docker image is tailored to be able to run very simply at first, but will
-generally require additional customization to integration well with your host
+generally require additional customization to integrate well with your host
 system.
 
 Start by following


### PR DESCRIPTION
Changed integration to integrate. It seems that two sentences were spliced together and a word form change did not occur.