### PR TITLE
Add LHT65 Setup info to product page

### DIFF
--- a/docs/use-the-network/devices/ready-to-use/dragino/lht65.mdx
+++ b/docs/use-the-network/devices/ready-to-use/dragino/lht65.mdx
@@ -22,6 +22,7 @@ LoRaWAN Temperature & Humidity sensor
 
 - [Product Page](http://www.dragino.com/products/lora-lorawan-end-node/item/151-lht65.html)
 - [Datasheet](http://www.dragino.com/downloads/index.php?dir=LHT65/)
+- [Helium LHT65 Setup Guide](/use-the-network/devices/ready-to-use/dragino-lht65)
 
 ### Specifications
 
@@ -29,6 +30,8 @@ LoRaWAN Temperature & Humidity sensor
 
 - temperature
 - humidity
+- battery voltage
+- external plug-in sensor
 
 ---
 


### PR DESCRIPTION
Add link to LHT65 setup page from the product page.