### PR TITLE
Update OUI and self-hosted console guide with correct HNT burn strategy

### DIFF
--- a/docs/use-the-network/run-a-network-server/buy-an-oui/buy-an-oui.mdx
+++ b/docs/use-the-network/run-a-network-server/buy-an-oui/buy-an-oui.mdx
@@ -43,79 +43,11 @@ any further. You'll want to
 [create a wallet](https://github.com/helium/helium-wallet-rs#create-a-wallet)
 and to have at least $900 in HNT (base on current HNT Oracle pricing).
 
-## Create Data Credits
-
-Many fees benefit from
-[implicit burn](/blockchain/transaction-fees#transaction-fees-and-implicit-burn),
-but when paying for OUIs and DevAddr's, the Data Credits must be part of the
-purchasers balance.
-
-```text
-$ ./helium-wallet balance
-+-----------------------------------------------------+------------+--------------+-----------------+
-| Address                                             | Balance    | Data Credits | Security Tokens |
-+-----------------------------------------------------+------------+--------------+-----------------+
-| 12yUUZmsVyVaomxkvuNXtD2rAHYWgYwJLXtz4H9FjYgE2WcniLx | 0.00000000 | 0            | 0.00000000      |
-+-----------------------------------------------------+------------+--------------+-----------------+
-```
-
-If we don't have an account balance of at least `90,000,000` DCs ($900), we need
-to create the data credits now.
-
-Inspect
-[the current oracle price](https://api.helium.io/v1/oracle/prices/current) and
-you'll get the current price of HNT as agreed by the Helium Network; it's
-represented in 10^-8 dollars. Suppose it is currently $4.5, so we would get:
-
-```text
-{"data":{"timestamp":"2021-02-25T10:01:32.000000Z","price":450000000,"block":735970}}
-```
-
-Since 1 DC = $.00001 = $10^-5 and we need to normalize with the $10^-8 from the
-oracle price, we can plug the following into our favorite calculate (for
-example, in Python):
-
-```text
->>> 90000000*10**3/450000000
-200.0
-```
-
-I need to **200 HNT** to get $900 of DC (plus a little extra for the OUI txn
-fee). From _any_ wallet with ~201 HNT, I need to initiate the following
-transaction, which sets the wallet I just created as the beneficiary of the
-burn.
-
-Note: I burn an extra 0.5 HNT ~= $2 with the values in this example. This should
-be sufficient for fees. That extra amount changes depending on the current
-oracle price.
-
-```text
-./helium-wallet burn --amount 200.5 --payee 12yUUZmsVyVaomxkvuNXtD2rAHYWgYwJLXtz4H9FjYgE2WcniLx --commit
-```
-
-This submits the transaction and the CLI will output the transaction hash which
-you can track at the following endpoint:
-
-```
-https://api.helium.io/v1/pending_transactions/HASH
-```
-
-When the transaction clears, our balance should look like this:
-
-```text
-$ ./helium-wallet balance
-+-----------------------------------------------------+------------+--------------+-----------------+
-| Address                                             | Balance    | Data Credits | Security Tokens |
-+-----------------------------------------------------+------------+--------------+-----------------+
-| 12yUUZmsVyVaomxkvuNXtD2rAHYWgYwJLXtz4H9FjYgE2WcniLx | 0.00000000 | 90225000     | 0.00000000      |
-+-----------------------------------------------------+------------+--------------+-----------------+
-```
-
 ## Purchase the OUI
 
-The next part is simple. Submit a "create OUI" transaction:
+Submit a "create OUI" transaction:
 
-```text
+```bash
 ./helium-wallet oui create --subnet-size 8 --filter wVwCiewtCpEKAAAAAAAAAAAAcCK3fwAAAAAAAAAAAABI7IQOAHAAAAAAAAAAAAAAAQAAADBlAAAAAAAAAAAAADEAAAA2AAAAOgAAAA
 ```
 
@@ -129,3 +61,4 @@ and on
 Congratulations! You are the proud owner of a Helium Network OUI. OUIs are
 numbered sequentially, so the lower you are, the earlier you were on the
 Network!.
+

--- a/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
+++ b/docs/use-the-network/run-a-network-server/run-console/run-console.mdx
@@ -100,7 +100,7 @@ later:
 
 We will do something similar for `.env-router`:
 
-```
+```bash
 cp templates/.env-router .env-router
 ```
 
@@ -141,7 +141,7 @@ can revisit them later.
 ### Run it!
 
 Copy the local docker-compose file
-```
+```bash
 cp templates/docker-compose-local.yaml docker-compose.yaml
 ```
 
@@ -163,7 +163,7 @@ Optionally, you can load a snapshot so that your Console is immediately ready
 for action. Technically, the Router component of Console is what keeps up with
 the blockchain. You can check its current height
 
-```
+```bash
 docker exec helium_router router info height
 ```
 
@@ -174,23 +174,55 @@ about how to do this are [here](/mine-hnt/build-a-packet-forwarder#snapshots).
 Simply replace `miner` with `docker exec helium_router router` for most of the
 commands to work.
 
-### OUI Update
+### Create Data Credits
 
 At this point, we have the software running and we have an OUI, but the
-blockchain does not know that the address of Router is associated with the OUI.
-Let's get the address of the OUI
+router does not have any DC to buy messages from the network. We need to burn
+some HNT to DC for the router.
 
-```
+The cost for rurning a router is complex. See community member disk91.com's
+[guide](https://www.disk91.com/2021/technology/lora/what-is-the-real-cost-of-helium-communication/)
+and calculate how much you need for your planned usage. One million DC ($10)
+can be a good number to start with.
+
+The easiest way to calculate how many HNT to burn to get the number of DC you
+need is to go to https://console.helium.com/datacredits and click on
+`Purchase Data Credits`. Enter the amount of DC you need and click on
+`Burn HNT to DC`. Helium Console shows how to burn the selected amount to the
+Helium Console itself. We won't do that. Just note the amount (for example
+`0.49043649`).
+
+Let's get the address of the OUI/router.
+
+```bash
 $ docker exec helium_router router peer addr
 /p2p/11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf
 ```
 
 The string after the second slash,
 `11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf`, is the libp2p address and
-this is what you need to update your OUI with, using the wallet you bought the
+this is where we need to burn the DC.
+Now return to your command line wallet and burn the HNT amount **with the
+libp2p address of your OUI/router as payee**. Example:
+
+```bash
+helium-wallet burn --amount 0.49043649 --payee 11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf --commit
+```
+
+Once this transaction clears, we'll be ready for the next step.
+
+### OUI Update
+
+At this point, we have the software running and we have an OUI, but the
+blockchain does not know that the address of Router is associated with the OUI.
+Use the same libp2p address used in the previous step.
+
+/p2p/11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf
+```
+
 OUI with.
 
-```
+```bash
 $ helium-wallet oui update routers --oui 4 --nonce 1 --address 11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf --commit
 ```
 
@@ -202,6 +234,26 @@ Monitor the account in explorer to verify that Router is doing this
 appropriately. eg:
 `https://explorer.helium.com/accounts/11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf`
 
+### Create Data Credits
+
+Many fees benefit from
+[implicit burn](/blockchain/transaction-fees#transaction-fees-and-implicit-burn),
+including when paying for OUIs and DevAddr's (done previously when you
+[purchased an OUI](/use-the-network/buy-an-oui), but your router needs a DC balance
+to run.
+
+The cost for rurning a router is complex. See community member disk91.com's
+[guide](https://www.disk91.com/2021/technology/lora/what-is-the-real-cost-of-helium-communication/)
+and calculate how much you need for your planned usage.
+
+One million DC ($10) can be a good number to start with. The easiest way to calculate how many HNT to burn to get the number of DC you need is to go to https://console.helium.com/datacredits and click on `Purchase Data Credits`. Enter the amount of DC you need and click on `Burn HNT to DC`. Helium Console shows how to burn the selected amount to the Helium Console itself. We won't do that. Just note the amount (for example `0.49043649`).
+
+Now return to your command line wallet and burn the HNT amount **with the libp2p address of your router as payee**. Example:
+
+```bash
+helium-wallet burn --amount 0.49043649 --payee 11xHXS5AgLyjYRCJ4ctcWcsMRULS8jro9Pb1GPaTG1neGk1dNcf --commit
+```
+
 ### Test a Device
 
 Login to your local Console instance (localhost:4000) and create an organization
@@ -212,7 +264,7 @@ Once you've created the device on console, go to a terminal window on server
 running Console and execute the following command to tell Router to update the
 `xor filter` on the blockchain:
 
-```
+```bash
 docker exec helium_router router device xor --commit
 ```
 


### PR DESCRIPTION
There were some areas of improvement in the original guide:
* Implicit burn works for OUI purchase, so no need to mess with manual
burn.
* Most users probably find it easier to calculate how many HNT to burn
by using the existing feature in Helium Console
* Calculation of DC cost for running a private router is very complex.
Refer to disk91.com's nice guide.