### PR TITLE
Mappers: Adds Rak/Johan's pre-flashed Rak Mapper

### DIFF
--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -75,6 +75,9 @@ The [Mappers Quickstart](/use-the-network/coverage-mapping/mappers-quickstart) g
 * Glamos Walker
     * [Product page](https://glamos.eu/product/walker/)
     * [Glamos Walker tutorial](https://glamos.eu/manual/)
+* RAK Wireless Helium Mapper Kit
+    * [Product page](https://store.rakwireless.com/products/helium-mapper-kit?variant=41259355701446)
+    * [RAK Helium Mapper Kit tutorial](https://news.rakwireless.com/make-a-helium-mapper-with-the-wisblock/)
 * RAK Wireless RAK7200 
     * [Product page](https://store.rakwireless.com/products/rak7200-lpwan-tracker?variant=29669491867693)
 


### PR DESCRIPTION
Adds reference to the RAK pre flashed mapper: https://store.rakwireless.com/products/helium-mapper-kit?variant=41259355701446 
cc/ @johansmacias 