### PR TITLE
Fix pathing on Validators "Rewards Total" endpoint `validators/rewards/sum` 

### DIFF
--- a/docs/api/blockchain/validators.mdx
+++ b/docs/api/blockchain/validators.mdx
@@ -7510,7 +7510,7 @@ Rewards for a validator in the last 24 hours: `min_time=-24%20hour`
 ## Reward Total for all Validators
 
 ```
-GET https://api.helium.io/v1/validators/:rewards/sum
+GET https://api.helium.io/v1/validators/rewards/sum
 ```
 
 Returns the total rewards earned for all validators over a given time range.
@@ -7523,18 +7523,12 @@ includes the `max_time` timestamp is **excluded** from the result.
   values={[{"label":"Request","value":"request"},{"label":"Response","value":"response"}]}>
 <TabItem value="request">
 
-_Path Parameters_
-
-| param              | Type     | Note                         |
-| ------------------ | -------- | ---------------------------- |
-| address (required) | _string_ | B58 address of the validator |
-
 _Query Parameters_
 
 | param               | Type     | Note                                   |
 | ------------------- | -------- | -------------------------------------- |
-| max_time (required) | _string_ | Last timestamp to include rewards for  |
-| min_time (required) | _string_ | First timestamp to include rewards for |
+| max_time (optional) | _string_ | Last timestamp to include rewards for  |
+| min_time (optional) | _string_ | First timestamp to include rewards for |
 
 </TabItem>
 <TabItem value="response">


### PR DESCRIPTION
The documentation for the "Reward Total for all Validators" section stated the endpoint as `/validators/:rewards/sum` but did **_not_** have a definition/description for the `:rewards` path parameter, and instead had a _required_ `:address` parameter. Clearly this was a mistake.

I did a quick `curl https://api.helium.io/v1/validators/rewards/sum` and, just as stated in the docs, got the expected response. That being the extent of my testing, I believe it to be both accurate and consistent with the actual functionality of the API.