### PR TITLE
Mapper API: Updates parameter type for int

### DIFF
--- a/docs/use-the-network/coverage-mapping/mappers-api.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-api.mdx
@@ -60,10 +60,10 @@ _Body Parameters_
 
 | Parameter Name  | Type     | Description                 | Expected Unit   | Example                |
 | --------------- | -------- | --------------------------- | --------------- | ---------------------- |
-| latitude        | _number_ | Device Latitude Value       | Decimal Degrees | `  37.79518664339426`  |
-| longitude       | _number_ | Device Longitude Value      | Decimal Degrees | `-122.39384483747301`  |
-| altitude        | _number_ | Device Altitude Value       | Meters          | `10`                   |
-| accuracy        | _number_ | Device GPS Accuracy Value   | Meters          | `2.3`                  |
+| latitude        | _float_ | Device Latitude Value       | Decimal Degrees | `  37.79518664339426`  |
+| longitude       | _float_ | Device Longitude Value      | Decimal Degrees | `-122.39384483747301`  |
+| altitude        | _int_   | Device Altitude Value       | Meters          | `10`                   |
+| accuracy        | _float_ | Device GPS Accuracy Value   | Meters          | `2.3`                  |
 
 </TabItem>
 <TabItem value="response">


### PR DESCRIPTION
Mappers API rejects floats for altitude, so changing the label of `number` to be more descriptive.

ref: 
https://github.com/helium/mappers/blob/master/lib/mappers/uplinks/uplink.ex#L27