### PR TITLE
Table for Helium validator providers

### DIFF
--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -45,11 +45,11 @@ Many community members possess hardware that easily meets or exceeds the recomme
 * Most residential ISPs lack distributed denial of service (DDoS) or denial of service (DoS) protection. If a bad actor decides to target your public IP address with a botnet, you may see your cable modem, DSL modem, or optical network terminal crash spectacularly. You may not have control over the assignment of a new public IP address, so power-cycling your modem may not allow you to recover from a continuous attack. Remember, your public IP is broadcast across the helium peer-to-peer network when you connect.
 * Your ISP may implement QoS (Quality of Service) or traffic shaping policies that dynamically prioritize or deprioritize certain types of traffic without your knowledge. This could potentially impact latency between your validator nodes and other nodes in a consensus group. Bad latency can result in your eviction from a consensus group.
 * Bad actors may target your public IP address with port scanners or other scanning techniques to identify entry points. Outdated router software, poor port management, or zero-day exploits could put your entire home network (including your personal computers, crypto wallets, mobile devices, and IoT devices) at risk for attack and compromise.
-* Your ISP may automatically throttle your connection speed if the sustained traffic or connection load exceeds a value that could negatively impact the performance of other customers in your neighborhood. 
+* Your ISP may automatically throttle your connection speed if the sustained traffic or connection load exceeds a value that could negatively impact the performance of other customers in your neighborhood.
 
 Despite the warnings above, some community members will decide to run their validator from home. Remember that Helium is not responsible for security, performance, or network issues that may result from your validator configuration.
 
-### Rewards 
+### Rewards
 
 **What is the expected APR of running Helium validator?**
 
@@ -86,7 +86,7 @@ No.
 
 No. You must wait until the validator is out of the consensus group.
 
-## Resources 
+## Resources
 
 ### Videos
 
@@ -94,27 +94,29 @@ No. You must wait until the validator is out of the consensus group.
 * [Validator Staking Tutorial](https://www.youtube.com/watch?v=S3eIIAPP9rk) - Full video guide on how to deploy a Validator from `jcarl`.
 * [Validator Quickstart](https://www.youtube.com/watch?v=4szCWSDowro) - Short overview from `joey` on how to deploy and stake a Validator.
 
-## Staking Providers 
+## Staking Providers
 
 :::info
 
 Links to these Staking Providers are provided as is. Helium, Inc. is not directly associated with any of the following vendors and makes no endorsements about the quality of their offering.
+Additionally, any pricing details listed here are likely to be out of date. Please verify pricing details with the given staking provider.
 
 :::
 
-* [Helium Rising](https://www.heliumrising.com)
-* [Argon.build](https://www.argon.build)
-* [HNT Validators](https://www.hntvalidators.com)
-* [Managed Helium Validator Service](https://heliumvalidators.com)
-* [StakeMyHNT](https://www.stakemyhnt.com)
-* [Helium Staking](https://www.helium-staking.com)
-* [Validators Pool](https://helium.bx-host.com)
-* [HNT Staking](https://www.hntstaking.net)
-* [Bison Trails](https://www.bisontrails.co)
-* [Vanager](https://vanager.io)
-* [StakeJoy](https://stakejoy.com)
-* [NodeValidators](https://nodevalidators.com)
-* [Chorus One](https://chorus.one/products/whitelabel-staking)
-* [Figment](https://figment.io/)
-* [Staked](https://staking.staked.us/helium-staking)
-* [Allnodes](https://www.allnodes.com)
+| Provider                                                     | Non-custodial full node | Pooling     | Pricing                                                             | Notes
+| :----------------------------------------------------------- |:----------------------- |:----------- | :-------------------------------------------------------------------|:-----
+| [Allnodes](https://www.allnodes.com)                         | Yes                     | No          | $80 per month (Basic) or $0.2380 per hour (Advanced)                |
+| [Argon.build](https://www.argon.build)                       | Yes                     | No          | $80 per month + 3% reward share                                     |
+| [Bison Trails](https://www.bisontrails.co)                   | Yes                     | No          |                                                                     | Does not offer service to individuals who plan to run fewer than 10 nodes
+| [Chorus One](https://chorus.one/products/whitelabel-staking) | Yes                     | No          |                                                                     | Does not have public pricing.
+| [Figment](https://figment.io/)                               | Yes                     | No          | 5% comission                                                        |
+| [Helium Rising](https://www.heliumrising.com)                | Yes                     | Yes         | 5% comission                                                        |
+| [Helium Staking](https://www.helium-staking.com)             | Yes                     | Yes         | $150 per month for non-custodial full node. 4% of rewards for pool. |
+| [HNT Staking](https://www.hntstaking.net)                    | Yes                     | Yes         | $149 per monthly or $3 per day + 3% commission on earnings"         |
+| [HNT Validators](https://www.hntvalidators.com)              | Yes                     | No          | $199 per month                                                      |
+| [NodeValidators](https://nodevalidators.com)                 | Yes                     | Coming soon | $120 per month + 2.5% comission on earnings                         |
+| [Staked](https://staking.staked.us/helium-staking)           | Yes                     | No          |                                                                     | Does not have public pricing.
+| [StakeJoy](https://stakejoy.com)                             | Yes                     | No          | 5% comission on earnings                                            |
+| [StakeMyHNT](https://www.stakemyhnt.com)                     | Yes                     | Coming soon | $169 per month                                                      |
+| [Validators Pool](https://helium.bx-host.com)                | Yes                     | No          | $120 per month + 2% comission on earnings                           |
+| [Vanager](https://vanager.io)                                | Yes                     | Yes         | $4 per day + 3% comission on earnings                               |

--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -93,6 +93,7 @@ No. You must wait until the validator is out of the consensus group.
 * [HIP25 Hips Don't Lie](https://www.youtube.com/watch?v=qOEAxXaANkI) - An in-depth discussion of [HIP25](https://github.com/helium/HIP/blob/master/0025-validators.md), the foundational HIP for validators.
 * [Validator Staking Tutorial](https://www.youtube.com/watch?v=S3eIIAPP9rk) - Full video guide on how to deploy a Validator from `jcarl`.
 * [Validator Quickstart](https://www.youtube.com/watch?v=4szCWSDowro) - Short overview from `joey` on how to deploy and stake a Validator.
+* [Staking provider comparison](https://www.youtube.com/watch?v=pnW72u3ysbo) - Courtesy of **@MattLong6**. [HNT Staking Vendors](https://docs.google.com/spreadsheets/d/1xl5IjZY3xeAXTmnbLk2Ynedb9Ssd6yxRBwHixJQg8xM)
 
 ## Staking Providers
 
@@ -119,4 +120,4 @@ Additionally, any pricing details listed here are likely to be out of date. Plea
 | [StakeJoy](https://stakejoy.com)                             | Yes                     | No          | 5% comission on earnings                                            |
 | [StakeMyHNT](https://www.stakemyhnt.com)                     | Yes                     | Coming soon | $169 per month                                                      |
 | [Validators Pool](https://helium.bx-host.com)                | Yes                     | No          | $120 per month + 2% comission on earnings                           |
-| [Vanager](https://vanager.io)                                | Yes                     | Yes         | $4 per day + 3% comission on earnings                               |
+| [Vanager](https://vanager.io)                                | No                      | Yes         | $4 per day + 3% comission on earnings                               |


### PR DESCRIPTION
- Alphabetize providers
- Removed duplicate provider: https://heliumvalidators.com redirects to Vanager so we only need the latter in the table
- Added columns for Non-custodial full node, Pooling, Pricing, and Notes
- The git diff doesn't look great because this table is wide (widest column is 248 characters). Spacing looks good if you pull this locally.

### Screenshot

<img width="493" alt="Screen Shot 2021-07-15 at 11 57 20 AM" src="https://user-images.githubusercontent.com/3699047/125819109-fda2e71f-d305-489e-97c1-b5b556087b7c.png">

