### PR TITLE
Move Docs Installation Guide

### DIFF
--- a/docs/open-source/docs/installation.mdx
+++ b/docs/open-source/docs/installation.mdx
@@ -1,11 +1,11 @@
 ---
 id: installation
 hide_title: false
-sidebar_label: Installation
-slug: /open-source/installation
+sidebar_label: Installation Guide
+slug: /open-source/docs/installation
 ---
 
-# Prerequisite installation guide for docs website development
+# Helium Documentation Installation Guide
 
 ## Node.js
 

--- a/docs/open-source/open-source.mdx
+++ b/docs/open-source/open-source.mdx
@@ -2,7 +2,7 @@
 id: open-source
 hide_title: true
 sidebar_label: Overview
-slug: /open-source/open-source
+slug: /open-source
 ---
 
 
@@ -84,5 +84,5 @@ some of the code that makes it possible.
 - [Helium Docs](https://github.com/helium/docs) - Docusaurus-based docs for all
   things Helium. (You're reading them.)
   
-   - [Installation](/open-source/installation) - How to install the needed components 
+   - [Installation](/open-source/docs/installation) - How to install the needed components 
    to start helping docs development.

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -67,7 +67,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Open Source',
-      items: ['open-source/open-source','open-source/installation'],
+      items: ['open-source/open-source'],
       collapsed: true,
     },
     {
@@ -116,6 +116,19 @@ module.exports = {
       type: 'category',
       label: 'Console',
       items: ['use-the-network/console/quickstart', 'use-the-network/console/users', 'use-the-network/console/data-credits', 'use-the-network/console/adding-devices', 'use-the-network/console/migrating-devices/migrating-devices', 'use-the-network/console/labels', 'use-the-network/console/debug', 'use-the-network/console/device-configurations', 'use-the-network/console/flows/flows', 'use-the-network/console/functions', 'use-the-network/console/integrations/integrations', 'use-the-network/console/console-cli', 'use-the-network/console/console-api','use-the-network/console/my-account', 'use-the-network/console/troubleshooting'],
+      collapsed: false,
+    }
+  ],
+  opensourcedocs: [
+   {
+      type: 'link',
+      label: '<- Back',
+      href: '/open-source'
+    },
+    {
+      type: 'category',
+      label: 'Docs',
+      items: ['open-source/docs/installation'],
       collapsed: false,
     }
   ],


### PR DESCRIPTION
The original location of the new docs install guide was a little out of place. This PR creates a new docs section under open source to place it instead.