### PR TITLE
Adds Staked to list of Staking Providers

### DIFF
--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -116,3 +116,4 @@ Links to these Staking Providers are provided as is. Helium, Inc. is not directl
 * [NodeValidators](https://nodevalidators.com)
 * [Chorus One](https://chorus.one/products/whitelabel-staking)
 * [Figment](https://figment.io/)
+* [Staked](https://staking.staked.us/helium-staking)


### PR DESCRIPTION
Adds Staked to list of Staking Providers with a link directly to Staked's Helium Staking page: https://staking.staked.us/helium-staking