### PR TITLE
Removed unnecessary full-stop

### DIFF
--- a/docs/blockchain/transaction-fees/transaction-fees.mdx
+++ b/docs/blockchain/transaction-fees/transaction-fees.mdx
@@ -85,7 +85,7 @@ For example:
 - After the transaction is submitted and processed, your resulting Helium Wallet
   balance will be `0 HNT`.
 
-In the above example, had you attempted to send `10.0001HNT` with only. `11 HNT`
+In the above example, had you attempted to send `10.0001HNT` with only `11 HNT`
 in your wallet, this transaction would have failed as burning `.999 HNT` would
 only result in `34965 DCs`, a mere 35 DCs short of the `35000` required for a
 `send` transaction.


### PR DESCRIPTION
Removed unnecessary full-stop from "send `10.0001HNT` with only. `11 HNT` in your wallet"