### PR TITLE
Conform to "_" instead of "-" for consistency

### DIFF
--- a/docs/api/blockchain/oracle_prices.mdx
+++ b/docs/api/blockchain/oracle_prices.mdx
@@ -1,7 +1,7 @@
 ---
-id: oracle-prices
+id: oracle_prices
 sidebar_label: Oracle Prices
-slug: /api/blockchain/oracle-prices
+slug: /api/blockchain/oracle_prices
 ---
 
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
Found an inconsistency with hyphens and underscores when using the API docs. 

My initial response here:
https://discord.com/channels/404106811252408320/761227215710060574/883483181645455420