### PR TITLE
Better representation of the acceptable data types in mappers api

### DIFF
--- a/docs/use-the-network/coverage-mapping/mappers-api.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-api.mdx
@@ -58,12 +58,12 @@ All of the following fields are required `latitude`, `longitude`, `altitude`
 
 _Body Parameters_
 
-| Parameter Name  | Type     | Description                 | Expected Unit   | Example                |
-| --------------- | -------- | --------------------------- | --------------- | ---------------------- |
-| latitude        | _number_ | Device Latitude Value       | Decimal Degrees | `  37.79518664339426`  |
-| longitude       | _number_ | Device Longitude Value      | Decimal Degrees | `-122.39384483747301`  |
-| altitude        | _number_ | Device Altitude Value       | Meters          | `10`                   |
-| accuracy        | _number_ | Device GPS Accuracy Value   | Meters          | `2.3`                  |
+| Parameter Name  | Type      | Description                 | Expected Unit   | Example                |
+| --------------- | --------  | --------------------------- | --------------- | ---------------------- |
+| latitude        | _float_   | Device Latitude Value       | Decimal Degrees | `  37.79518664339426`  |
+| longitude       | _float_   | Device Longitude Value      | Decimal Degrees | `-122.39384483747301`  |
+| altitude        | _integer_ | Device Altitude Value       | Meters          | `10`                   |
+| accuracy        | _float_   | Device GPS Accuracy Value   | Meters          | `2.3`                  |
 
 </TabItem>
 <TabItem value="response">


### PR DESCRIPTION
This change changes the types in the type column for body parameters for the mappers api. 

I think it is important to explain what kind of data is accepted in the api, especially the altitude field. I spent quite a long time trying to figure out why my data was not accepted (though not consistently) even though all my data looked correct. Turns out that altitude needs to be an integer and the lgt92 reported it as a float and an integer if there was no decimal points hence the data was accepted occasionally. Not sure if float and integer is the best words to describe the types but anything is better than the current "number" type which implies all rational numbers. 

Edit: There's also [a pull request](https://github.com/helium/console-decoders/pull/20) related to this that fixes the official decoder by jas_williams. 