### PR TITLE
Document that ?filter_types works on all /activity endpoints

### DIFF
--- a/docs/api/blockchain/accounts.mdx
+++ b/docs/api/blockchain/accounts.mdx
@@ -559,6 +559,12 @@ _Path Parameters_
 | ------------------ | -------- | ----------------------------------------- |
 | address (required) | _string_ | Account B58 address to fetch activity for |
 
+_Query Parameters_
+
+| param        | Type     | Note                                       |
+| ------------ | -------- | ------------------------------------------ |
+| filter_types | _string_ | Comma separated list of transaction types |
+
 </TabItem>
 <TabItem value="response">
 

--- a/docs/api/blockchain/accounts.mdx
+++ b/docs/api/blockchain/accounts.mdx
@@ -707,7 +707,7 @@ _Query Parameters_
 
 | param        | Type     | Note                                       |
 | ------------ | -------- | ------------------------------------------ |
-| filter_types | _string_ | Comma separated list of transasction types |
+| filter_types | _string_ | Comma separated list of transaction types |
 
 </TabItem>
 <TabItem value="response">

--- a/docs/api/blockchain/hotspots.mdx
+++ b/docs/api/blockchain/hotspots.mdx
@@ -806,9 +806,11 @@ _Path Parameters_
 
 _Query Parameters_
 
-| param             | Type     | Note                                |
-| ----------------- | -------- | ----------------------------------- |
-| cursor (optional) | _string_ | Cursor for page of results to fetch |
+| param             | Type     | Note                                       |
+| ----------------- | -------- | ------------------------------------------ |
+| cursor (optional) | _string_ | Cursor for page of results to fetch        |
+| filter_types      | _string_ | Comma separated list of transaction types  |
+
 
 </TabItem>
 <TabItem value="response">

--- a/docs/api/blockchain/hotspots.mdx
+++ b/docs/api/blockchain/hotspots.mdx
@@ -884,7 +884,7 @@ _Query Parameters_
 
 | param        | Type     | Note                                       |
 | ------------ | -------- | ------------------------------------------ |
-| filter_types | _string_ | Comma separated list of transasction types |
+| filter_types | _string_ | Comma separated list of transaction types |
 
 </TabItem>
 <TabItem value="response">

--- a/docs/api/blockchain/validators.mdx
+++ b/docs/api/blockchain/validators.mdx
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 :::warning
 
-These docs reflect the Validator Mainnet API. If you would like to use the Testnet API, 
+These docs reflect the Validator Mainnet API. If you would like to use the Testnet API,
 please use the following base url:
 
 ```
@@ -6460,7 +6460,7 @@ _Query Parameters_
 
 | param        | Type     | Note                                       |
 | ------------ | -------- | ------------------------------------------ |
-| filter_types | _string_ | Comma separated list of transasction types |
+| filter_types | _string_ | Comma separated list of transaction types |
 
 </TabItem>
 <TabItem value="response">

--- a/docs/api/blockchain/validators.mdx
+++ b/docs/api/blockchain/validators.mdx
@@ -6354,9 +6354,10 @@ _Path Parameters_
 
 _Query Parameters_
 
-| param             | Type     | Note                                |
-| ----------------- | -------- | ----------------------------------- |
-| cursor (optional) | _string_ | Cursor for page of results to fetch |
+| param             | Type     | Note                                       |
+| ----------------- | -------- | ------------------------------------------ |
+| cursor (optional) | _string_ | Cursor for page of results to fetch        |
+| filter_types      | _string_ | Comma separated list of transaction types  |
 
 </TabItem>
 <TabItem value="response">


### PR DESCRIPTION
The following endpoints support the extremely-useful ?filter_types parameter:

* hotspots/:address/activity
* accounts/:address/activity
* validators/:address/activity

I also fixed some "transasction" typos while I was in there

Hi Mark
