### PR TITLE
Add Mappers Roadmap

### DIFF
--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -30,7 +30,7 @@ In order to place a mark on the map, the mapper device sends out a signal with a
 
 ### Why should I contribute to Mappers?
 There are a variety of ways that Mapping is valuable to both hotspot owners and network users.
-For hotspot owners, the collected data helps to visualize the coverage provided by all Helium hotspots - identifying areas where coverage is lacking or even where hotspot placements could be made that would participate in Proof of Coverage with other hotspots. A marked hex on the map indicates that uplink signals from registered Helium Lorawan sensors have been proven to be “heard” by the Helium network somewhere within that hex shaped area.
+For hotspot owners, the collected data helps to visualize the coverage provided by all Helium hotspots - identifying areas where coverage is lacking or even where hotspot placements could be made that would participate in Proof of Coverage with other hotspots. A marked hex on the map indicates that uplink signals from registered Helium LoRaWAN sensors have been proven to be “heard” by the Helium network somewhere within that hex shaped area.
 
 For network users, the map proves the real-world coverage that hotspots provide. This is like looking at the Verizon or T-Mobile map when evaluating phone plans, but for business users. This real world evidence at the scale and resolution offered by our map gives prospective network users the information they need to make decisions about their deployments.
 As an example, this map is what someone like Lime scooters would look to before they sign a contract. 

--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -16,8 +16,10 @@ View Mappers data at [mappers.helium.com](https://mappers.helium.com/). The Mapp
 Be sure to check out the ongoing conversation in the dedicated `#mappers` channel on the [Helium Discord Server](https://discord.gg/helium).
 
 ## Mappers Newsletter
-
 Join the Mappers [newsletter](https://www.helium.com/mappers) to stay up to date on new and upcoming features.
+
+## Project Roadmap
+Take a look at the big picture in the [Mappers Roadmap](/use-the-network/coverage-mapping/mappers-roadmap). The roadmap is a great way to understand the full scope of the project and find an area to make your own contributions to the project.
 
 ## Frequently Asked Questions
 

--- a/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
@@ -1,5 +1,5 @@
 ---
-id: Mappers Roadmap
+id: mappers-roadmap
 sidebar_label: Mappers Roadmap
 slug: /use-the-network/coverage-mapping/mappers-roadmap
 ---

--- a/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
@@ -1,5 +1,5 @@
 ---
-id: mappers-api
+id: Mappers Roadmap
 sidebar_label: Mappers Roadmap
 slug: /use-the-network/coverage-mapping/mappers-roadmap
 ---
@@ -8,42 +8,70 @@ slug: /use-the-network/coverage-mapping/mappers-roadmap
 
 ## Introduction
 The Mappers project is a crowd-sourced effort to build a true-signal coverage map of the Helium network across the globe.
-The ‘Moonshot’ goal for this roadmap is to get the Helium coverage map to a state where it offers a full understanding of the ubiquitious LoRaWAN network. 
+
+The ‘Moonshot’ goal for this roadmap is to get the Helium coverage map to a state where it offers a full understanding of the ubiquitious LoRaWAN and 5G networks and can be adapted for future protocols. 
 In pursuit of this goal, there are several high-level objectives that are broken out into their tactical subparts.
+
+Since this project is an open source, community-driven effort; timelines have not been applied to the various goals listed. We encourage the community to adopt any of the goals in the effort of growing the project.
 
 ## Make It Easier to Contribute
 ### Mapping Device Tutorials
-* Document existing mapping devices
-* Write in-depth guides for each mapping device in Helium docs
+In the nearterm, the easiest way to enable more people to participate in mapping is simply to make it easier for them to get started. 
+
+Any community member with experience getting their own device set up can help the next wave of mappers get their start! If you have experience getting a device set up, consider contributing your experience in the form of an in-depth guide.
+
 ### Develop BLE Mapper
-* Next generation of mapper device allows reporting of uncovered areas via native app pair.
-* Open source project and protocol designed to interface with Mapping App
-* Any party can manufacture and sell their own.
-* DIY mappers still supported.
+We seek to build new firmware, initially targeting bluetooth-enabled, nRF52-based devices like the RAK WisBlock or TTGO T-Echo. Building on this platform allows us to address some of the shortcomings of LoRa-only mappers by leveraging the Bluetooth to pair with a phone. 
+
+This firmware will be open source and accompanied by a protocol that other developers can follow if they wish to build their own variations. Any party will be able to manufacture and sell their own mapping devices.
+
+The current generation of mapping devices do a great job of showing coverage where it exists, but are unable to report where coverage does not exist. By pairing with a phone, we can utilize the cellular connection to report when an uplink has been attempted. With this information we have geographic record a packet that should exist that can be compared with received data.
+
+The device can optionally include a GPS module which would allow reducing overall cost. When a GPS module is not available, a phone connection would be required to provide geographic information.
+
+Existing devices will continue to be supported.
+
 ### Native Mapping App
-* Streamline onboarding for users. No console account or firmware needed.
-* Works in tandem with BLE mappers
-* Offers extended functionality beyond current platforms.
+In association with the new BLE-based mapper, a purpose-built phone app must be developed to interface with these devices. This opens many opportunities to streamline the experience for community members joining the project.
+
+The onboarding of devices will no longer require the creation of a console account, EUI onboarding, or device flashing. Devices will be onboarded throught the app, and data credit costs may either be paid by a party like Helium, DeWi, or covered through a small in-app fee. Just pair the device with the app and it's ready to map.
+
+To make sure all mappers are up to date, software has been developed that will allow the mapping device to be updated directly through the app as the BLE mapper firmware evolves.
 
 ## Better Understand Mappers Data
 ### Continued Mappers v2 Improvements
-Mappers v2 was structured to be the 'Minimum Lovable Release' of the longterm vision, a Helium Coverage Explorer. In pursuit of the next major release, we have used v2 to teach us the value of the data, how it is used, and how community members most enjoy contributing. The v2 platform has already done a lot to help us in this respect. In the effort of continuing our user research, we will continue to add additional features and enhancements. These additions will continue to be tracked as issues on the [Mappers Github](https://github.com/helium/mappers/issues) project. 
+Mappers v2 was structured to be the 'Minimum Lovable Release' of the longterm vision, a Helium Coverage Explorer. In pursuit of the next major release, we have used v2 to teach us the value of the data, how it is used, and how community members most enjoy contributing. The v2 platform has already done a lot to help us in this respect. In the effort of continuing our user research, we will continue to add additional features and enhancements. These additions will continue to be tracked as issues on the [Mappers Github](https://github.com/helium/mappers/issues) project.
+
 ### Mappers v3 (Coverage Explorer)
-* Shaped by learnings from v2 release
-* Tools designed to allow users to better understand hotspot deployments
+In pursuit of supporting more in-depth analysis of the data, more tools, layers, and metrics can be surfaced in the app. A rework of the UI will allow these features to be added ad-hoc to the application.
+It is also possible that the mappers data finds itself in the Helium Explorer, augmenting the data already offered there.
+
+As example, a few features that may land in a v3 release:
+* Showing the coverage for a single hotspot.
+* New map layers showing redundancy or recency.
+* Filters for altitude or spreading factor.
+* Clearing of data from old assertions of hotspots.
 
 ## Further Engage Mappers
-Should mapper growth be lower than desired, there are opportunities to expand.
+Should mapper growth be lower than desired, there are opportunities to further grow. Other roadmap items likely take priority.
 * Leaderboard
 * Capture the Hex game
 
 ## Enable Community Participation
 ### Mappers API
-* Broader opportunities for community-built apps.
-### Open Source
-* All source of this project will continue to be freely available
+Mappers v1 and v2 have offered a glimpse of what is possible with the data collected by the Mappers community. Outside of the Mappers project, we have seen explosive growth of community-developed apps like Hotspotty and Helium Vision - to name a few. 
 
-## Explore New Uses for Mapping Project 
-* Explore secure mapping opportunities
- 
-{/* #a334fb;*/}
+In the interest of enabling the community to build on top of the Mappers dataset, a cohesive API can be built to support developers in crafting their own reprentation of Helium coverage.
+
+### Open Source
+All source of this project will continue to be freely available to the community. In purusit of further enabling community involvement, documentation of code, issues, and roadmap will continue to be a high priority. Open source also means nothing is set in stone, and community input continues to shape the future of this project.
+
+## Further Engage Mappers
+Should mapper growth be lower than desired, there are opportunities to further grow. Other roadmap items likely take priority.
+* Leaderboard
+* Capture the Hex game
+
+## Explore Secure Mappers 
+Many have recognized the value of real-world coverage data as a valuable resource for proof of coverage and hotspot verification. However, the current system of submitting mapper data is inadequate for protecting the incentive-based models that reward hotspot owners. This is due only to the fact that submitting false data to Mappers would be a trivial task. (As such, no data from this system would ever be used in this manner.)
+
+In order to leverage Mappers data for network verification; new ingest protocols will need to be built and new classes of hardware will need to be developed that are hardened against attack by those who might submit false coverage information.

--- a/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
@@ -1,0 +1,49 @@
+---
+id: mappers-api
+sidebar_label: Mappers Roadmap
+slug: /use-the-network/coverage-mapping/mappers-roadmap
+---
+
+# Mappers Roadmap
+
+## Introduction
+The Mappers project is a crowd-sourced effort to build a true-signal coverage map of the Helium network across the globe.
+The ‘Moonshot’ goal for this roadmap is to get the Helium coverage map to a state where it offers a full understanding of the ubiquitious LoRaWAN network. 
+In pursuit of this goal, there are several high-level objectives that are broken out into their tactical subparts.
+
+## Make It Easier to Contribute
+### Mapping Device Tutorials
+* Document existing mapping devices
+* Write in-depth guides for each mapping device in Helium docs
+### Develop BLE Mapper
+* Next generation of mapper device allows reporting of uncovered areas via native app pair.
+* Open source project and protocol designed to interface with Mapping App
+* Any party can manufacture and sell their own.
+* DIY mappers still supported.
+### Native Mapping App
+* Streamline onboarding for users. No console account or firmware needed.
+* Works in tandem with BLE mappers
+* Offers extended functionality beyond current platforms.
+
+## Better Understand Mappers Data
+### Continued Mappers v2 Improvements
+Mappers v2 was structured to be the 'Minimum Lovable Release' of the longterm vision, a Helium Coverage Explorer. In pursuit of the next major release, we have used v2 to teach us the value of the data, how it is used, and how community members most enjoy contributing. The v2 platform has already done a lot to help us in this respect. In the effort of continuing our user research, we will continue to add additional features and enhancements. These additions will continue to be tracked as issues on the [Mappers Github](https://github.com/helium/mappers/issues) project. 
+### Mappers v3 (Coverage Explorer)
+* Shaped by learnings from v2 release
+* Tools designed to allow users to better understand hotspot deployments
+
+## Further Engage Mappers
+Should mapper growth be lower than desired, there are opportunities to expand.
+* Leaderboard
+* Capture the Hex game
+
+## Enable Community Participation
+### Mappers API
+* Broader opportunities for community-built apps.
+### Open Source
+* All source of this project will continue to be freely available
+
+## Explore New Uses for Mapping Project 
+* Explore secure mapping opportunities
+ 
+{/* #a334fb;*/}

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -194,7 +194,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Coverage Mapping',
-      items: ['use-the-network/coverage-mapping/mappers-quickstart', 'use-the-network/coverage-mapping/mappers-api', 'use-the-network/coverage-mapping/adeunis-mapper'],
+      items: ['use-the-network/coverage-mapping/mappers-quickstart', 'use-the-network/coverage-mapping/mappers-api', 'use-the-network/coverage-mapping/adeunis-mapper', 'use-the-network/coverage-mapping/mappers-roadmap'],
       collapsed: false,
     },
   ],


### PR DESCRIPTION
Adds a Mappers roadmap to build alignment in the project and open opportunities for further community contribution – either on volunteer basis or through DeWi grants.

- [x] Add overall base content 
- [x] Add more detail
~Formatting improvements~