### PR TITLE
Update rak-concentrators.mdx

### DIFF
--- a/docs/mine-hnt/data-only-guides/rak-concentrators.mdx
+++ b/docs/mine-hnt/data-only-guides/rak-concentrators.mdx
@@ -379,7 +379,7 @@ your device if it's needed.
 
 As a final check, you can compare if the Hotspot Name matches the one you
 obtained before. It could be different if there are more hotspots providing 
-overage around you. In that case, you can explore the *Multiple Packets*
+coverage around you. In that case, you can explore the *Multiple Packets*
 configuration to purchase more packets when several hotspots hear the device.
 
 ## What's next?


### PR DESCRIPTION
fixed typo missing the character "c" for the word "coverage"