### PR TITLE
Conform to "_" instead of "-" for consistency

### DIFF
--- a/docs/api/blockchain/chain-variables.mdx
+++ b/docs/api/blockchain/chain-variables.mdx
@@ -1,7 +1,7 @@
 ---
-id: chain-variables
+id: chain_variables
 sidebar_label: Chain Variables
-slug: /api/blockchain/chain-variables
+slug: /api/blockchain/chain_variables
 ---
 
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
Found an inconsistency with hyphens and underscores when using the API docs. 

My initial response here:
https://discord.com/channels/404106811252408320/761227215710060574/883483181645455420