### PR TITLE
Add more links to GitHub repos and tutorials

### DIFF
--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -86,17 +86,23 @@ Flash your own code and spend your own Data Credits. Setting up a mapper from yo
 * Helium Dev Kit / RAK WisBlock 
     * [Product page via RAKWireless](https://store.rakwireless.com/products/helium-developer-kit), [Product page via ParleyLabs](https://shop.parleylabs.com/collections/iot-developers-products/products/helium-wisblock-connected-kit)
     * [Helium Dev Kit tutorial](https://github.com/arkieguy/RAK4631-Helium-Mapper)
+    * [Make a Helium Mapper with the WisBlock (rakwireless.com)](https://news.rakwireless.com/make-a-helium-mapper-with-the-wisblock/)
 * Heltec CubeCell
-    * [Product page](https://heltec.org/project/htcc-ab02s/)
-    * [Heltec Cubecell tutorial](https://github.com/jas-williams/CubeCell-Helium-Mapper)
+    * [Product page](https://heltec.org/project/htcc-ab02s/), [Product page via Parley Labs](https://shop.parleylabs.com/collections/iot-developers-products/products/cubecell-gps-6502-by-heltec-htcc-ab02s), [IoWE DIY Kit](https://www.internetofwe.net/product-page/diy-coverage-mapper-kit-us915)
+    * [Heltec Cubecell tutorial 1](https://github.com/jas-williams/CubeCell-Helium-Mapper)
+    * [Heltec Cubecell tutorial 2](https://github.com/hkicko/CubeCell-GPS-Helium-Mapper)
 * Lilygo TTGO T-Beam
     * [Product page](http://www.lilygo.cn/prod_view.aspx?TypeId=50060&Id=1317&FId=t3:50060:3)
+    * [T-Beam tutorial 1](https://github.com/kizniche/ttgo-tbeam-ttn-tracker)
+    * [T-Beam tutorial 2](https://github.com/khrys63/helium-mapper-tbeam)
+    * [T-Beam tutorial 3](https://github.com/hekopath/ttgo-rev1-helium)
+    * [T-Beam tutorial 4](https://github.com/tmiklas/tbeam-helium-mapper)
 
 ### Configuration Basics
 At its core, contributing to Mappers is just a matter of delivering a specific payload through the console. Learn more about the [Mappers API](/use-the-network/coverage-mapping/mappers-api)
 
 ## Understanding the Mappers Visualization
-From within the [Mappers tool](http://mappers.helium.com), clicking on a green hexagon will allow you to get more infomation about the coverage available in that region.
+From within the [Mappers tool](http://mappers.helium.com), clicking on a green hexagon will allow you to get more information about the coverage available in that region.
 * H3 Index
     * The funny looking number like `89283082853ffff` is the unique h3 index of the hexagon on the map. In other words, it's the hex’s name. H3 is a system of managing global datasets, and is pervasive throughout different Helium protocols.
 * RSSI

--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -85,18 +85,18 @@ Flash your own code and spend your own Data Credits. Setting up a mapper from yo
     * [Disk91 Mapper tutorial](https://www.disk91.com/2021/technology/lora/low-cost-lorawan-field-tester/)
 * Helium Dev Kit / RAK WisBlock 
     * [Product page via RAKWireless](https://store.rakwireless.com/products/helium-developer-kit), [Product page via ParleyLabs](https://shop.parleylabs.com/collections/iot-developers-products/products/helium-wisblock-connected-kit)
-    * [Helium Dev Kit tutorial](https://github.com/arkieguy/RAK4631-Helium-Mapper)
-    * [Make a Helium Mapper with the WisBlock (rakwireless.com)](https://news.rakwireless.com/make-a-helium-mapper-with-the-wisblock/)
+    * [Helium Dev Kit tutorial (arkieguy)](https://github.com/arkieguy/RAK4631-Helium-Mapper)
+    * [Make a Helium Mapper with the WisBlock (johansmacias)](https://news.rakwireless.com/make-a-helium-mapper-with-the-wisblock/)
 * Heltec CubeCell
     * [Product page](https://heltec.org/project/htcc-ab02s/), [Product page via Parley Labs](https://shop.parleylabs.com/collections/iot-developers-products/products/cubecell-gps-6502-by-heltec-htcc-ab02s), [IoWE DIY Kit](https://www.internetofwe.net/product-page/diy-coverage-mapper-kit-us915)
-    * [Heltec Cubecell tutorial 1](https://github.com/jas-williams/CubeCell-Helium-Mapper)
-    * [Heltec Cubecell tutorial 2](https://github.com/hkicko/CubeCell-GPS-Helium-Mapper)
+    * [Heltec Cubecell (jas_williams)](https://github.com/jas-williams/CubeCell-Helium-Mapper)
+    * [Heltec Cubecell (kicko)](https://github.com/hkicko/CubeCell-GPS-Helium-Mapper)
 * Lilygo TTGO T-Beam
     * [Product page](http://www.lilygo.cn/prod_view.aspx?TypeId=50060&Id=1317&FId=t3:50060:3)
-    * [T-Beam tutorial 1](https://github.com/kizniche/ttgo-tbeam-ttn-tracker)
-    * [T-Beam tutorial 2](https://github.com/khrys63/helium-mapper-tbeam)
-    * [T-Beam tutorial 3](https://github.com/hekopath/ttgo-rev1-helium)
-    * [T-Beam tutorial 4](https://github.com/tmiklas/tbeam-helium-mapper)
+    * [TTGO T-Beam (kizniche)](https://github.com/kizniche/ttgo-tbeam-ttn-tracker)
+    * [TTGO T-Beam (khrys)](https://github.com/khrys63/helium-mapper-tbeam)
+    * [TTGO T-Beam (hekopath)](https://github.com/hekopath/ttgo-rev1-helium)
+    * [TTGO T-Beam (tmiklas)](https://github.com/tmiklas/tbeam-helium-mapper)
 
 ### Configuration Basics
 At its core, contributing to Mappers is just a matter of delivering a specific payload through the console. Learn more about the [Mappers API](/use-the-network/coverage-mapping/mappers-api)


### PR DESCRIPTION
Updated the coverage-mapping intro page to add more links to GitHub repos and tutorials.