### PR TITLE
Add Foundry Digital as a provider

### DIFF
--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -113,6 +113,8 @@ Additionally, any pricing details listed here are likely to be out of date. Plea
 | [Chorus One](https://chorus.one/products/whitelabel-staking) | Yes                     | No          |                                                                     | Does not have public pricing.
 | [DLI](https://dlinodes.com)                                  | Yes                     | Yes         | All run in DLI Cloud, Staking, Nodes, 24/7 Support                  |
 | [Figment](https://figment.io/)                               | Yes                     | No          | 5% comission                                                        |
+| [Foundry Digital](https://foundrystaking.com/)               | Yes                     | No          | $150.00 per month
+             |
 | [Helium Rising](https://www.heliumrising.com)                | Yes                     | Yes         | 5% comission                                                        |
 | [Helium Staking](https://www.helium-staking.com)             | Yes                     | Yes         | $150 per month for non-custodial full node. 4% of rewards for pool. |
 | [HNT Staking](https://www.hntstaking.net)                    | Yes                     | Yes         | $149 per monthly or $3 per day + 3% commission on earnings"         |

--- a/docs/mine-hnt/validators/faqs-resources-providers.mdx
+++ b/docs/mine-hnt/validators/faqs-resources-providers.mdx
@@ -113,8 +113,7 @@ Additionally, any pricing details listed here are likely to be out of date. Plea
 | [Chorus One](https://chorus.one/products/whitelabel-staking) | Yes                     | No          |                                                                     | Does not have public pricing.
 | [DLI](https://dlinodes.com)                                  | Yes                     | Yes         | All run in DLI Cloud, Staking, Nodes, 24/7 Support                  |
 | [Figment](https://figment.io/)                               | Yes                     | No          | 5% comission                                                        |
-| [Foundry Digital](https://foundrystaking.com/)               | Yes                     | No          | $150.00 per month
-             |
+| [Foundry Digital](https://foundrystaking.com/)               | Yes                     | No          | $150 per month                                                      | 
 | [Helium Rising](https://www.heliumrising.com)                | Yes                     | Yes         | 5% comission                                                        |
 | [Helium Staking](https://www.helium-staking.com)             | Yes                     | Yes         | $150 per month for non-custodial full node. 4% of rewards for pool. |
 | [HNT Staking](https://www.hntstaking.net)                    | Yes                     | Yes         | $149 per monthly or $3 per day + 3% commission on earnings"         |


### PR DESCRIPTION
Add Foundry Digital as a provider to docs to be displayed on this page.

https://docs.helium.com/mine-hnt/validators/faqs-resources-providers/#staking-providers
