### PR TITLE
Mappers Roadmap light cleanup.

### DIFF
--- a/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
+++ b/docs/use-the-network/coverage-mapping/mappers-roadmap.mdx
@@ -9,7 +9,7 @@ slug: /use-the-network/coverage-mapping/mappers-roadmap
 ## Introduction
 The Mappers project is a crowd-sourced effort to build a true-signal coverage map of the Helium network across the globe.
 
-The ‘Moonshot’ goal for this roadmap is to get the Helium coverage map to a state where it offers a full understanding of the ubiquitious LoRaWAN and 5G networks and can be adapted for future protocols. 
+The goal for this roadmap is to get the Helium coverage map to a state where it offers a full understanding of the ubiquitious LoRaWAN and 5G networks and can be adapted for future protocols. 
 In pursuit of this goal, there are several high-level objectives that are broken out into their tactical subparts.
 
 Since this project is an open source, community-driven effort; timelines have not been applied to the various goals listed. We encourage the community to adopt any of the goals in the effort of growing the project.
@@ -52,11 +52,6 @@ As example, a few features that may land in a v3 release:
 * Filters for altitude or spreading factor.
 * Clearing of data from old assertions of hotspots.
 
-## Further Engage Mappers
-Should mapper growth be lower than desired, there are opportunities to further grow. Other roadmap items likely take priority.
-* Leaderboard
-* Capture the Hex game
-
 ## Enable Community Participation
 ### Mappers API
 Mappers v1 and v2 have offered a glimpse of what is possible with the data collected by the Mappers community. Outside of the Mappers project, we have seen explosive growth of community-developed apps like Hotspotty and Helium Vision - to name a few. 
@@ -66,12 +61,18 @@ In the interest of enabling the community to build on top of the Mappers dataset
 ### Open Source
 All source of this project will continue to be freely available to the community. In purusit of further enabling community involvement, documentation of code, issues, and roadmap will continue to be a high priority. Open source also means nothing is set in stone, and community input continues to shape the future of this project.
 
-## Further Engage Mappers
+### Further Engage Mappers
 Should mapper growth be lower than desired, there are opportunities to further grow. Other roadmap items likely take priority.
 * Leaderboard
 * Capture the Hex game
 
-## Explore Secure Mappers 
+## Forward-looking Opportunities
+### Explore Secure Mappers
 Many have recognized the value of real-world coverage data as a valuable resource for proof of coverage and hotspot verification. However, the current system of submitting mapper data is inadequate for protecting the incentive-based models that reward hotspot owners. This is due only to the fact that submitting false data to Mappers would be a trivial task. (As such, no data from this system would ever be used in this manner.)
 
 In order to leverage Mappers data for network verification; new ingest protocols will need to be built and new classes of hardware will need to be developed that are hardened against attack by those who might submit false coverage information.
+
+### Additional Community Input
+As with all parts of the Helium project, we look to the community to develop use cases, provide feedback, and define new features. Get involved in the Mappers project:
+* [Mappers Project GitHub](https://github.com/helium/mappers/)
+* [Helium Community Discord](https://discord.gg/helium) - `#mappers` channel.


### PR DESCRIPTION
* `Further Engage Mappers` section was in there twice. 🤦‍♂️ 
* Light restructuring

I may circle back with some verbiage to introduce the focus areas from within the introduction section – or a little bit of description to follow each level-two heading.