### PR TITLE
Fixed typo in hotspots.mdx

### DIFF
--- a/docs/api/blockchain/hotspots.mdx
+++ b/docs/api/blockchain/hotspots.mdx
@@ -1552,8 +1552,8 @@ _No Parameters_
 GET https://api.helium.io/v1/hotspots/:address/challenges
 ```
 
-Lists the challenge (receipts) that the given hotspot a challenger, challengee
-or a witness in. This route is paged using a `cursor`.
+Lists the challenge (receipts) that the given hotspot was a challenger, challengee
+or witness in. This route is paged using a `cursor`.
 
 <Tabs
   block={true}


### PR DESCRIPTION
Fixed a small grammatical error/type in `hotspots.mdx`