### PR TITLE
Console: Add info on backing up the swarm key

### DIFF
--- a/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
+++ b/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
@@ -228,4 +228,4 @@ Congratulations!
 Extract the router's swarm key and store it somewhere safe. The swarm key can be extracted by running `base64 ~/console/data/router/blockchain/swarm_key` and saved in your favorite password manager. An alternative is to copy the file somewhere safe.
 
 #### A Note on the Purpose of a `swarm_key`
-The `swarm_key` equates to your validator's unique identity on the Helium blockchain. Backing up the `swarm_key` enables you to maintain your validator's identity in the event that your node becomes compromised in some way, or needs to be rebuilt on another server for any reason.
+The `swarm_key` equates to your validator's unique identity on the Helium blockchain. Backing up the `swarm_key` enables you to maintain your router's identity in the event that your node becomes compromised in some way, or needs to be rebuilt on another server for any reason.

--- a/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
+++ b/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
@@ -222,3 +222,10 @@ Join Request, then you are successfully running your private LoRaWAN Network
 Server.
 
 Congratulations!
+
+### Backing up your `swarm_key`
+
+Extract the router's swarm key and store it somewhere safe. The swarm key can be extracted by running `base64 ~/console/data/router/blockchain/swarm_key` and saved in your favorite password manager. An alternative is to copy the file somewhere safe.
+
+#### A Note on the Purpose of a `swarm_key`
+The `swarm_key` equates to your validator's unique identity on the Helium blockchain. Backing up the `swarm_key` enables you to maintain your validator's identity in the event that your node becomes compromised in some way, or needs to be rebuilt on another server for any reason.


### PR DESCRIPTION
Backing up the swarm key is an important part of maintaining a router.