### PR TITLE
Missing underscore in "_Up to 607.6389"

### DIFF
--- a/docs/blockchain/mining/mining.mdx
+++ b/docs/blockchain/mining/mining.mdx
@@ -85,7 +85,7 @@ the following reward types:
 | Witnesses             | 20.08%        | 348.6111              |
 | Consensus Group       | 6%            | 104.1666              |
 | Security Tokens       | 33%           | 572.9166              |
-| Network Data Transfer | _Up to 35%_   | _Up to 607.6389       |
+| Network Data Transfer | _Up to 35%_   | _Up to 607.6389_      |
 | **Total**             | **100%**      | **1736.1111**         |
 
 **Rewards Change Over Time**


### PR DESCRIPTION
In the HNT Distributions table, there was a missing underscore in the "Network Data Transfer" row of the "HNT Earned by Reward Type" column, making the text "Up to 607.6389" regular instead of italic.