### PR TITLE
Conform to "-" instead of "_" for document URLs

### DIFF
--- a/docs/api/blockchain/assert-locations.mdx
+++ b/docs/api/blockchain/assert-locations.mdx
@@ -1,7 +1,7 @@
 ---
-id: assert_locations
+id: assert-locations
 sidebar_label: Assert Locations
-slug: /api/blockchain/assert_locations
+slug: /api/blockchain/assert-locations
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/api/blockchain/dc-burns.mdx
+++ b/docs/api/blockchain/dc-burns.mdx
@@ -1,7 +1,7 @@
 ---
-id: dc_burns
+id: dc-burns
 sidebar_label: DC Burns
-slug: /api/blockchain/dc_burns
+slug: /api/blockchain/dc-burns
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/api/blockchain/state-channels.mdx
+++ b/docs/api/blockchain/state-channels.mdx
@@ -1,7 +1,7 @@
 ---
-id: state_channels
+id: state-channels
 sidebar_label: State Channels
-slug: /api/blockchain/state_channels
+slug: /api/blockchain/state-channels
 ---
 
 import Tabs from "@theme/Tabs";

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -88,7 +88,7 @@ module.exports = {
    {
       type: 'category',
       label: 'Blockchain',
-      items: ['api/blockchain/introduction', 'api/blockchain/stats', 'api/blockchain/blocks', 'api/blockchain/accounts', 'api/blockchain/validators', 'api/blockchain/hotspots', 'api/blockchain/cities', 'api/blockchain/locations', 'api/blockchain/transactions', 'api/blockchain/pending-transactions', 'api/blockchain/oracle-prices', 'api/blockchain/chain-variables', 'api/blockchain/ouis', 'api/blockchain/rewards', 'api/blockchain/dc_burns', 'api/blockchain/challenges', 'api/blockchain/elections', 'api/blockchain/state_channels', 'api/blockchain/assert_locations'],
+      items: ['api/blockchain/introduction', 'api/blockchain/stats', 'api/blockchain/blocks', 'api/blockchain/accounts', 'api/blockchain/validators', 'api/blockchain/hotspots', 'api/blockchain/cities', 'api/blockchain/locations', 'api/blockchain/transactions', 'api/blockchain/pending-transactions', 'api/blockchain/oracle-prices', 'api/blockchain/chain-variables', 'api/blockchain/ouis', 'api/blockchain/rewards', 'api/blockchain/dc-burns', 'api/blockchain/challenges', 'api/blockchain/elections', 'api/blockchain/state-channels', 'api/blockchain/assert-locations'],
       collapsed: true,
     },
     'api/console',


### PR DESCRIPTION
Some URLs have - for spaces and some for _ so making them the standardized "-".

I noticed this when trying to use the API that the URLs were inconsistent. Strange though that the URLs for docs are a hyphen ("-") and the actual API calls use underscore ("_") still inconsistent but yet more consistent :)

I would have to imagine it would be a big overhaul to replace either other across the entire project. My only focus has been using the block chain API.