### PR TITLE
Changed "POC" to "PoC" once

### DIFF
--- a/docs/blockchain/mining/mining.mdx
+++ b/docs/blockchain/mining/mining.mdx
@@ -28,7 +28,7 @@ according to the following distribution:
 | Reward Type           | Description                                                                                                       |
 | :-------------------- | :---------------------------------------------------------------------------------------------------------------- |
 | PoC Challenger        | Rewarded to any Hotspot that creates a valid PoC challenge and submits the corresponding receipt to the blockchain. |
-| PoC Challengees       | Awarded to any Hotspot that transmits a POC packet after being targeted by the challenger.                                                   |
+| PoC Challengees       | Awarded to any Hotspot that transmits a PoC packet after being targeted by the challenger.                                                   |
 | Witnesses             | Distributed to all Hotspots that witness a beacon packet as part of a PoC Challenge.                                       |
 | Consensus Group       | Divided equally among the Validators that are part of the outgoing Consensus Group, responsible for mining blocks.     |
 | Security              | Awarded to Helium, Inc and other Network investors who hold Security Tokens.                                      |


### PR DESCRIPTION
"POC" has been changed to "PoC" in the sentence "Awarded to any Hotspot that transmits a POC packet after being targeted by the challenger."