### PR TITLE
Mappers: Adds link higher on the page.

### DIFF
--- a/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
+++ b/docs/use-the-network/coverage-mapping/coverage-mapping.mdx
@@ -11,7 +11,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 
 # Coverage Mapping
 
-Coverage mapping is a crowd-sourced effort to build a true-signal coverage map of the Helium network across the globe. By mapping real-world coverage, network users can understand where sensor deployments are likely to have success connecting to Helium.
+The [Mappers Coverage map](https://mappers.helium.com) is a crowd-sourced effort to build a true-signal coverage map of the Helium network across the globe. By mapping real-world coverage, network users can understand where sensor deployments are likely to have success connecting to Helium.
 
 > Coverage mapping should only be done from ground level, or slightly above it. We would like the map to indicate the expected coverage a standard sensor device would experience. If you want to fly a GPS tracker on a balloon or aircraft, please do not contribute this data to the coverage map.
 


### PR DESCRIPTION
Help newcomers discover the mappers site by pushing a mappers.helium.com link higher on the page.