### PR TITLE
Conform to "_" instead of "-" for consistency

### DIFF
--- a/docs/api/blockchain/pending-transactions.mdx
+++ b/docs/api/blockchain/pending-transactions.mdx
@@ -1,7 +1,7 @@
 ---
-id: pending-transactions
+id: pending_transactions
 sidebar_label: Pending Transactions
-slug: /api/blockchain/pending-transactions
+slug: /api/blockchain/pending_transactions
 ---
 
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
Found an inconsistency with hyphens and underscores when using the API docs.

My initial response here:
https://discord.com/channels/404106811252408320/761227215710060574/883483181645455420