### PR TITLE
Word usage error correction

### DIFF
--- a/docs/blockchain/oracles/oracles.mdx
+++ b/docs/blockchain/oracles/oracles.mdx
@@ -104,7 +104,7 @@ machine if you're not using it already.
 #### Submitting HNT Prices
 
 We've added a new transaction to the blockchain for Oracle price submissions -
-`price_oracle_submission` added a corresponding CLI command - `oracle report`.
+`price_oracle_submission`, and a corresponding CLI command - `oracle report`.
 
 When you download the CLI and run `helium-wallet oracle report --help`, you'll
 see something like this:


### PR DESCRIPTION
Changed "We've added a new transaction to the blockchain for Oracle price submissions - `price_oracle_submission`, added corresponding CLI command" to "We've added a new transaction to the blockchain for Oracle price submissions - `price_oracle_submission`, and a corresponding CLI command"