### PR TITLE
Corrected spelling of "Validator"

### DIFF
--- a/docs/blockchain/mining/mining.mdx
+++ b/docs/blockchain/mining/mining.mdx
@@ -141,7 +141,7 @@ This calculation is:`(500,000,000 DC * $0.00001 / $2 HNT Oracle Price)`
 
 **Additional Notes on Reward Types and Payouts**
 
-- All Valdators in the `Consensus` group will earn an equal reward.
+- All Validators in the `Consensus` group will earn an equal reward.
 - All Hotspots participating in PoC, including `Challengers`, `Challengees` and
   `Witnesses` will earn rewards proportional to how many events they
   participated in out of the total number of events per epoch.


### PR DESCRIPTION
Corrected spelling of the word "Validator", from the sentence "All Valdators in the `Consensus` group will earn an equal reward."