### PR TITLE
fix links to dragino/kerlink light miners

### DIFF
--- a/docs/use-the-network/light-hotspots/light-hotspots.mdx
+++ b/docs/use-the-network/light-hotspots/light-hotspots.mdx
@@ -167,9 +167,9 @@ All Hotspots will not need to follow the Blockchain.
 
 ## Data-Only Hotspot Setup Guides
 
-- [Dragino LPS80/DLOS8](/mine-hnt/light-hotspots/guides/dragino)
+- [Dragino LPS80/DLOS8](/use-the-network/light-hotspots/guides/dragino)
   - Draginos will only mine HNT as a Data Only Hotspot
-- [Kerlink gateways](/mine-hnt/light-hotspots/guides/kerlink)
+- [Kerlink gateways](/use-the-network/light-hotspots/guides/kerlink)
   - Kerlink gateways will only mine HNT as Data Only Hotspot unless it is
     specified as a Helium-Compatible Kerlink Miner.
 


### PR DESCRIPTION
I don't know if relative links work? this would have prevented the broken link in the first place.