### PR TITLE
Dismambiguate deployment guide

### DIFF
--- a/docs/mine-hnt/validators/validators.mdx
+++ b/docs/mine-hnt/validators/validators.mdx
@@ -42,7 +42,7 @@ There is no direct migration path to move Testnet Validators to Mainnet. To depl
 
 * [Expectations](/mine-hnt/validators/testnet/expectations) - Read this guide first. These are the expectations of Testnet validators.
 * [Design](/mine-hnt/validators/testnet/design) - Differences between the Testnet and the Mainnet.
-* [Deployment Guide](/mine-hnt/validators/testnet/deployment-guide) - How to get up and running with your Testnet validator.  Including staking, running, updating, and monitoring.
+* [Testnet Deployment Guide](/mine-hnt/validators/testnet/deployment-guide) - How to get up and running with your Testnet validator.  Including staking, running, updating, and monitoring.
 * [Wallet Commands](/mine-hnt/validators/testnet/wallet) - Additional wallet commands for use with validators.
 * [Test Cases](/mine-hnt/validators/testnet/test-cases) - Test cases and areas of focus for the Testnet.
 * [Testnet Explorer](https://explorer.helium.wtf/validators) - There is a new Explorer being developed by Helium and the community.


### PR DESCRIPTION
Dismambiguate deployment guide since there are separate guides for Mainnet and Testnet