### PR TITLE
Update sys.config override

### DIFF
--- a/docs/mine-hnt/full-hotspots/become-a-maker/docker-integration.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/docker-integration.mdx
@@ -142,7 +142,7 @@ Docker container, and connect D-bus to the Docker container. For example:
  --net host \
  --privileged \
  -v /var/run/dbus:/var/run/dbus \
- --mount type=bind,source=/home/ubuntu/overlay/docker.config,target=/opt/miner/releases/0.1.0/sys.config
+ --mount type=bind,source=/home/ubuntu/overlay/docker.config,target=/config/sys.config
 ```
 
 ## Define the DBus Config


### PR DESCRIPTION
As of some recent versions of the miner, the `sys.config` file no longer lives at the fixed path `/opt/miner/releases/0.1.0`. Use the manufactured symlink `/configs` instead.