### PR TITLE
Add "Router Benchmarking" doc under "run a network server"

### DIFF
--- a/docs/use-the-network/console/cli.mdx
+++ b/docs/use-the-network/console/cli.mdx
@@ -25,7 +25,8 @@ appropriate platform.
 
 ## API Key
 
-You must activate [an API key](api#api-key) before using the CLI.
+You must activate a [Console API key](my-account#console-api-keys)
+before using the CLI.
 
 The first time you run the CLI, it will prompt you for this key. It will save
 the key in a local file: `.helium-console-config.toml`

--- a/docs/use-the-network/run-a-network-server/debug-with-sniffer.mdx
+++ b/docs/use-the-network/run-a-network-server/debug-with-sniffer.mdx
@@ -67,6 +67,7 @@ cd ..
 
 git clone https://github.com/helium/gateway-rs.git
 cd gateway-rs/
+cargo install cargo-make
 cargo build --release
 
 cd ..
@@ -116,17 +117,24 @@ exchange rates in early 2022.
 Copy the value from the `Address` field:
 `WalletADDRESS...` will be used as the example in excerpts below.
 
-## Join Device To Network
+## Join Hotspot To Network
 
 Use the `WalletADDRESS...` from the earlier wallet "info" command.
 
 Arguments to both the owner and payer options will be your wallet address
 (as with a self-signed certificate).
 
-Run:
+As of v1.0, gateway-rs requires running in server-mode in the background:
 
 ```bash
 cd ~/helium/gateway-rs/
+./target/release/helium_gateway server &
+gw_pid=$!
+```
+
+Generate transaction:
+
+```bash
 ./target/release/helium_gateway add --mode dataonly \
     --owner WalletADDRESS... \
     --payer WalletADDRESS...
@@ -136,11 +144,12 @@ Output from that command will include a transaction ID associated with the
 `txn` field.  Copy this value (without quotes) which is referred to as
 `TxnID...` below for use with the CLI wallet.
 
-Accommodate cache, which isn't strictly necessary for purposes here:
+Stop the gateway service for now:
 
 ```bash
-mkdir cache
-echo 'store = "'$(pwd)'/cache"' > config/settings.toml
+kill $gw_pid
+# or
+killall helium_gateway
 ```
 
 The gateway service will be started below, after adding the device.

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -1,0 +1,754 @@
+---
+id: router-benchmarking
+sidebar_label: Router Benchmarking
+slug: /use-the-network/run-a-network-server/router-benchmarking
+---
+
+# Router Benchmarking
+
+This measures load by steadily increasing load on a
+[Helium Router](https://github.com/helium/router)
+to find its threshold of capacity for a given server instance.
+
+The procedure used is *load & capacity measurement* but some people refer to
+it as *stress testing*.
+
+This document also gives insight to interactions of routers, gateways,
+organizations, devices and wallets in production.
+
+For these instructions, each dependency is installed beneath `~/helium/`,
+and **Bash** shell syntax on Linux is used below.
+
+## Dependencies
+
+These should be **isolated** instances dedicated to load & capacity testing,
+as other users of the system *will* be negatively impacted:
+
+- [router](https://github.com/helium/router)
+- [console](https://github.com/helium/console)
+
+Install wallet on same host as your router if sharing its private key:
+
+- [helium-wallet](https://github.com/helium/helium-wallet-rs)
+  + Use a wallet with minimal funding **as assurance to avoid overspending**
+
+These may be run locally on your laptop/workstation within their respective
+build subdirectories:
+
+- [gateway-rs](https://github.com/helium/gateway-rs)
+- [helium-console-cli](https://github.com/helium/helium-console-cli)
+- [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
+
+Additional utilities, possibly already installed on your system:
+
+- [jq](https://github.com/stedolan/jq)
+
+Our working directory is `~/helium/load+capacity/`.
+
+```bash
+WORKDIR=~/helium/load+capacity
+```
+
+Convenience aliases:
+
+```bash
+alias helium-console-cli="~/helium/helium-console-cli/target/release/helium-console-cli"
+alias helium_gateway="~/helium/gateway-rs/target/release/helium_gateway"
+alias helium-wallet=~/helium/helium-wallet-rs/target/release/helium-wallet
+alias virtual-lorawan-device="~/helium/virtual-lorawan-device/target/release/virtual-lorawan-device"
+```
+
+Define base URLs as shell variables:
+
+```bash
+# development versus production, respectively:
+API_URL=https://api.helium.wtf
+API_URL=https://api.helium.io
+
+# Console corresponding to router-dev:
+CONSOLE_URL="https://helium-console-dev.herokuapp.com"
+
+# router-dev:
+ROUTER_URL="http://54.176.88.149:8080"
+# Optionally defined via script below:
+ROUTER_OUI=2
+```
+
+Convenience variables:  
+(After a few preliminary runs, significantly increase the following values)
+
+```bash
+# number of organizations:
+N_ORGS=2
+
+# number of gateways:
+N_GATEWAYS=2
+
+# number of devices per org:
+N_DEVICES=4
+
+# For priming each loop so subsequent runs can add
+# more orgs/devices/gws without clobbering:
+
+FIRST_ORG=1
+FIRST_GW=1
+FIRST_DEV=1
+```
+
+(If going above double digits for gateways or triple digits for devices, the
+scripts will need to be revised; see `seq --format` below.)
+
+Additional variables will be created along the way.
+
+## Logs & Graphs
+
+Load Tests are meaningless without the ability to measure, and in order to
+improve requires meaningful measurements.
+
+Graphs described below help on both points.
+
+Subtle nuances to comprehend first:
+
+- *Normal* has multiple meanings:
+  1. colloquially speaking, it's that which is *healthy*
+  2. in statistics it's the set of values centered within a particular
+     *distribution* such as a bell curve
+- *Nominal* also has multiple meanings:
+  + Within acceptable limits, synonymous with *healthy operation*
+  + Say *nominal* instead of *normal* in context of Load & Capacity for
+    clarity because inbound traffic fluctuates, constantly altering the
+    baseline
+
+The router repo includes
+[Grafana dashboard](https://github.com/helium/router/blob/master/grafana-dashboard.json)
+configuration used in production.
+
+For router under significant load, the most critical graphs to watch:
+
+- Ensure **Last Block** nominally remains within single digit minutes
+  + Spikes of 10-20 minutes are generally recoverable
+  + Sustaining 15 minutes behind should be cause for alarm to take action
+- Active **State Channels** on a server routing traffic
+  nominally has **at least 1** and **often 5-20**
+  + A "state channel" facilitates off-block transactions which get persisted
+    to the Blockchain as a single transaction
+  + The term "state channel" is the generic term for a Layer-2 Ledger (like the
+    "Lightning Network") and critical to router's use of the Helium Blockchain
+  + An "actor" is a co-routine in Erlang (or "Green Threads", or similar in
+    purpose to "async/await" but different mechanisms)
+- **Offer -> Packet -> Downlink** travel times:
+  + Ideally would be within **milliseconds** (ms)
+  + Acceptable when below **2 seconds**
+  + Alarm and take action when above 5 seconds
+- **Offer Duration** should be within **milliseconds** (ms)
+  + This translates directly to latency of server response, *not* counting
+    Internet traffic latency
+
+For designing your own graphs, it helps bucketing by percentiles.  Common
+buckets are: 1%, 5%, 15%, 50%, 85%, 90%, 95%, 97%, 98%, 99% 100%, which
+gives the average/mean, an approximation of standard deviation (15%, 85%)
+and most importantly the *outliers*.  Outliers are skewed here towards the
+troublesome high end for fine-grained tracking.  The 99th and 100th may be
+safely ignored when those values are indistinguishable from latency across
+the Internet, and such outliers are generally due to periodic
+garbage-collection of Erlang's underlying BEAM virtual machine.
+
+Ensure those graphs exist **before** load & capacity tests begin.
+
+## Manual Setup
+
+[Generate a Console API
+Key](https://docs.helium.com/use-the-network/console/my-account/#console-api-keys),
+which requires logging onto Console user interface (UI).  Everything else
+will be done by command-line interface (CLI).
+
+Store the newly generated Console API Key to this TOML file, and specify
+base URL of the console.  The default of `https://console.helium.com` is
+probably **not** what you want for purposes here.
+
+If using multiple organizations, create individual configuration files
+within each org's subdirectory; e.g., `org-01`, `org-02`, respectively.
+
+```bash
+for i in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  mkdir $WORKDIR/org-$i
+done
+```
+
+Persist each org's API key and Console base URL in its respective TOML file:
+
+```bash
+cd $WORKDIR/org-01/
+
+out=.helium-console-config.toml
+# Be sure to use *your* assigned key:
+echo 'key = "AlphaNumericString..."' > $out
+echo 'base_url = "'${CONSOLE_URL}'"' >> $out
+echo 'request_timeout = 120'         >> $out
+```
+
+**Repeat** for each of the multiple organizations to be used.
+
+Confirm getting valid JSON as a result:
+
+```bash
+for i in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  cd $WORKDIR/org-$i/
+  helium-console-cli device list
+done
+```
+
+With valid JSON as the result, preliminary installation is complete.
+
+Everything else may be scripted; however, creating your first device via
+Console UI may be easier than remembering how to create a unique EUI or app
+key.
+
+## Create & Fund Wallet
+
+Use or create a new wallet with minimal funding
+**as assurance to avoid overspending**.
+
+```bash
+mkdir $WORKDIR/wallet
+cd $WORKDIR/wallet/
+
+helium-wallet create basic
+
+WALLET=$(helium-wallet info | grep Address | awk '{print $4}')
+echo $WALLET
+```
+
+Ensure enough Data Credits (DC) to cover
+[cost of adding data-only hotspots and asserting
+location](https://docs.helium.com/mine-hnt/data-only-hotspots)
+of each.
+
+> e.g.,
+> For 20 instances of gateway-rs: 20 x (1000000 + 500000) at HNT prices
+in 2022Q2, this will require 15 HNT.  Plus **add for uplinks** from devices if
+> on a non developer instance of router.
+
+Provide the equivalent of the following command to whomever has the main
+wallet from which the limited wallet gets funded:
+
+> Please add funds for Load & Capacity testing:  
+> helium-wallet burn --amount 25 --payee $WALLET --commit
+
+#### Optional: Sharing Keys With Router
+
+*Only applies when router's wallet uses ed25519 keys:*
+
+Since the Load & Capacity activities will likely be using a development
+instance of a router, you may use same private key for the wallet:
+`/var/data/blockchain/swarm_key`
+
+Router can generate a file containing both public and private keys.
+
+Evaluate the following **on router host** via `router remote_console`
+command:
+
+```Erlang
+SwarmKey = filename:join([
+    application:get_env(blockchain, base_dir, "data"),
+    "blockchain",
+    "swarm_key"
+  ]),
+  {ok, RouterKeys} = libp2p_crypto:load_keys(SwarmKey),
+#{public := RouterPubKey, secret := RouterPrivKey} = RouterKeys.
+
+%% View octets of private key as Erlang Binary:
+io:format("~P", [libp2p_crypto:keys_to_bin(RouterKeys), 999]).
+
+%% Using any other file path creates INSIDE docker container:
+libp2p_crypto:save_keys(RouterKeys, "/var/data/wallet.key").
+```
+
+> If output from above indicates that it's an ECC Compact key, that key file
+is incompatible with `helium-wallet` due to using a different elliptic curve.
+
+The private key to be used by `helium-wallet` command will be in
+`/var/data/wallet.key` file.
+
+```bash
+WALLET=$(helium-wallet -f /var/data/wallet.key info | \
+         grep Address | \
+         awk '{print $4}')
+echo $WALLET
+```
+
+That shared wallet should be ready for use below.
+
+## Router Address
+
+Determine address of the router that you are using by running this one
+command **on router host**:
+
+```bash
+ssh router-dev
+cd router/
+router peer listen
+```
+
+Visually extract the entry beginning with `/p2p/` and copy the sequence up
+to but excluding the subsequent slash (`/`).  (Unfortunately, due to
+`router` being an aliased Docker command, `grep` and `sed` cannot be of
+service here.  (Otherwise, manually do the equivalent of:  
+`grep /p2p/ | sed 's%^./p2p/\([^/]*\)/.*$%\1%'`.)
+
+That long alphanumeric value gets used in multiple places below as the
+`$P2P` variable.
+
+Define this on your laptop/workstation:
+
+```bash
+P2P=longAlphanumeric...
+echo $P2P
+```
+
+## Router Location
+
+On your laptop/workstation, append router's P2P address (long alphanumeric
+string) to the API endpoint:
+
+```bash
+cd $WORKDIR
+
+UA="XYZ Location Confirmation"
+
+curl --user-agent "$UA" \
+  "$API_URL/v1/hotspots/$P2P" > router.json
+
+jq . router.json
+```
+
+Extract latitude and longitude:
+
+```bash
+LAT=$(jq .data.lat router.json)
+LON=$(jq .data.lng router.json)
+echo $LAT $LON
+```
+
+This pair of latitude and longitude will be used below.
+
+## Hexagons
+
+Find a hexagon for each gateway instance such that each hex is an
+equal distance from the router to be used.
+
+> The importance of asserting a location for each hotspot:
+
+> Without any location asserted for a particular gateway, the distance
+calculated to router defaults to 1000 as defined within `distance_between()`
+in
+[router_device_devaddr.erl](https://github.com/helium/router/blob/master/src/device/router_device_devaddr.erl)
+which may be preferable to triangulating based upon physical location.
+
+> However, relying upon this default will bypass much program logic which
+involves a blockchain ledger lookup, thereby yielding *artificially* higher
+throughput.
+
+A dedicated and isolated router and console pair may disregard concerns
+about Proof-of-Coverage (PoC) or an oversaturated Hex.
+
+Therefore:
+
+Keep it simple, and use Lat/Lon matching the router.
+
+([Router](https://github.com/helium/router) uses
+[h3](https://github.com/helium/erlang-h3) hexagonal hierarchical geospatial
+indexing system for computing distance, so dig there for any unique criteria
+or constraints.)
+
+## Create Devices in Console
+
+Values for example devices below are valid and may be copied.
+
+For multiple devices within the same organization, only the Dev EUI and name
+parameters need to differ.  App EUI and App Key must be unique across
+different organizations.
+
+Ensure using organization ID and app-key as presented within the Console UI.
+
+```bash
+cd $WORKDIR/org-01/
+
+for i in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
+    helium-console-cli device create \
+      6081F9AF355EDE29 \
+      87653070BE490D1780C830DA0CD28AFC \
+      6000000000000$i \
+      benchmark-$i
+done
+```
+
+**Repeat** for each of your organizations.
+
+Confirm:
+
+```bash
+for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  cd $WORKDIR/org-$o/
+  helium-console-cli device list > devices.json
+done
+```
+
+Returns JSON, which when formatted via `jq .` resembles the following.
+
+```JSON
+{
+  "devices": [
+    {
+      "app_eui": "6081F9AF355EDE29",
+      "app_key": "87653070BE490D1780C830DA0CD28AFC",
+      "dev_eui": "6000000000000001",
+      "id": "7cbc7f9d-0205-4f85-ab0a-34de8c4d8f52",
+      "name": "benchmark-001",
+      "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
+      "oui": 2
+    },
+    {
+      "app_eui": "6081F9AF355EDE29",
+      "app_key": "87653070BE490D1780C830DA0CD28AFC",
+      "dev_eui": "6000000000000002",
+      "id": "81d39917-b772-4937-b78b-618f4461340f",
+      "name": "benchmark-002",
+      "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
+      "oui": 2
+    },
+    {
+      "app_eui": "6081F9AF355EDE29",
+      "app_key": "87653070BE490D1780C830DA0CD28AFC",
+      "dev_eui": "6000000000000003",
+      "id": "cb82bc53-49ec-4401-bed0-2c4010f26c1d",
+      "name": "benchmark-003",
+      "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
+      "oui": 2
+    },
+    {
+      "app_eui": "6081F9AF355EDE29",
+      "app_key": "87653070BE490D1780C830DA0CD28AFC",
+      "dev_eui": "6000000000000004",
+      "id": "e7cca34d-5234-457f-ae92-8037c2649569",
+      "name": "benchmark-004",
+      "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
+      "oui": 2
+    }
+  ]
+}
+```
+
+The value of `"oui"` in output above should correspond to your value for
+`$ROUTER_OUI`.
+
+```bash
+ROUTER_OUI=$(jq '.devices[0].oui' org-01/devices.json)
+echo $ROUTER_OUI
+```
+
+## Virtual Devices
+
+Generate a custom `settings.toml` file for **each**
+[virtual LoRaWAN device](https://github.com/helium/virtual-lorawan-device)
+based upon data within the earlier `devices.json` file from each
+organization.
+
+Each device needs its own subdirectory for a set of configuration files.
+
+Connections of devices will distribute across multiple gateways, simulating
+real world scenarios with geographically dispersed deployments.
+
+```bash
+for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  cd $WORKDIR/org-$o/
+
+  for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
+    mkdir device-$d
+
+    ln -s ~/helium/virtual-lorawan-device/settings/default.toml device-$d/
+
+    out="device-$d/settings.toml"
+    echo "[device.$d.credentials]"            > $out
+    i=$((d - 1))
+    echo 'dev_eui = '$(jq .devices[$i].dev_eui < devices.json) >> $out
+    echo 'app_eui = '$(jq .devices[$i].app_eui < devices.json) >> $out
+    echo 'app_key = '$(jq .devices[$i].app_key < devices.json) >> $out
+    echo 'default_secs_between_transmits = 0' >> $out
+    echo ''                                   >> $out
+    echo '[packet_forwarder.default]'         >> $out
+    port=$((1680 + $d % $N_GATEWAYS))
+    echo 'host = "localhost:'${port}'"'       >> $out
+  done
+done
+```
+
+Each device may require waiting upwards of 20 minutes for the router's XOR
+filter to run.  The device will be marked in Console with "Pending" status
+until then.
+
+## Gateways
+
+This uses the `$P2P` value defined above in "Router Address" section.
+
+Each gateway must open a listening socket on a unique port, so this simply
+increments from the default base port.
+
+Install default and *preliminary* configuration files:
+
+```bash
+cd $WORKDIR
+
+for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  mkdir gw-$i
+  ln -s ~/helium/gateway-rs/config/default.toml gw-$i/
+
+  out=gw-$i/settings.toml
+  keyfile="$(pwd)/gw-$i/gateway_key.bin"
+  echo 'keypair = "'${keyfile}'"'       > $out
+  port=$((1680 + $i))
+  echo 'listen = "127.0.0.1:'${port}'"' >> $out
+  echo ''                               >> $out
+  echo '[update]'                       >> $out
+  echo 'enabled = false'                >> $out
+done
+```
+
+Those configuration files will be appended in a few steps below.  Each
+gateway must initially communicate with default routers when being added to
+the blockchain and when asserting location, because development routers are
+seeded from [mainnet](https://docs.helium.com/mine-hnt/validators/#mainnet).
+
+> **If using an entirely private deployment**, apply your variation of an
+> amended configuration *now* from end of this section.
+
+Generate transactions using `WALLET` variable defined earlier.
+
+These transactions will be signed and committed later:
+
+```bash
+for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  helium_gateway -c gw-$i server &
+  pid=$!
+  sleep 1
+
+  helium_gateway -c gw-$i \
+    add --mode dataonly \
+      --owner $WALLET \
+      --payer $WALLET > gw-$i/add-dataonly.json
+
+  kill $pid
+done
+```
+
+Extract each `txn` value from the previous output:
+
+```bash
+jq .txn gw-*/add-dataonly.json > txn-ids.log
+```
+
+Prepare command to assert locations based upon previous transactions:  
+(if wallet is on router host, run it there)
+
+```bash
+for txn in $(cat txn-ids.log); do
+   helium-wallet \
+     -f $WORKDIR/wallet/wallet.key \
+     hotspots add $txn
+done
+```
+
+Ensure there were no errors in the preceding output, and repeat same command
+adding `--commit` flag to make it reality.
+
+**This burns HNT from your wallet:**
+
+```bash
+for txn in $(cat txn-ids.log); do
+   # Burn HNT from your wallet:
+   helium-wallet \
+     -f $WORKDIR/wallet/wallet.key \
+     hotspots add $txn \
+     --commit
+done
+```
+
+Assert location, which as of gateway-rs v1.0 requires running as server in
+the background momentarily:
+
+```bash
+for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  helium_gateway -c gw-$i server &
+  pid=$!
+  sleep 1
+  key=$(helium_gateway -c gw-$i info | jq .key)
+  kill $pid
+
+  helium-wallet \
+     -f $WORKDIR/wallet/wallet.key \
+     hotspots assert --gateway $key \
+     --mode dataonly \
+     --lat $LAT --lon $LON --elevation 6 \
+     --commit
+done
+```
+
+Confirm asserted location via
+[blockchain API](https://docs.helium.com/api/blockchain/introduction/):
+
+```bash
+curl --user-agent "$UA" \
+  "$API_URL/v1/hotspots/location/distance?lat=$LAT&lon=$LON&distance=1000"
+```
+
+Ensure that your gateways appear within those results.
+
+Other gateways appearing within the results is benign because a virtual
+LoRaWAN device will only reach those for which it was explicitly configured
+since its radio is simulated.
+
+Finally, finish the local configuration suitable for producing load on your
+intended router instance:
+
+```bash
+cd $WORKDIR
+
+for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  out=gw-$i/settings.toml
+  echo ''                        >> $out
+  echo '[router.release]'        >> $out
+  echo 'pubkey = "'${P2P}'"'     >> $out
+  echo 'uri = "'${ROUTER_URL}'"' >> $out
+  echo 'oui = '${ROUTER_OUI}     >> $out
+done
+```
+
+(If using "beta" or other version of
+[gateway-rs](https://github.com/helium/gateway-rs) instead of "release",
+change `[router.release]` to match.)
+
+With that, your gateways are finally ready for Load & Capacity runs.
+
+## Start Gateways
+
+Launch each gateway "server" as a separate process, and let the OS handle
+concurrency:
+
+```bash
+cd $WORKDIR
+
+for i in $(seq --format="%03g" $N_GATEWAYS); do
+  helium_gateway -c gw-$i server > gw-$i/gw.log 2>&1 &
+done
+```
+
+## Spawn Virtual Devices
+
+The Console may indicate "Pending" from having added new devices above and
+may take upwards of 20 minutes.
+
+Wait until that message clears before proceeding.
+
+There is an API call for that status:
+
+```bash
+for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  cd $WORKDIR/org-$o/
+
+  # TODO when PR#21 gets merged, replace curl with this:
+  # helium-console-cli devices all > status.json
+
+  apikey=$(grep key .helium-console-config.toml | awk '{print $3}')
+  curl -H "key: $apikey" \
+    https://console.helium.com/api/v1/devices > status.json
+done
+```
+
+If any report as `false`, **wait one minute** at minimum before checking
+again:
+
+```bash
+cd $WORKDIR
+jq '.[].in_xor_filter' org-*/status.json \
+  | grep false && sleep 60
+```
+
+TODO: add feature to `virtual-lorawan-device` to facilitate "slow start" for
+progressively increasing load.
+
+
+Launch each as a separate process, and again let the OS handle concurrency:
+
+```bash
+cd $WORKDIR
+
+for o in $(seq --format="%02g" $N_ORGS); do
+  for i in $(seq --format="%03g" $N_DEVICES); do
+    ( cd org-$o/device-$i/ && virtual-lorawan-device > log 2>&1 ) &
+
+    # Facilitate slow-start of load to avoid hammer effect:
+    sleep 5
+  done
+done
+```
+
+While waiting for the outer loop to finish, watch your graphs; e.g, Grafana.
+
+## Stop
+
+Generally allow this fleet of virtual devices to run for 15-20 minutes,
+which gives ample traffic that the Erlang BEAM virtual machine's
+garbage-collector will have run, etc.
+
+When you have enough data:
+
+```bash
+killall virtual-lorawan-device
+killall helium_gateway
+```
+
+Confirm no longer running:
+
+```bash
+ps aux virtual-lorawan-device
+ps aux gateway-rs
+```
+
+## Iterate
+
+To ensure sufficient load, you may need to **run again with increased values**
+for:
+
+- number of organizations (`N_ORGS`)
+- number of devices (`N_DEVICES`)
+- number of gateways (`N_GATEWAYS`)
+
+When doing so, also increase corresponding values for `FIRST_*`.
+
+## Comprehending The Results
+
+There should be a slow ramp-up of traffic such that we can "find the knee"
+of the graph *before* hitting the plateau (ceiling).  That plateau should be
+understood as an approximation due to the nature of simulated/artificial
+traffic.
+
+A good rule-of-thumb:
+
+**Plan for 70% CPU utilization** for nominal load, which provides a cushion
+for traffic spikes without being excessively oversized.
+
+## Repeatable Results
+
+When confirming any such measurements:
+
+**Run** the same scenario a **minimum of three consecutive** times.
+
+That *excludes* a preliminary run to invalidate the OS file-system cache.
+
+The rule of three requires consistency.  If results vary by more than
+rounding error, keep running until getting 3 with similar results.
+
+If the only consistency is that results vary widely, look to other artifacts
+on the host OS that might be causing interference.  Consider migrating to a
+different server instance, if running on a virtualized/hypervisor
+environment such as AWS, GCP, Linode, etc.

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -6,7 +6,7 @@ slug: /use-the-network/run-a-network-server/router-benchmarking
 
 # Router Benchmarking
 
-This measures load by steadily increasing LoRaWAN traffic on a
+This measures load by increasing LoRaWAN traffic in steps on a
 [Helium Router](https://github.com/helium/router)
 to find its threshold of capacity for a given server instance.
 
@@ -22,6 +22,12 @@ For these instructions, each dependency is installed beneath `~/helium/`,
 and **Bash** shell syntax on Linux is used below.
 
 **Order of operations is significant.**
+
+Challenges can arise due to the nature of simulation, much like watching the
+shadows of Plato's *Allegory of the Cave* rather than seeing the true cause.
+Therefore, any defects observed or suspected should be
+[flagged](https://github.com/helium/router/issues)
+by the community-- please!  Then we all benefit from the corrections.
 
 ## Dependencies
 
@@ -531,7 +537,7 @@ for o in $(seq $N_ORGS); do
   #  gateway=$(printf "%02g" $gw)
   #  echo "[packet_forwarder.gw${gateway}]"     >> $out
   #  port=$((1680 + gw))
-  #  echo 'host = "localhost:${port}'"'         >> $out
+  #  echo 'host = "localhost:'${port}'"'        >> $out
   #  echo 'mac = "08070605040302'${gateway}'"'  >> $out
   #done
 
@@ -540,7 +546,11 @@ for o in $(seq $N_ORGS); do
     device=$(printf "%03g" $d)
     echo ''                                    >> $out
     echo "[device.${device}]"                  >> $out
-    echo 'secs_between_transmits = 15'         >> $out
+    seconds=$((20 + d % 20))
+    echo 'secs_between_transmits = '$seconds   >> $out
+    frames=$((100 + d % 30))
+    echo 'rejoin_frames = '$frames             >> $out
+
     echo 'packet_forwarder = "mux"'            >> $out
     # Optional round-robin allocation:
     #i=$(( (d % N_GATEWAYS) + FIRST_GW ))

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -13,7 +13,7 @@ to find its threshold of capacity for a given server instance.
 Measuring capacity of a particular server instance may then be
 compared with another server instance with different hardware specs.
 The procedure used is *load & capacity measurement* but some people
-also refer to this as *stress testing*.
+also refer to this as *stress testing* or *performance testing*.
 
 This document also gives insight to interactions of routers, gateways,
 organizations, devices and wallets in production.
@@ -34,6 +34,8 @@ meaningless benchmarks:
     triggered
   + Set environment variables: `ROUTER_HOTSPOT_REPUTATION_ENABLED=false`
     and/or `ROUTER_HOTSPOT_REPUTATION_THRESHOLD` to a large integer
+  + By using an ed25519 key for router's wallet, it can be also used for
+    hotspot add and location assertion
 - [console](https://github.com/helium/console)
   + Set environment variable: `IMPOSE_HARD_CAP=false`
   + Ensure `MAX_DEVICES_IN_ORG` exceeds number of virtual devices
@@ -477,8 +479,8 @@ Despite lack of plural in the name,
 [virtual LoRaWAN device](https://github.com/helium/virtual-lorawan-device)
 accommodates multiple devices, as indicated by its README.
 
-Generate a single `settings.toml` file all devices per organization.  (This
-segments by org for managing benchmarking runs.)
+Generate a single `settings.toml` file for all devices per organization.
+(This segments by org for managing benchmarking runs.)
 
 Connections of devices from same org will distribute across multiple
 gateways, simulating real world scenarios with geographically dispersed
@@ -550,7 +552,7 @@ This uses the `$P2P` value defined above in "Router Address" section.
 Each gateway must open a listening socket on a unique port number, so
 this simply increments from the default base port.
 
-Install default and *preliminary* configuration files:
+Install configuration files:
 
 ```bash
 cd $WORKDIR

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -45,6 +45,8 @@ Additional utilities, possibly already installed on your system:
 
 - [jq](https://github.com/stedolan/jq)
 
+## Aliases & Vars
+
 Our working directory is `~/helium/benchmark/`.
 
 ```bash
@@ -524,7 +526,7 @@ for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   port=$((1680 + $i))
   echo 'listen = "127.0.0.1:'${port}'"' >> $out
   port=$((4467 + $i))
-  echo 'api = $port'                    >> $out
+  echo "api = $port"                    >> $out
   echo 'region = "US915"'               >> $out
   echo ''                               >> $out
   echo '[update]'                       >> $out
@@ -551,7 +553,9 @@ These transactions will be signed and committed later:
 for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   helium_gateway -c gw-$i server > gw-$i/server.log &
   pid=$!
-  sleep 60
+
+  # Wait!
+  watch -n 9 --chgexit grep height gw-$i/server.log
 
   helium_gateway -c gw-$i info > gw-$i/gw-info.json
 
@@ -710,6 +714,53 @@ for i in $(seq --format="%02g" $N_GATEWAYS); do
   helium_gateway -c gw-$i server >> gw-$i/run.log 2>&1 &
 done
 ```
+
+Allow several minutes for each gateway concurrently connecting to validators
+and the router specified in settings.toml file.
+
+**Wait** until seeing an entry similar to the following for each:
+
+```
+ INFO updated routing to height 123456789, module: dispatcher
+```
+
+To determine whether to continue or wait, run:
+
+```
+[ "$(grep -l height gw-*/run.log | wc -l)" = "$N_GATEWAYS" ] \
+  && echo Continue || echo Wait
+```
+
+Due to backoff and retry, each delay takes an increasing amount of time with
+random variation:
+
+```
+ INFO selecting new gateway in 36s, module: dispatcher
+ ...
+ INFO selecting new gateway in 69s, module: dispatcher
+ ...
+ INFO selecting new gateway in 152s, module: dispatcher
+ ...
+
+ INFO selecting new gateway in 1826s, module: dispatcher
+```
+
+Warnings about deadlines logged between retries can be safely ignored:
+
+```
+ WARN gateway stream setup error: ...
+   "error trying to connect: deadline has elapsed" ...
+```
+
+> Note:
+>
+> A gateway may disconnect from its upstream validators or router and
+automatically reconnect.  When that occurs, the warnings and retries
+described above may appear at that time.
+>
+> One or two retries should be just a blip on the graphs, but extended
+retries might be cause for invalidating the affected run for purposes of
+benchmarking.
 
 ## Spawn Virtual Devices
 

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -34,6 +34,8 @@ meaningless benchmarks:
     triggered
   + Set environment variables: `ROUTER_HOTSPOT_REPUTATION_ENABLED=false`
     and/or `ROUTER_HOTSPOT_REPUTATION_THRESHOLD` to a large integer
+  + Set environment variable: `ROUTER_SC_OPEN_DC_AMOUNT=1000000`
+    or higher integer value for budget per State Channel
   + By using an ed25519 key for router's wallet, it can be also used for
     hotspot add and location assertion
 - [console](https://github.com/helium/console)
@@ -50,6 +52,7 @@ build subdirectories:
 
 - [gateway-rs](https://github.com/helium/gateway-rs)
 - [helium-console-cli](https://github.com/helium/helium-console-cli)
+- [gwmp-mux](https://github.com/helium/gwmp-mux) LoRaWAN protocol multiplexer
 - [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
 
 Additional utilities, possibly already installed on your system:
@@ -69,7 +72,8 @@ Convenience aliases:
 ```bash
 alias helium-console-cli="~/helium/helium-console-cli/target/release/helium-console-cli"
 alias helium_gateway="~/helium/gateway-rs/target/release/helium_gateway"
-alias helium-wallet=~/helium/helium-wallet-rs/target/release/helium-wallet
+alias helium-wallet="~/helium/helium-wallet-rs/target/release/helium-wallet"
+alias gwmp-mux="~/helium/gwmp-mux/target/release/gwmp-mux"
 alias virtual-lorawan-device="~/helium/virtual-lorawan-device/target/release/virtual-lorawan-device"
 ```
 
@@ -487,7 +491,7 @@ gateways, simulating real world scenarios with geographically dispersed
 deployments.
 
 Sending more frequently than 2 seconds per device would be unrealistic.
-The value for `default_secs_between_transmits` may be tuned below, and
+The value for `secs_between_transmits` may be tuned below, and
 `rx_delay` which defaults to 1s, may be increased via Console up to 15s.
 
 ```bash
@@ -507,32 +511,45 @@ for o in $(seq $N_ORGS); do
   echo 'metrics_port = '$metrics_port          >> $out
   echo ''                                      >> $out
 
-  for gw in $(seq $N_GATEWAYS); do
-    gateway=$(printf "%02g" $gw)
-    echo "[packet_forwarder.gw${gateway}]"     >> $out
-    port=$((1680 + gw))
-    echo 'host = "localhost:'${port}'"'        >> $out
-    echo 'mac = "08070605040302'${gateway}'"'  >> $out
-  done
+  # Multiplexer sprays across all gateways:
+  echo "[packet_forwarder.mux]"                >> $out
+  echo 'host = "localhost:1680"'               >> $out
+  echo 'mac = "0807060504030200"'              >> $out
+  echo ''                                      >> $out
+
+  # Optional, if you want to bypass multiplexer:
+  # uncomment this block and use packet_forwarder=gw below.
+  #for gw in $(seq $N_GATEWAYS); do
+  #  gateway=$(printf "%02g" $gw)
+  #  echo "[packet_forwarder.gw${gateway}]"     >> $out
+  #  port=$((1680 + gw))
+  #  echo 'host = "localhost:${port}'"'         >> $out
+  #  echo 'mac = "08070605040302'${gateway}'"'  >> $out
+  #done
 
   json="org-$org/devices.json"
   for d in $(seq $N_DEVICES); do
     device=$(printf "%03g" $d)
     echo ''                                    >> $out
     echo "[device.${device}]"                  >> $out
-    # Round-robin distribution:
-    i=$(( (d % N_GATEWAYS) + 1 ))
-    gateway=$(printf "%02g" $i)
-    echo 'packet_forwarder = "gw'${gateway}'"' >> $out
+    echo secs_between_transmits = 15'          >> $out
+    echo 'packet_forwarder = "mux"'            >> $out
+    # Optional round-robin allocation:
+    #i=$(( (d % N_GATEWAYS) + FIRST_GW ))
+    #gateway=$(printf "%02g" $i)
+    #echo '#packet_forwarder = "gw'${gateway}'"' >> $out
     echo "[device.${device}.credentials]"      >> $out
     j=$((d - 1))
     echo 'dev_eui = '$(jq .devices[$j].dev_eui < $json) >> $out
     echo 'app_eui = '$(jq .devices[$j].app_eui < $json) >> $out
     echo 'app_key = '$(jq .devices[$j].app_key < $json) >> $out
-    echo 'default_secs_between_transmits = 5'  >> $out
   done
 done
 ```
+
+Some `'packet_forwarder` lines are intentionally commented-out above,
+because there may be occasions for using the multiplexer versus connecting
+to a specific gateway directly.
 
 Sanity check:
 
@@ -544,6 +561,19 @@ grep -q 'dev_eui = null' org*/settings/settings.toml && \
 Devices may require waiting upwards of 20 minutes (concurrently) for
 the router's XOR filter to run.  The device will be marked in Console
 with "Pending" status until then, and there is an API call for this below.
+
+Later when running the actual test, check logs of `virtual-lorawan-device`
+for entries containing the following excerpt:
+
+```log
+WARN ... UDP packet received after tx time ...
+```
+
+Significantly more than 1:100 ratio indicates the value for
+`default_secs_between_transmits` should be increased.  That ratio
+accommodates interference patterns from the scheduler in Linux and the Tokio
+async/await framework used within the Rust app, or it can be from the
+hypervisor when on a virtualized server instance.
 
 ## Configure Gateways
 
@@ -595,26 +625,32 @@ Generate transactions using `WALLET` variable defined earlier.  Each
 transaction gets committed *later*.
 
 When in server-mode for the first time, gateway-rs needs time to generate
-key material and connect to upstream services.
-
-These transactions will be signed and committed later:
+key material and connect to upstream services, so start all concurrently:
 
 ```bash
 for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   helium_gateway -c gw-$gw server > gw-$gw/server.log &
-  pid=$!
+done
+```
 
-  # Wait!
-  watch -n 9 --chgexit grep height gw-$gw/server.log
+Wait until all log files contain at least one entry for `height`, which
+implies that each has connected to its upstream validator:
 
+```bash
+# Wait:
+grep -c height gw-$gw/server.log
+```
+
+Generate transactions, which will be signed and committed later:
+
+```bash
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   helium_gateway -c gw-$gw info > gw-$gw/gw-info.json
 
   helium_gateway -c gw-$gw \
     add --mode dataonly \
       --owner $WALLET \
       --payer $WALLET > gw-$gw/add-dataonly.json
-
-  kill $pid
 done
 ```
 
@@ -758,14 +794,7 @@ There is an API call for that status:
 ```bash
 for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
   cd $WORKDIR/org-$o/
-
-  # TODO requires helium-console-cli PR#21
   helium-console-cli devices all > status.json
-
-  # ALTERNATIVE:
-  # apikey=$(grep key .helium-console-config.toml | sed 's/^.*"\(.*\)"$/\1/')
-  # curl -H "key: $apikey" \
-  #   https://console.helium.com/api/v1/devices > status.json
 done
 ```
 
@@ -838,6 +867,29 @@ described above may appear at that time.
 retries might be cause for invalidating the affected run for purposes of
 benchmarking.
 
+## Start Multiplexers
+
+This sends every Join request and packet to all gateways.
+
+Device configurations performed earlier per organization already account for
+using the multiplexer.
+
+Run in its own Terminal window:  
+(running in background to be accommodated in a future release)
+
+```bash
+port=1681
+GW_LIST=''
+for gw in $(seq 2 $N_GATEWAYS); do
+  port=$((port + 1))
+  GW_LIST="${GW_LIST} 127.0.0.1:$port"
+done
+
+gwmp-mux --host 1680 --client $GW_LIST > mux.log 2>&1
+```
+
+All gateways will receive all Join and Uplink requests.
+
 ## Spawn Virtual Devices
 
 Launch fleet of virtual devices as a single OS process:
@@ -860,6 +912,40 @@ Note:
 [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
 causes the device to Join (or re-join) upon each start of the utility.
 (For continuing a previous session, pull-requests there are welcomed!)
+
+## Watch Devices
+
+The `metrics_port` associated with each running instance of
+`virtual-lorawan-device` may be queried via HTTP GET.  For bulk requests:
+
+```bash
+metrics() {
+  time=$(date +%Y-%m-%dt%H:%M:%S)
+  for o in $(seq --format="%02g" $N_ORGS); do
+    port=$(grep metrics_port org-$o/settings/settings.toml | awk '{print $3}')
+    curl http://localhost:$port/ > org-$o-stats-$time.txt
+  done
+}
+```
+
+Run:
+
+```bash
+metrics
+```
+
+Useful statistics to observe while everything is running may be determined
+by counting the following log entries for determining success ratios sampled
+over duration of each benchmarking run.
+
+Logs of virtual-lorawan-device:
+
+- "No Join Accept Received"
+- "sending packet"
+- "RxWindow expired, expected ACK to confirmed uplink not received"
+
+Logs from gateway-rs for each packet indicate that the packet has been
+queued but not necessarily delivered to router.
 
 ## Watch A Single Device
 

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -382,32 +382,33 @@ This pair of latitude and longitude values will be used below.
 
 ## Create Devices via Console API
 
-Values for example devices below are valid and may be copied.
+Each device across all organizations must have *unique* Dev EUI, App EUI and
+App Key.
 
-For multiple devices within the same organization, only the Dev EUI and name
-parameters need to differ.  App EUI and App Key must be unique across
-different organizations.
+For reference, see
+[LoRaWAN](https://lora-alliance.org/lorawan-for-developers/)
+*Link Layer Specification* sections as of v1.0.4:
 
-Ensure using organization ID and app-key as presented within the Console UI.
+- 6.2.1 End-device identifier (DevEUI)
+- 6.2.3 Application key (AppKey)
+  + and its footnote which implies the uniqueness constraint
+
+By using **an isolated instance** of router, we may generate identifiers:
 
 ```bash
-cd $WORKDIR/org-01/
+cd $WORKDIR
 
-for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
-    helium-console-cli device create \
-      6081F9AF355EDE29 \
-      87653070BE490D1780C830DA0CD28AFC \
-      6000000000000$d \
-      benchmark-$d
+for org in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  for dev in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
+    (cd org-$org && \
+     helium-console-cli device create \
+       6a000000000$org$dev \
+       600000000000000000000000000$org$dev \
+       6d000000000$org$dev \
+       benchmark-$dev || echo "org=$org device=$dev" >> errors.log)
+  done
 done
 ```
-
-(On subsequent runs when `$FIRST_DEV` is larger than 1, make use of:  
-`jq .devices[0].app_eui org-01/devices.json` and  
-`jq .devices[0].app_key org-01/devices.json`  
-for first and second parameters following "device create", respectively.)
-
-**Repeat** for each of your organizations.
 
 Confirm:
 
@@ -463,6 +464,12 @@ Returns JSON, which when formatted via `jq .` resembles the following.
 }
 ```
 
+Confirm consistent number of devices generated across organizations:
+
+```bash
+wc -l org-*/devices.json
+```
+
 The value of `"oui"` in output above should correspond to your value for
 `$ROUTER_OUI`.
 
@@ -508,6 +515,7 @@ for o in $(seq $N_ORGS); do
   echo 'default_server = "dev"'                > $out
   # Must be unique across all instances of virtual-lorawan-device:
   metrics_port=$((9898 + o))
+  echo 'metrics_server = "127.0.0.1"'          >> $out
   echo 'metrics_port = '$metrics_port          >> $out
   echo ''                                      >> $out
 
@@ -532,7 +540,7 @@ for o in $(seq $N_ORGS); do
     device=$(printf "%03g" $d)
     echo ''                                    >> $out
     echo "[device.${device}]"                  >> $out
-    echo secs_between_transmits = 15'          >> $out
+    echo 'secs_between_transmits = 15'         >> $out
     echo 'packet_forwarder = "mux"'            >> $out
     # Optional round-robin allocation:
     #i=$(( (d % N_GATEWAYS) + FIRST_GW ))
@@ -548,8 +556,8 @@ done
 ```
 
 Some `'packet_forwarder` lines are intentionally commented-out above,
-because there may be occasions for using the multiplexer versus connecting
-to a specific gateway directly.
+because there might be occasions for connecting to a specific gateway
+directly rather than using the multiplexer.
 
 Sanity check:
 
@@ -908,6 +916,8 @@ done
 
 While waiting for the outer loop to finish, watch your graphs; e.g, Grafana.
 
+Optionally set `RUST_LOG=debug` environment variable for verbose logs.
+
 Note:
 [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
 causes the device to Join (or re-join) upon each start of the utility.
@@ -922,7 +932,8 @@ The `metrics_port` associated with each running instance of
 metrics() {
   time=$(date +%Y-%m-%dt%H:%M:%S)
   for o in $(seq --format="%02g" $N_ORGS); do
-    port=$(grep metrics_port org-$o/settings/settings.toml | awk '{print $3}')
+    port=$(grep metrics_port $WORKDIR/org-$o/settings/settings.toml | \
+           awk '{print $3}')
     curl http://localhost:$port/ > org-$o-stats-$time.txt
   done
 }

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -413,9 +413,9 @@ for org in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
   for dev in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
     (cd org-$org && \
      helium-console-cli device create \
-       6a000000000$org$dev \
+       a0000000000$org$dev \
        600000000000000000000000000$org$dev \
-       6d000000000$org$dev \
+       d0000000000$org$dev \
        benchmark-$dev || echo "org=$org device=$dev" >> errors.log)
   done
 done
@@ -436,36 +436,36 @@ Returns JSON, which when formatted via `jq .` resembles the following.
 {
   "devices": [
     {
-      "app_eui": "6081F9AF355EDE29",
-      "app_key": "87653070BE490D1780C830DA0CD28AFC",
-      "dev_eui": "6000000000000001",
+      "app_eui": "a000000000001001",
+      "app_key": "60000000000000000000000000001001",
+      "dev_eui": "d000000000001001",
       "id": "7cbc7f9d-0205-4f85-ab0a-34de8c4d8f52",
       "name": "benchmark-001",
       "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
       "oui": 2
     },
     {
-      "app_eui": "6081F9AF355EDE29",
-      "app_key": "87653070BE490D1780C830DA0CD28AFC",
-      "dev_eui": "6000000000000002",
+      "app_eui": "a000000000001002",
+      "app_key": "60000000000000000000000000001002",
+      "dev_eui": "d000000000001002",
       "id": "81d39917-b772-4937-b78b-618f4461340f",
       "name": "benchmark-002",
       "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
       "oui": 2
     },
     {
-      "app_eui": "6081F9AF355EDE29",
-      "app_key": "87653070BE490D1780C830DA0CD28AFC",
-      "dev_eui": "6000000000000003",
+      "app_eui": "a000000000001003",
+      "app_key": "60000000000000000000000000001003",
+      "dev_eui": "d000000000001003",
       "id": "cb82bc53-49ec-4401-bed0-2c4010f26c1d",
       "name": "benchmark-003",
       "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
       "oui": 2
     },
     {
-      "app_eui": "6081F9AF355EDE29",
-      "app_key": "87653070BE490D1780C830DA0CD28AFC",
-      "dev_eui": "6000000000000004",
+      "app_eui": "a000000000001004",
+      "app_key": "60000000000000000000000000001004",
+      "dev_eui": "d000000000001004",
       "id": "e7cca34d-5234-457f-ae92-8037c2649569",
       "name": "benchmark-004",
       "organization_id": "57d5b743-fc08-4119-b4ff-0c60ddf976ff",
@@ -574,7 +574,7 @@ As seconds between transmits increases, number of frames until re-joins
 decreases for leveling overall traffic (reducing spikes and eliminating
 artificial surges).
 
-Some `'packet_forwarder` lines are intentionally commented-out above,
+Some `packet_forwarder` lines are intentionally commented-out above,
 because there might be occasions for connecting to a specific gateway
 directly rather than using the multiplexer.
 
@@ -932,6 +932,7 @@ Launch fleet of virtual devices as a single OS process:
 ```bash
 cd $WORKDIR
 
+#export RUST_LOG=warn
 for o in $(seq --format="%02g" $N_ORGS); do
   virtual-lorawan-device \
     --settings org-$o/settings/ >> org-$o/run.log 2>&1 &

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -21,6 +21,8 @@ organizations, devices and wallets in production.
 For these instructions, each dependency is installed beneath `~/helium/`,
 and **Bash** shell syntax on Linux is used below.
 
+**Order of operations is significant.**
+
 ## Dependencies
 
 These should be **isolated** instances dedicated to load & capacity testing,
@@ -100,7 +102,8 @@ FIRST_DEV=1
 ```
 
 (If going above double digits for gateways or triple digits for devices, the
-scripts will need to be revised; see `seq --format` below.)
+scripts will need to be revised; see Bash `printf` and `seq --format`
+expressions below.)
 
 Additional variables will be created along the way.
 
@@ -366,7 +369,7 @@ Keep it simple, and use Lat/Lon matching your router.
 indexing system for computing distance, so dig there for any unique criteria
 or constraints.)
 
-## Create Devices in Console
+## Create Devices via Console API
 
 Values for example devices below are valid and may be copied.
 
@@ -387,6 +390,11 @@ for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
       benchmark-$d
 done
 ```
+
+(On subsequent runs when `$FIRST_DEV` is larger than 1, make use of:  
+`jq .devices[0].app_eui org-01/devices.json` and  
+`jq .devices[0].app_key org-01/devices.json`  
+for first and second parameters following "device create", respectively.)
 
 **Repeat** for each of your organizations.
 
@@ -454,6 +462,12 @@ echo $ROUTER_OUI
 
 ## Virtual Devices
 
+This requires devices already having been created via Console API.
+
+The API provides the *single source of truth* about devices.  (Device ID in
+Console might be mismatched with respect to file names generated below due
+to sequence of output from API, which is unimportant for benchmarking.)
+
 Generate a custom `settings.toml` file for **each**
 [virtual LoRaWAN device](https://github.com/helium/virtual-lorawan-device)
 based upon data within the `devices.json` file generated above from each
@@ -466,22 +480,24 @@ real world scenarios with geographically dispersed deployments.
 
 ```bash
 metrics_port=9898
-for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+for o in $(seq --format="%02g" $N_ORGS); do
   cd $WORKDIR/org-$o/
 
-  for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
-    mkdir -p device-$d/settings
+  # Use printf, not seq --format to avoid octal when assigning $i
+  for d in $(seq $N_DEVICES); do
+    device=$(printf "%03g" $d)
+    mkdir -p device-$device/settings
 
     ln -s ~/helium/virtual-lorawan-device/settings/default.toml \
-      device-$d/settings/
+      device-$device/settings/
 
-    out="device-$d/settings/settings.toml"
+    out="device-$device/settings/settings.toml"
     echo 'default_server = "dev"'             > $out
-    echo 'metrics_port = '$metrics_port       >> $out
     # Must be unique across all devices:
+    echo 'metrics_port = '$metrics_port       >> $out
     metrics_port=$((metrics_port + 1))
     echo ''                                   >> $out
-    echo "[device.$d.credentials]"            >> $out
+    echo "[device.$device.credentials]"       >> $out
     i=$((d - 1))
     echo 'dev_eui = '$(jq .devices[$i].dev_eui < devices.json) >> $out
     echo 'app_eui = '$(jq .devices[$i].app_eui < devices.json) >> $out
@@ -496,9 +512,16 @@ for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
 done
 ```
 
+Sanity check:
+
+```bash
+grep -q 'dev_eui = null' org*/device*/settings/settings.toml && \
+  echo Something went wrong.
+```
+
 Devices may require waiting upwards of 20 minutes (concurrently) for
 the router's XOR filter to run.  The device will be marked in Console
-with "Pending" status until then, and we check for this further below.
+with "Pending" status until then, and there is an API call for this below.
 
 ## Gateways
 
@@ -512,7 +535,7 @@ Install default and *preliminary* configuration files:
 ```bash
 cd $WORKDIR
 
-i=0
+i=$((FIRST_GW - 1))
 for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   mkdir gw-$gw
   ln -s ~/helium/gateway-rs/config/default.toml gw-$gw/
@@ -520,8 +543,10 @@ for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   out=gw-$gw/settings.toml
   keyfile="$(pwd)/gw-$gw/gateway_key.bin"
   echo 'keypair = "'${keyfile}'"'       > $out
+  # Must be unique per gw and consistent with device configs:
   port=$((1680 + i))
   echo 'listen = "127.0.0.1:'${port}'"' >> $out
+  # Only needs to be unique:
   port=$((4467 + i))
   echo "api = $port"                    >> $out
   echo 'region = "US915"'               >> $out
@@ -779,7 +804,7 @@ for o in $(seq --format="%02g" $N_ORGS); do
       virtual-lorawan-device >> run.log 2>&1 ) &
 
     # Facilitate slow-start of load to avoid hammer effect:
-    sleep 5
+    sleep 1
   done
 done
 ```

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -730,8 +730,8 @@ First, find your `organization_id` which may be obtained via Console UI.
 From the Organizations page, there is an export widget associated with each
 organization listed.
 
-Alternative, extract from `devices.json` for each organization.  These files
-were generated above.
+Alternatively, extract from `devices.json` for each organization.  Those
+files were generated above.
 
 Run:
 
@@ -740,7 +740,7 @@ jq .devices[0].organization_id org-*/devices.json
 ```
 
 Use each of those organization IDs and provide the target DC balance, which
-gets specify as 100k in this example:
+gets specified as 100k in this example:
 
 ```bash
 ssh router-dev
@@ -807,7 +807,7 @@ and the router specified in settings.toml file.
 **Wait** until seeing an entry similar to the following for each:
 
 ```
- INFO updated routing to height 123456789, module: dispatcher
+INFO updated routing to height 123456789, module: dispatcher
 ```
 
 To determine whether to continue or wait, run:
@@ -866,9 +866,10 @@ done
 
 While waiting for the outer loop to finish, watch your graphs; e.g, Grafana.
 
-Note: `virtual-lorawan-device` causes the device to Join (or re-join) upon
-each start of the utility.  (For continuing a previous session,
-pull-requests there are welcomed!)
+Note:
+[virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
+causes the device to Join (or re-join) upon each start of the utility.
+(For continuing a previous session, pull-requests there are welcomed!)
 
 ## Stop
 
@@ -888,8 +889,8 @@ killall helium_gateway
 Confirm no longer running:
 
 ```bash
-ps aux virtual-lorawan-device
-ps aux gateway-rs
+ps aux | grep virtual-lorawan-device
+ps aux | grep helium_gateway
 ```
 
 ## Iterate

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -10,8 +10,10 @@ This measures load by steadily increasing load on a
 [Helium Router](https://github.com/helium/router)
 to find its threshold of capacity for a given server instance.
 
-The procedure used is *load & capacity measurement* but some people refer to
-it as *stress testing*.
+Measuring load a particular server instance may then be compared with
+equivalent measurements on another server instance with different hardware
+specs.  The procedure used is *load & capacity measurement* but some people
+also refer to this as *stress testing*.
 
 This document also gives insight to interactions of routers, gateways,
 organizations, devices and wallets in production.
@@ -43,10 +45,10 @@ Additional utilities, possibly already installed on your system:
 
 - [jq](https://github.com/stedolan/jq)
 
-Our working directory is `~/helium/load+capacity/`.
+Our working directory is `~/helium/benchmark/`.
 
 ```bash
-WORKDIR=~/helium/load+capacity
+WORKDIR=~/helium/benchmark
 ```
 
 Convenience aliases:
@@ -102,8 +104,8 @@ Additional variables will be created along the way.
 
 ## Logs & Graphs
 
-Load Tests are meaningless without the ability to measure, and in order to
-improve requires meaningful measurements.
+Benchmarking load is meaningless without the ability to measure, and in
+order to optimize server capacity requires meaningful measurements.
 
 Graphs described below help on both points.
 
@@ -277,7 +279,7 @@ WALLET=$(helium-wallet -f /var/data/wallet.key info | \
 echo $WALLET
 ```
 
-That shared wallet should be ready for use below.
+That shared wallet is ready for use below.
 
 ## Router Address
 
@@ -293,7 +295,7 @@ router peer listen
 Visually extract the entry beginning with `/p2p/` and copy the sequence up
 to but excluding the subsequent slash (`/`).  (Unfortunately, due to
 `router` being an aliased Docker command, `grep` and `sed` cannot be of
-service here.  (Otherwise, manually do the equivalent of:  
+service here.  Otherwise, manually do the equivalent of:  
 `grep /p2p/ | sed 's%^./p2p/\([^/]*\)/.*$%\1%'`.)
 
 That long alphanumeric value gets used in multiple places below as the
@@ -338,13 +340,13 @@ Find a hexagon for each gateway instance such that each hex is an
 equal distance from the router to be used.
 
 > The importance of asserting a location for each hotspot:
-
+>
 > Without any location asserted for a particular gateway, the distance
 calculated to router defaults to 1000 as defined within `distance_between()`
 in
 [router_device_devaddr.erl](https://github.com/helium/router/blob/master/src/device/router_device_devaddr.erl)
 which may be preferable to triangulating based upon physical location.
-
+>
 > However, relying upon this default will bypass much program logic which
 involves a blockchain ledger lookup, thereby yielding *artificially* higher
 throughput.
@@ -460,16 +462,22 @@ Connections of devices will distribute across multiple gateways, simulating
 real world scenarios with geographically dispersed deployments.
 
 ```bash
+metrics_port=9898
 for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
   cd $WORKDIR/org-$o/
 
   for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
-    mkdir device-$d
+    mkdir -p device-$d/settings
 
-    ln -s ~/helium/virtual-lorawan-device/settings/default.toml device-$d/
+    ln -s ~/helium/virtual-lorawan-device/settings/default.toml \
+      device-$d/settings/
 
-    out="device-$d/settings.toml"
-    echo "[device.$d.credentials]"            > $out
+    out="device-$d/settings/settings.toml"
+    echo 'default_server = "dev"'             > $out
+    echo 'metrics_port = '$metrics_port       >> $out
+    metrics_port=$((metrics_port + 1))
+    echo ''                                   >> $out
+    echo "[device.$d.credentials]"            >> $out
     i=$((d - 1))
     echo 'dev_eui = '$(jq .devices[$i].dev_eui < devices.json) >> $out
     echo 'app_eui = '$(jq .devices[$i].app_eui < devices.json) >> $out
@@ -508,6 +516,9 @@ for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   echo 'keypair = "'${keyfile}'"'       > $out
   port=$((1680 + $i))
   echo 'listen = "127.0.0.1:'${port}'"' >> $out
+  port=$((4467 + $i))
+  echo 'api = $port'                    >> $out
+  echo 'region = "US915"'               >> $out
   echo ''                               >> $out
   echo '[update]'                       >> $out
   echo 'enabled = false'                >> $out
@@ -524,13 +535,18 @@ seeded from [mainnet](https://docs.helium.com/mine-hnt/validators/#mainnet).
 
 Generate transactions using `WALLET` variable defined earlier.
 
+When in server-mode for the first time, gateway-rs needs time to generate
+key material and connect to upstream services.
+
 These transactions will be signed and committed later:
 
 ```bash
 for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  helium_gateway -c gw-$i server &
+  helium_gateway -c gw-$i server > gw-$i/server.log &
   pid=$!
-  sleep 1
+  sleep 60
+
+  helium_gateway -c gw-$i info > gw-$i/gw-info.json
 
   helium_gateway -c gw-$i \
     add --mode dataonly \
@@ -541,10 +557,12 @@ for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
 done
 ```
 
-Extract each `txn` value from the previous output:
+Extract each `txn` value from the previous output and strip quotes from
+value:
 
 ```bash
-jq .txn gw-*/add-dataonly.json > txn-ids.log
+jq .txn gw-*/add-dataonly.json | \
+   sed 's/"//g' > txn-ids.log
 ```
 
 Prepare command to assert locations based upon previous transactions:  
@@ -552,6 +570,7 @@ Prepare command to assert locations based upon previous transactions:
 
 ```bash
 for txn in $(cat txn-ids.log); do
+   # Prompts for wallet password
    helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
      hotspots add $txn
@@ -573,27 +592,40 @@ for txn in $(cat txn-ids.log); do
 done
 ```
 
-Assert location, which as of gateway-rs v1.0 requires running as server in
-the background momentarily:
+Assert location, which uses `$GW_KEY` populated during our previous run of
+`helium_gateway` in server-mode:
 
 ```bash
 for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  helium_gateway -c gw-$i server &
-  pid=$!
-  sleep 1
-  key=$(helium_gateway -c gw-$i info | jq .key)
-  kill $pid
+  key=$(jq .key $gw-01/gw-info.json)
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
      hotspots assert --gateway $key \
      --mode dataonly \
-     --lat $LAT --lon $LON --elevation 6 \
+     --lat=$LAT --lon=$LON --elevation 6
+done
+```
+
+Repeat with `--commit` flag, which **burns HNT from your wallet:**
+
+```bash
+for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  # key=$(jq .key $gw-01/gw-info.json)
+  key=$(grep 'INFO starting server, key:' gw-$i/server.log | \
+        sed 's/^.*: \(.*\),.*$/\1/')
+
+  helium-wallet \
+     -f $WORKDIR/wallet/wallet.key \
+     hotspots assert --gateway $key \
+     --mode dataonly \
+     --lat=$LAT --lon=$LON --elevation 6 \
      --commit
 done
 ```
 
-Confirm asserted location via
+Allow time-- approximately 5-20 minutes-- for those transactions to be
+recorded onto the blockchain, and then confirm asserted locations via
 [blockchain API](https://docs.helium.com/api/blockchain/introduction/):
 
 ```bash
@@ -601,7 +633,8 @@ curl --user-agent "$UA" \
   "$API_URL/v1/hotspots/location/distance?lat=$LAT&lon=$LON&distance=1000"
 ```
 
-Ensure that your gateways appear within those results.
+Ensure that your gateways appear within those results.  If not found, wait
+and check again later.
 
 Other gateways appearing within the results is benign because a virtual
 LoRaWAN device will only reach those for which it was explicitly configured
@@ -629,20 +662,7 @@ change `[router.release]` to match.)
 
 With that, your gateways are finally ready for Load & Capacity runs.
 
-## Start Gateways
-
-Launch each gateway "server" as a separate process, and let the OS handle
-concurrency:
-
-```bash
-cd $WORKDIR
-
-for i in $(seq --format="%03g" $N_GATEWAYS); do
-  helium_gateway -c gw-$i server > gw-$i/gw.log 2>&1 &
-done
-```
-
-## Spawn Virtual Devices
+## Wait for XOR Filter
 
 The Console may indicate "Pending" from having added new devices above and
 may take upwards of 20 minutes.
@@ -673,18 +693,35 @@ jq '.[].in_xor_filter' org-*/status.json \
   | grep false && sleep 60
 ```
 
+## Start Gateways
+
+Launch each gateway "server" as a separate process, and let the OS handle
+concurrency:
+
+```bash
+cd $WORKDIR
+
+for i in $(seq --format="%02g" $N_GATEWAYS); do
+  helium_gateway -c gw-$i server >> gw-$i/run.log 2>&1 &
+done
+```
+
+## Spawn Virtual Devices
+
 TODO: add feature to `virtual-lorawan-device` to facilitate "slow start" for
 progressively increasing load.
 
 
-Launch each as a separate process, and again let the OS handle concurrency:
+Launch each virtual device as a separate process, and again let the OS
+handle concurrency:
 
 ```bash
 cd $WORKDIR
 
 for o in $(seq --format="%02g" $N_ORGS); do
   for i in $(seq --format="%03g" $N_DEVICES); do
-    ( cd org-$o/device-$i/ && virtual-lorawan-device > log 2>&1 ) &
+    ( cd org-$o/device-$i/ && \
+      virtual-lorawan-device >> run.log 2>&1 ) &
 
     # Facilitate slow-start of load to avoid hammer effect:
     sleep 5
@@ -723,7 +760,8 @@ for:
 - number of devices (`N_DEVICES`)
 - number of gateways (`N_GATEWAYS`)
 
-When doing so, also increase corresponding values for `FIRST_*`.
+When doing so, also increase corresponding values for `FIRST_*` to be the
+former value of `N_*` to avoid clobbering or creating duplicate devices.
 
 ## Comprehending The Results
 

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -170,6 +170,11 @@ For router under significant load, the most critical graphs to watch:
 - **Offer Duration** should be within **milliseconds** (ms)
   + This translates directly to latency of server response
   + Excludes any Internet traffic latency
+- Others have values and trends that vary based upon what is being measured
+  and are described [below](#comprehending-the-results):
+  + **Join Offer Rate**
+  + **Packet Offer Rate**
+  + **Offer Rejected Reasons**
 
 For designing your own graphs, it helps bucketing by percentiles.  Common
 buckets are: 1%, 5%, 15%, 50%, 85%, 90%, 95%, 97%, 98%, 99% 100%, which
@@ -548,7 +553,7 @@ for o in $(seq $N_ORGS); do
     echo "[device.${device}]"                  >> $out
     seconds=$((20 + d % 20))
     echo 'secs_between_transmits = '$seconds   >> $out
-    frames=$((100 + d % 30))
+    frames=$((120 - d % 40))
     echo 'rejoin_frames = '$frames             >> $out
 
     echo 'packet_forwarder = "mux"'            >> $out
@@ -564,6 +569,10 @@ for o in $(seq $N_ORGS); do
   done
 done
 ```
+
+As seconds between transmits increases, number of frames until re-joins
+decreases for leveling overall traffic (reducing spikes and eliminating
+artificial surges).
 
 Some `'packet_forwarder` lines are intentionally commented-out above,
 because there might be occasions for connecting to a specific gateway
@@ -592,6 +601,8 @@ Significantly more than 1:100 ratio indicates the value for
 accommodates interference patterns from the scheduler in Linux and the Tokio
 async/await framework used within the Rust app, or it can be from the
 hypervisor when on a virtualized server instance.
+
+The metrics API will be used below to track successful Joins.
 
 ## Configure Gateways
 
@@ -628,6 +639,10 @@ for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   echo 'pubkey = "'${P2P}'"'            >> $out
   echo 'uri = "'${ROUTER_URL}'"'        >> $out
   echo 'oui = '${ROUTER_OUI}            >> $out
+  echo ''                               >> $out
+  # Uncomment for high traffic runs:
+  echo '# [log]'                        >> $out
+  echo '# level = "warn"'               >> $out
   i=$((i + 1))
 done
 ```
@@ -636,6 +651,10 @@ done
 If using "beta" or other version of
 [gateway-rs](https://github.com/helium/gateway-rs) instead of "release",
 change `[router.release]` to match.)
+
+For benchmark runs with very high traffic, uncomment the `[log]` section
+above, because there's a measurable cost of I/O due to logging that can
+negatively impact the host sending packets.
 
 ## Add Gateways To Blockchain
 
@@ -841,23 +860,21 @@ done
 Allow several minutes for each gateway concurrently connecting to validators
 and the router specified in settings.toml file.
 
-**Wait** until seeing an entry similar to the following for each:
+**Wait** until each hotspot reports height of the blockchain:
 
-```
-INFO updated routing to height 123456789, module: dispatcher
+```bash
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  helium_gateway -c gw-$gw info > gw-$gw/gw-info.json
+done
+jq .gateway.height gw-*/gw-info.json || echo "Wait!"
 ```
 
-To determine whether to continue or wait, run:
-
-```
-[ "$(grep -l height gw-*/run.log | wc -l)" = "$N_GATEWAYS" ] \
-  && echo Continue || echo Wait
-```
+Only after each gateway reports a large integer for height, continue.
 
 Due to backoff and retry, each delay takes an increasing amount of time with
 random variation:
 
-```
+```log
  INFO selecting new gateway in 36s, module: dispatcher
  ...
  INFO selecting new gateway in 69s, module: dispatcher
@@ -870,7 +887,7 @@ random variation:
 
 Warnings about deadlines logged between retries can be safely ignored:
 
-```
+```log
  WARN gateway stream setup error: ...
    "error trying to connect: deadline has elapsed" ...
 ```
@@ -949,7 +966,7 @@ metrics() {
 }
 ```
 
-Run:
+Periodically run:
 
 ```bash
 metrics
@@ -1047,8 +1064,21 @@ that may facilitate driving higher traffic.  Future work will occur there.
 
 ## Comprehending The Results
 
+For measuring number of **devices within a devaddr slab**:
+
+Ensure "Join Offer Rate" graph shows step-wise increases, and "Packet Offer
+Rate" graph resembles a plateau.  Then, watch "Offer Rejected Reasons" graph
+and stop when seeing an increase in `devaddr_no_device`.
+
+With disambiguation due in part to the Message Integrity Check (MIC), the
+usable number will be higher than apparent capacity; thus, an 8 slab
+accommodates more than eight devices.  Actual limits may vary with Router
+and/or Console configurations used.
+
+For measuring **traffic load**:
+
 There should be a slow ramp-up of traffic such that we "find the knee"
-of the graph *before* hitting the plateau (ceiling).  Understand that
+of the graph *before* hitting the plateau (ceiling).  Understand this
 plateau being an approximation due to the nature of generated traffic.
 
 A good rule-of-thumb:
@@ -1073,3 +1103,12 @@ artifacts on the host OS that might be causing interference.  Consider
 migrating to different host server hardware (via hard stop/start) if
 running on a virtualized/hypervisor environment such as AWS, GCP,
 Linode, etc.
+
+Items that we addressed:
+
+- On Ubuntu Server, prevent Snap from updating during a benchmark run:
+  + `sudo snap list` and `sudo apt-get purge snapd`
+- If graphs are inconsistent, confirm each gateway is still connected to its
+upstream Validator:
+  + Confirm "Join Offer Rate" graph shows step-wise increases
+  + Confirm "Packet Offer Rate" graph resembles a plateau

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -32,9 +32,10 @@ meaningless benchmarks:
 - [router](https://github.com/helium/router)
   + Must be an isolated instance because **abuse-prevention measures** get
     triggered
-  + Requires being reset
+  + Set environment variables: `ROUTER_HOTSPOT_REPUTATION_ENABLED=false`
+    and/or `ROUTER_HOTSPOT_REPUTATION_THRESHOLD` to a large integer
 - [console](https://github.com/helium/console)
-  + Omit `IMPOSE_HARD_CAP` environment variable
+  + Set environment variable: `IMPOSE_HARD_CAP=false`
   + Ensure `MAX_DEVICES_IN_ORG` exceeds number of virtual devices
 
 Install wallet on same host as your router if sharing its private key:
@@ -855,7 +856,8 @@ Launch fleet of virtual devices as a single OS process:
 cd $WORKDIR
 
 for o in $(seq --format="%02g" $N_ORGS); do
-  ( cd org-$o/ && virtual-lorawan-device >> run.log 2>&1 ) &
+  virtual-lorawan-device \
+    --settings org-$o/settings/ >> org-$o/run.log 2>&1 &
 
   # Slight mitigation against hammer effect:
   sleep 5
@@ -938,32 +940,3 @@ artifacts on the host OS that might be causing interference.  Consider
 migrating to different host server hardware (via hard stop/start) if
 running on a virtualized/hypervisor environment such as AWS, GCP,
 Linode, etc.
-## Troubleshooting
-### Traffic Dropped By Router
-
-The nature of driving load to find capacity of a server may trigger
-abuse-prevention measures of [router](https://github.com/helium/router)
-such as its reputation system.
-
-Check:
-
-```bash
-ssh router-dev
-cd router
-router hotspot_reputation ls
-```
-
-If you see the name corresponding to your instance(s) of gateway-rs, with a
-score approaching `10`, that device has either been banned or is about to
-be.
-
-Copy the alphanumeric string associated with your gateway's name under the
-`b58` column, and use it as the identifier below.
-
-Reset reputation:
-
-```bash
-ssh router-dev
-cd router
-router hotspot_reputation reset longAlphaNumeric...
-```

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -177,6 +177,9 @@ Key](https://docs.helium.com/use-the-network/console/my-account/#console-api-key
 which requires logging onto Console user interface (UI).  Everything else
 will be done by command-line interface (CLI).
 
+Each organization will have its own API Key, which may be obtained via the
+Console UI under Account Settings.
+
 Store your new Console API Key generated from the UI to the TOML file
 below, and specify base URL of the console.  The default of
 `https://console.helium.com` is probably **not** what you want for
@@ -332,9 +335,10 @@ echo $P2P
 Choose a hexagon for each gateway instance.
 
 Because this is a test router yet each gateway's location must be asserted
-onto mainnet blockchain, pick a bogus location such as middle of a lake or
-river.  (While there might be legitimate *devices* in a particular body of
-water, there is unlikely to be a hotspot there as well.)
+onto [mainnet](https://docs.helium.com/mine-hnt/validators/#mainnet)
+blockchain, pick a bogus location such as middle of a lake or river.  (While
+there could be legitimate *devices* in a particular body of water, there is
+unlikely to be a hotspot there as well.)
 
 > The importance of asserting a location for each hotspot:
 >
@@ -497,8 +501,8 @@ for o in $(seq $N_ORGS); do
   out="org-$org/settings/settings.toml"
   echo 'default_server = "dev"'                > $out
   # Must be unique across all instances of virtual-lorawan-device:
-  echo 'metrics_port = '$metrics_port          >> $out
   metrics_port=$((9898 + o))
+  echo 'metrics_port = '$metrics_port          >> $out
   echo ''                                      >> $out
 
   for gw in $(seq $N_GATEWAYS); do
@@ -539,7 +543,7 @@ Devices may require waiting upwards of 20 minutes (concurrently) for
 the router's XOR filter to run.  The device will be marked in Console
 with "Pending" status until then, and there is an API call for this below.
 
-## Gateways
+## Configure Gateways
 
 This uses the `$P2P` value defined above in "Router Address" section.
 
@@ -583,7 +587,10 @@ If using "beta" or other version of
 [gateway-rs](https://github.com/helium/gateway-rs) instead of "release",
 change `[router.release]` to match.)
 
-Generate transactions using `WALLET` variable defined earlier.
+## Add Gateways To Blockchain
+
+Generate transactions using `WALLET` variable defined earlier.  Each
+transaction gets committed *later*.
 
 When in server-mode for the first time, gateway-rs needs time to generate
 key material and connect to upstream services.
@@ -617,7 +624,7 @@ jq .txn gw-*/add-dataonly.json | \
    sed 's/"//g' > txn-ids.log
 ```
 
-Prepare command to assert locations based upon previous transactions:  
+Prepare command to add each new gateway based upon previous transactions:  
 (if wallet is on router host, run it there)
 
 ```bash
@@ -643,6 +650,8 @@ for txn in $(cat txn-ids.log); do
      --commit
 done
 ```
+
+## Assert Location For Each Gateway
 
 Assert location using `$LAT` and `$LON` defined earlier for
 each gateway.
@@ -674,6 +683,8 @@ for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
 done
 ```
 
+## Confirm Locations
+
 Allow time-- approximately 5-20 minutes-- for those transactions to be
 recorded onto the blockchain, and then confirm asserted locations via
 [blockchain API](https://docs.helium.com/api/blockchain/introduction/):
@@ -683,6 +694,9 @@ curl --user-agent "$UA" \
   "$API_URL/v1/hotspots/location/distance?lat=$LAT&lon=$LON&distance=1000"
 ```
 
+The `distance` parameter above is in meters, so adjust its value if
+necessary.
+
 Ensure that your gateways appear within those results.  If not found, wait
 several minutes and check again later.
 
@@ -690,7 +704,7 @@ Other gateways appearing within the results is benign because a virtual
 LoRaWAN device will only reach those for which it was explicitly configured
 since its radio is simulated.
 
-With that, your gateways are finally ready for Load & Capacity runs.
+With that, your gateways are ready for Load & Capacity runs.
 
 ## Fund Organizations
 
@@ -845,6 +859,46 @@ Note:
 causes the device to Join (or re-join) upon each start of the utility.
 (For continuing a previous session, pull-requests there are welcomed!)
 
+## Watch A Single Device
+
+This is an optional debugging step.
+
+While the fleet of `virtual-lorawan-device` instances runs, watch a
+single device.
+
+First, run the loop from [Wait for XOR Filter](#wait-for-xor-filter) above
+again to re-populate `status.json` for each organization.
+
+Find devices that indicate a potential problem.
+
+Device IDs that never connected:
+
+```bash
+jq '.[]|select(.last_connected|.==null)|.id' org-*/status.json
+```
+
+Devices that connected longest ago:
+
+```bash
+jq '.|sort_by(.last_connected)|.[0]'  org-*/status.json
+```
+
+Device IDs with fewest packets:
+
+```bash
+jq '.|sort_by(.total_packets)|.[0].id' org-*/status.json
+```
+
+Use those Device IDs for tracing via router CLI:
+
+```bash
+ssh router
+cd router/
+router device trace --id=8db30307-1234-5678-9abc-511376ac301b
+```
+
+Each trace expires after 240 minutes.
+
 ## Stop
 
 Generally allow this fleet of virtual devices to run for 15-20 minutes,
@@ -878,11 +932,6 @@ for:
 
 When doing so, also increase corresponding values for `FIRST_*` to be the
 former value of `N_*` to avoid clobbering or creating duplicate devices.
-
-For significantly large numbers of devices, consider increasing Linux kernel
-values such as `/proc/sys/net/core/somaxconn` for IP socket listen backlog.
-
-Eventually eliminate per-device logging.
 
 Check for new releases of [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
 that may facilitate driving higher traffic.  Future work will occur there.

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -177,8 +177,8 @@ If using multiple organizations, create individual configuration files
 within each org's subdirectory; e.g., `org-01`, `org-02`, respectively.
 
 ```bash
-for i in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
-  mkdir $WORKDIR/org-$i
+for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  mkdir $WORKDIR/org-$o
 done
 ```
 
@@ -201,8 +201,8 @@ echo 'request_timeout = 120'         >> $out
 Confirm getting valid JSON as a result:
 
 ```bash
-for i in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
-  cd $WORKDIR/org-$i/
+for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
+  cd $WORKDIR/org-$o/
   helium-console-cli device list
 done
 ```
@@ -296,14 +296,10 @@ command **on router host**:
 ```bash
 ssh router-dev
 cd router/
-router peer listen
+router peer addr
 ```
 
-Visually extract the entry beginning with `/p2p/` and copy the sequence up
-to but excluding the subsequent slash (`/`).  (Unfortunately, due to
-`router` being an aliased Docker command, `grep` and `sed` cannot be of
-service here.  Otherwise, manually do the equivalent of:  
-`grep /p2p/ | sed 's%^./p2p/\([^/]*\)/.*$%\1%'`.)
+Extract the sequence following `/p2p/` from the output.
 
 That long alphanumeric value gets used in multiple places below as the
 `$P2P` variable.
@@ -383,12 +379,12 @@ Ensure using organization ID and app-key as presented within the Console UI.
 ```bash
 cd $WORKDIR/org-01/
 
-for i in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
+for d in $(seq --format="%03g" $FIRST_DEV $N_DEVICES); do
     helium-console-cli device create \
       6081F9AF355EDE29 \
       87653070BE490D1780C830DA0CD28AFC \
-      6000000000000$i \
-      benchmark-$i
+      6000000000000$d \
+      benchmark-$d
 done
 ```
 
@@ -494,7 +490,7 @@ for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
     echo ''                                   >> $out
     echo '[packet_forwarder.default]'         >> $out
     # Round-robin distribution:
-    port=$((1680 + $d % $N_GATEWAYS))
+    port=$((1680 + i % N_GATEWAYS))
     echo 'host = "localhost:'${port}'"'       >> $out
   done
 done
@@ -516,21 +512,23 @@ Install default and *preliminary* configuration files:
 ```bash
 cd $WORKDIR
 
-for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  mkdir gw-$i
-  ln -s ~/helium/gateway-rs/config/default.toml gw-$i/
+i=0
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  mkdir gw-$gw
+  ln -s ~/helium/gateway-rs/config/default.toml gw-$gw/
 
-  out=gw-$i/settings.toml
-  keyfile="$(pwd)/gw-$i/gateway_key.bin"
+  out=gw-$gw/settings.toml
+  keyfile="$(pwd)/gw-$gw/gateway_key.bin"
   echo 'keypair = "'${keyfile}'"'       > $out
-  port=$((1680 + $i))
+  port=$((1680 + i))
   echo 'listen = "127.0.0.1:'${port}'"' >> $out
-  port=$((4467 + $i))
+  port=$((4467 + i))
   echo "api = $port"                    >> $out
   echo 'region = "US915"'               >> $out
   echo ''                               >> $out
   echo '[update]'                       >> $out
   echo 'enabled = false'                >> $out
+  i=$((i + 1))
 done
 ```
 
@@ -550,19 +548,19 @@ key material and connect to upstream services.
 These transactions will be signed and committed later:
 
 ```bash
-for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  helium_gateway -c gw-$i server > gw-$i/server.log &
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  helium_gateway -c gw-$gw server > gw-$gw/server.log &
   pid=$!
 
   # Wait!
-  watch -n 9 --chgexit grep height gw-$i/server.log
+  watch -n 9 --chgexit grep height gw-$gw/server.log
 
-  helium_gateway -c gw-$i info > gw-$i/gw-info.json
+  helium_gateway -c gw-$gw info > gw-$gw/gw-info.json
 
-  helium_gateway -c gw-$i \
+  helium_gateway -c gw-$gw \
     add --mode dataonly \
       --owner $WALLET \
-      --payer $WALLET > gw-$i/add-dataonly.json
+      --payer $WALLET > gw-$gw/add-dataonly.json
 
   kill $pid
 done
@@ -607,8 +605,8 @@ Assert location, which uses `$GW_KEY` populated during our previous run of
 `helium_gateway` in server-mode:
 
 ```bash
-for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  key=$(jq .key $gw-01/gw-info.json)
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  key=$(jq .key gw-$gw/gw-info.json)
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
@@ -621,8 +619,8 @@ done
 Repeat with `--commit` flag, which **burns HNT from your wallet:**
 
 ```bash
-for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  key=$(jq .key $gw-01/gw-info.json)
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  key=$(jq .key gw-$gw/gw-info.json)
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
@@ -655,8 +653,8 @@ intended router instance:
 ```bash
 cd $WORKDIR
 
-for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  out=gw-$i/settings.toml
+for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
+  out=gw-$gw/settings.toml
   echo ''                        >> $out
   echo '[router.release]'        >> $out
   echo 'pubkey = "'${P2P}'"'     >> $out
@@ -684,12 +682,13 @@ There is an API call for that status:
 for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
   cd $WORKDIR/org-$o/
 
-  # TODO when PR#21 gets merged, replace curl with this:
-  # helium-console-cli devices all > status.json
+  # TODO requires helium-console-cli PR#21
+  helium-console-cli devices all > status.json
 
-  apikey=$(grep key .helium-console-config.toml | awk '{print $3}')
-  curl -H "key: $apikey" \
-    https://console.helium.com/api/v1/devices > status.json
+  # ALTERNATIVE:
+  # apikey=$(grep key .helium-console-config.toml | sed 's/^.*"\(.*\)"$/\1/')
+  # curl -H "key: $apikey" \
+  #   https://console.helium.com/api/v1/devices > status.json
 done
 ```
 
@@ -710,8 +709,8 @@ concurrency:
 ```bash
 cd $WORKDIR
 
-for i in $(seq --format="%02g" $N_GATEWAYS); do
-  helium_gateway -c gw-$i server >> gw-$i/run.log 2>&1 &
+for gw in $(seq --format="%02g" $N_GATEWAYS); do
+  helium_gateway -c gw-$gw server >> gw-$gw/run.log 2>&1 &
 done
 ```
 
@@ -775,8 +774,8 @@ handle concurrency:
 cd $WORKDIR
 
 for o in $(seq --format="%02g" $N_ORGS); do
-  for i in $(seq --format="%03g" $N_DEVICES); do
-    ( cd org-$o/device-$i/ && \
+  for d in $(seq --format="%03g" $N_DEVICES); do
+    ( cd org-$o/device-$d/ && \
       virtual-lorawan-device >> run.log 2>&1 ) &
 
     # Facilitate slow-start of load to avoid hammer effect:

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -327,36 +327,14 @@ P2P=longAlphanumeric...
 echo $P2P
 ```
 
-## Router Location
-
-On your laptop/workstation, append router's P2P address (long alphanumeric
-string) to the API endpoint:
-
-```bash
-cd $WORKDIR
-
-UA="XYZ Location Confirmation"
-
-curl --user-agent "$UA" \
-  "$API_URL/v1/hotspots/$P2P" > router.json
-
-jq . router.json
-```
-
-Extract latitude and longitude:
-
-```bash
-LAT=$(jq .data.lat router.json)
-LON=$(jq .data.lng router.json)
-echo $LAT $LON
-```
-
-This pair of latitude and longitude will be used below.
-
 ## Hexagons
 
-Find a hexagon for each gateway instance such that each hex is an
-**equal distance** from the router to be used.
+Choose a hexagon for each gateway instance.
+
+Because this is a test router yet each gateway's location must be asserted
+onto mainnet blockchain, pick a bogus location such as middle of a lake or
+river.  (While there might be legitimate *devices* in a particular body of
+water, there is unlikely to be a hotspot there as well.)
 
 > The importance of asserting a location for each hotspot:
 >
@@ -373,14 +351,24 @@ throughput.
 A dedicated and isolated router and console pair may disregard concerns
 about Proof-of-Coverage (PoC) or an oversaturated Hex.
 
-Therefore:
-
-Keep it simple, and use Lat/Lon matching your router.
-
 ([Router](https://github.com/helium/router) uses
 [h3](https://github.com/helium/erlang-h3) hexagonal hierarchical geospatial
 indexing system for computing distance, so dig there for any unique criteria
-or constraints.)
+or constraints.  For previewing the hex for each pair of coordinates,
+use the live JavaScript feature of the underlying
+[API's documentation](https://h3geo.org/docs/api/indexing#geotoh3)
+with resolution of 8, and append the resulting value to:
+`https://explorer.helium.com/hotspots/hex/`.)
+
+Select latitude and longitude:
+
+```bash
+LAT="43.5482302"
+LON="-116.6575001"
+echo $LAT $LON
+```
+
+This pair of latitude and longitude values will be used below.
 
 ## Create Devices via Console API
 
@@ -492,6 +480,10 @@ Connections of devices from same org will distribute across multiple
 gateways, simulating real world scenarios with geographically dispersed
 deployments.
 
+Sending more frequently than 2 seconds per device would be unrealistic.
+The value for `default_secs_between_transmits` may be tuned below, and
+`rx_delay` which defaults to 1s, may be increased via Console up to 15s.
+
 ```bash
 cd $WORKDIR
 # Use printf, not `seq --format` to avoid octal when assigning $i below
@@ -531,7 +523,7 @@ for o in $(seq $N_ORGS); do
     echo 'dev_eui = '$(jq .devices[$j].dev_eui < $json) >> $out
     echo 'app_eui = '$(jq .devices[$j].app_eui < $json) >> $out
     echo 'app_key = '$(jq .devices[$j].app_key < $json) >> $out
-    echo 'default_secs_between_transmits = 0'   >> $out
+    echo 'default_secs_between_transmits = 5'  >> $out
   done
 done
 ```
@@ -559,7 +551,7 @@ Install default and *preliminary* configuration files:
 ```bash
 cd $WORKDIR
 
-i=$((FIRST_GW - 1))
+i=${FIRST_GW:-1}
 for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   mkdir gw-$gw
   ln -s ~/helium/gateway-rs/config/default.toml gw-$gw/
@@ -577,17 +569,19 @@ for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
   echo ''                               >> $out
   echo '[update]'                       >> $out
   echo 'enabled = false'                >> $out
+  echo ''                               >> $out
+  echo '[router.release]'               >> $out
+  echo 'pubkey = "'${P2P}'"'            >> $out
+  echo 'uri = "'${ROUTER_URL}'"'        >> $out
+  echo 'oui = '${ROUTER_OUI}            >> $out
   i=$((i + 1))
 done
 ```
 
-Those configuration files will be appended in a few steps below.  Each
-gateway must initially communicate with default routers when being added to
-the blockchain and when asserting location, because development routers are
-seeded from [mainnet](https://docs.helium.com/mine-hnt/validators/#mainnet).
-
-> **If using an entirely private deployment**, apply your variation of an
-> amended configuration *now* from end of this section.
+> Note:
+If using "beta" or other version of
+[gateway-rs](https://github.com/helium/gateway-rs) instead of "release",
+change `[router.release]` to match.)
 
 Generate transactions using `WALLET` variable defined earlier.
 
@@ -650,18 +644,18 @@ for txn in $(cat txn-ids.log); do
 done
 ```
 
-Assert location, which uses `$GW_KEY` populated during our previous run of
-`helium_gateway` in server-mode:
+Assert location using `$LAT` and `$LON` defined earlier for
+each gateway.
 
 ```bash
 for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  key=$(jq .key gw-$gw/gw-info.json)
+  key=$(jq .key gw-$gw/gw-info.json | sed 's/"//g')
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
      hotspots assert --gateway $key \
      --mode dataonly \
-     --lat=$LAT --lon=$LON --elevation 6
+     --lat=$LAT$gw --lon=$LON$gw --elevation 6
 done
 ```
 
@@ -669,13 +663,13 @@ Repeat with `--commit` flag, which **burns HNT from your wallet:**
 
 ```bash
 for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  key=$(jq .key gw-$gw/gw-info.json)
+  key=$(jq .key gw-$gw/gw-info.json | sed 's/"//g')
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
      hotspots assert --gateway $key \
      --mode dataonly \
-     --lat=$LAT --lon=$LON --elevation 6 \
+     --lat=$LAT$gw --lon=$LON$gw --elevation 6 \
      --commit
 done
 ```
@@ -695,26 +689,6 @@ several minutes and check again later.
 Other gateways appearing within the results is benign because a virtual
 LoRaWAN device will only reach those for which it was explicitly configured
 since its radio is simulated.
-
-Finally, finish the local configuration suitable for producing load on your
-intended router instance:
-
-```bash
-cd $WORKDIR
-
-for gw in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  out=gw-$gw/settings.toml
-  echo ''                        >> $out
-  echo '[router.release]'        >> $out
-  echo 'pubkey = "'${P2P}'"'     >> $out
-  echo 'uri = "'${ROUTER_URL}'"' >> $out
-  echo 'oui = '${ROUTER_OUI}     >> $out
-done
-```
-
-(If using "beta" or other version of
-[gateway-rs](https://github.com/helium/gateway-rs) instead of "release",
-change `[router.release]` to match.)
 
 With that, your gateways are finally ready for Load & Capacity runs.
 

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -25,11 +25,17 @@ and **Bash** shell syntax on Linux is used below.
 
 ## Dependencies
 
-These should be **isolated** instances dedicated to load & capacity testing,
-as other users of the system *will* be negatively impacted:
+These **must be isolated** instances dedicated to load & capacity testing,
+as other users of the system *will* be negatively impacted as well as yield
+meaningless benchmarks:
 
 - [router](https://github.com/helium/router)
+  + Must be an isolated instance because **abuse-prevention measures** get
+    triggered
+  + Requires being reset
 - [console](https://github.com/helium/console)
+  + Omit `IMPOSE_HARD_CAP` environment variable
+  + Ensure `MAX_DEVICES_IN_ORG` exceeds number of virtual devices
 
 Install wallet on same host as your router if sharing its private key:
 
@@ -246,6 +252,12 @@ wallet from which the limited wallet gets funded:
 
 > Please add funds for Load & Capacity testing:  
 > helium-wallet burn --amount 25 --payee $WALLET --commit
+
+Again, burning HNT is **only for asserting hotspots** and their locations.
+
+When benchmarking within an isolated environment such as `router-dev`, reset
+DC balance on the router host which is described in
+[Fund Organizations](#fund-organizations) below.
 
 #### Optional: Sharing Keys With Router
 
@@ -465,49 +477,60 @@ echo $ROUTER_OUI
 This requires devices already having been created via Console API.
 
 The API provides the *single source of truth* about devices.  (Device ID in
-Console might be mismatched with respect to file names generated below due
+Console might be mismatched with respect to identifiers generated below due
 to sequence of output from API, which is unimportant for benchmarking.)
 
-Generate a custom `settings.toml` file for **each**
+Despite lack of plural in the name,
 [virtual LoRaWAN device](https://github.com/helium/virtual-lorawan-device)
-based upon data within the `devices.json` file generated above from each
-organization.
+accommodates multiple devices, as indicated by its README.
 
-Each device needs its own subdirectory for a set of configuration files.
+Generate a single `settings.toml` file all devices per organization.  (This
+segments by org for managing benchmarking runs.)
 
-Connections of devices will distribute across multiple gateways, simulating
-real world scenarios with geographically dispersed deployments.
+Connections of devices from same org will distribute across multiple
+gateways, simulating real world scenarios with geographically dispersed
+deployments.
 
 ```bash
-metrics_port=9898
-for o in $(seq --format="%02g" $N_ORGS); do
-  cd $WORKDIR/org-$o/
+cd $WORKDIR
+# Use printf, not `seq --format` to avoid octal when assigning $i below
+for o in $(seq $N_ORGS); do
+  org=$(printf "%02g" $o)
+  [ -d org-$org/settings ] || mkdir -p org-$org/settings
+  [ -e org-$org/settings/default.toml ] || \
+    ln -s ~/helium/virtual-lorawan-device/settings/default.toml \
+      org-$org/settings/
 
-  # Use printf, not seq --format to avoid octal when assigning $i
+  out="org-$org/settings/settings.toml"
+  echo 'default_server = "dev"'                > $out
+  # Must be unique across all instances of virtual-lorawan-device:
+  echo 'metrics_port = '$metrics_port          >> $out
+  metrics_port=$((9898 + o))
+  echo ''                                      >> $out
+
+  for gw in $(seq $N_GATEWAYS); do
+    gateway=$(printf "%02g" $gw)
+    echo "[packet_forwarder.gw${gateway}]"     >> $out
+    port=$((1680 + gw))
+    echo 'host = "localhost:'${port}'"'        >> $out
+    echo 'mac = "08070605040302'${gateway}'"'  >> $out
+  done
+
+  json="org-$org/devices.json"
   for d in $(seq $N_DEVICES); do
     device=$(printf "%03g" $d)
-    mkdir -p device-$device/settings
-
-    ln -s ~/helium/virtual-lorawan-device/settings/default.toml \
-      device-$device/settings/
-
-    out="device-$device/settings/settings.toml"
-    echo 'default_server = "dev"'             > $out
-    # Must be unique across all devices:
-    echo 'metrics_port = '$metrics_port       >> $out
-    metrics_port=$((metrics_port + 1))
-    echo ''                                   >> $out
-    echo "[device.$device.credentials]"       >> $out
-    i=$((d - 1))
-    echo 'dev_eui = '$(jq .devices[$i].dev_eui < devices.json) >> $out
-    echo 'app_eui = '$(jq .devices[$i].app_eui < devices.json) >> $out
-    echo 'app_key = '$(jq .devices[$i].app_key < devices.json) >> $out
-    echo 'default_secs_between_transmits = 0' >> $out
-    echo ''                                   >> $out
-    echo '[packet_forwarder.default]'         >> $out
+    echo ''                                    >> $out
+    echo "[device.${device}]"                  >> $out
     # Round-robin distribution:
-    port=$((1680 + i % N_GATEWAYS))
-    echo 'host = "localhost:'${port}'"'       >> $out
+    i=$(( (d % N_GATEWAYS) + 1 ))
+    gateway=$(printf "%02g" $i)
+    echo 'packet_forwarder = "gw'${gateway}'"' >> $out
+    echo "[device.${device}.credentials]"      >> $out
+    j=$((d - 1))
+    echo 'dev_eui = '$(jq .devices[$j].dev_eui < $json) >> $out
+    echo 'app_eui = '$(jq .devices[$j].app_eui < $json) >> $out
+    echo 'app_key = '$(jq .devices[$j].app_key < $json) >> $out
+    echo 'default_secs_between_transmits = 0'   >> $out
   done
 done
 ```
@@ -515,7 +538,7 @@ done
 Sanity check:
 
 ```bash
-grep -q 'dev_eui = null' org*/device*/settings/settings.toml && \
+grep -q 'dev_eui = null' org*/settings/settings.toml && \
   echo Something went wrong.
 ```
 
@@ -694,6 +717,44 @@ change `[router.release]` to match.)
 
 With that, your gateways are finally ready for Load & Capacity runs.
 
+## Fund Organizations
+
+Benchmarking on an **isolated server instance of router** (e.g.,
+`router-dev`) affords the option of resetting DC balance of an organization.
+Otherwise, benchmarking will make a measurable impact to your wallet; see
+[Data Credits](https://docs.helium.com/use-the-network/console/data-credits/)
+within Console documentation.
+
+First, find your `organization_id` which may be obtained via Console UI.
+From the Organizations page, there is an export widget associated with each
+organization listed.
+
+Alternative, extract from `devices.json` for each organization.  These files
+were generated above.
+
+Run:
+
+```bash
+jq .devices[0].organization_id org-*/devices.json
+```
+
+Use each of those organization IDs and provide the target DC balance, which
+gets specify as 100k in this example:
+
+```bash
+ssh router-dev
+cd router/
+router organization update bb5a2fec-1234-5678-89e4-a0e3c4807628 -b 100000
+```
+
+Confirm output of the above command, and then repeat with `--commit` flag:
+
+```bash
+!! --commit
+```
+
+Again, the above command only works on **non-production** environments.
+
 ## Wait for XOR Filter
 
 The Console may indicate "Pending" from having added new devices above and
@@ -788,28 +849,24 @@ benchmarking.
 
 ## Spawn Virtual Devices
 
-TODO: add feature to `virtual-lorawan-device` to facilitate "slow start" for
-progressively increasing load.
-
-
-Launch each virtual device as a separate process, and again let the OS
-handle concurrency:
+Launch fleet of virtual devices as a single OS process:
 
 ```bash
 cd $WORKDIR
 
 for o in $(seq --format="%02g" $N_ORGS); do
-  for d in $(seq --format="%03g" $N_DEVICES); do
-    ( cd org-$o/device-$d/ && \
-      virtual-lorawan-device >> run.log 2>&1 ) &
+  ( cd org-$o/ && virtual-lorawan-device >> run.log 2>&1 ) &
 
-    # Facilitate slow-start of load to avoid hammer effect:
-    sleep 1
-  done
+  # Slight mitigation against hammer effect:
+  sleep 5
 done
 ```
 
 While waiting for the outer loop to finish, watch your graphs; e.g, Grafana.
+
+Note: `virtual-lorawan-device` causes the device to Join (or re-join) upon
+each start of the utility.  (For continuing a previous session,
+pull-requests there are welcomed!)
 
 ## Stop
 
@@ -845,6 +902,14 @@ for:
 When doing so, also increase corresponding values for `FIRST_*` to be the
 former value of `N_*` to avoid clobbering or creating duplicate devices.
 
+For significantly large numbers of devices, consider increasing Linux kernel
+values such as `/proc/sys/net/core/somaxconn` for IP socket listen backlog.
+
+Eventually eliminate per-device logging.
+
+Check for new releases of [virtual-lorawan-device](https://github.com/helium/virtual-lorawan-device)
+that may facilitate driving higher traffic.  Future work will occur there.
+
 ## Comprehending The Results
 
 There should be a slow ramp-up of traffic such that we "find the knee"
@@ -873,3 +938,32 @@ artifacts on the host OS that might be causing interference.  Consider
 migrating to different host server hardware (via hard stop/start) if
 running on a virtualized/hypervisor environment such as AWS, GCP,
 Linode, etc.
+## Troubleshooting
+### Traffic Dropped By Router
+
+The nature of driving load to find capacity of a server may trigger
+abuse-prevention measures of [router](https://github.com/helium/router)
+such as its reputation system.
+
+Check:
+
+```bash
+ssh router-dev
+cd router
+router hotspot_reputation ls
+```
+
+If you see the name corresponding to your instance(s) of gateway-rs, with a
+score approaching `10`, that device has either been banned or is about to
+be.
+
+Copy the alphanumeric string associated with your gateway's name under the
+`b58` column, and use it as the identifier below.
+
+Reset reputation:
+
+```bash
+ssh router-dev
+cd router
+router hotspot_reputation reset longAlphaNumeric...
+```

--- a/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
+++ b/docs/use-the-network/run-a-network-server/router-benchmarking.mdx
@@ -6,13 +6,13 @@ slug: /use-the-network/run-a-network-server/router-benchmarking
 
 # Router Benchmarking
 
-This measures load by steadily increasing load on a
+This measures load by steadily increasing LoRaWAN traffic on a
 [Helium Router](https://github.com/helium/router)
 to find its threshold of capacity for a given server instance.
 
-Measuring load a particular server instance may then be compared with
-equivalent measurements on another server instance with different hardware
-specs.  The procedure used is *load & capacity measurement* but some people
+Measuring capacity of a particular server instance may then be
+compared with another server instance with different hardware specs.
+The procedure used is *load & capacity measurement* but some people
 also refer to this as *stress testing*.
 
 This document also gives insight to interactions of routers, gateways,
@@ -104,8 +104,9 @@ Additional variables will be created along the way.
 
 ## Logs & Graphs
 
-Benchmarking load is meaningless without the ability to measure, and in
-order to optimize server capacity requires meaningful measurements.
+Benchmarking load is meaningless without the ability to measure, and
+in order to optimize server capacity requires comparing meaningful,
+consistent measurements.
 
 Graphs described below help on both points.
 
@@ -121,9 +122,9 @@ Subtle nuances to comprehend first:
     clarity because inbound traffic fluctuates, constantly altering the
     baseline
 
-The router repo includes
-[Grafana dashboard](https://github.com/helium/router/blob/master/grafana-dashboard.json)
-configuration used in production.
+The router repo includes the
+[Grafana dashboard configuration](https://github.com/helium/router/blob/master/grafana-dashboard.json)
+used in production.
 
 For router under significant load, the most critical graphs to watch:
 
@@ -137,18 +138,18 @@ For router under significant load, the most critical graphs to watch:
   + The term "state channel" is the generic term for a Layer-2 Ledger (like the
     "Lightning Network") and critical to router's use of the Helium Blockchain
   + An "actor" is a co-routine in Erlang (or "Green Threads", or similar in
-    purpose to "async/await" but different mechanisms)
+    purpose to "async/await" with differing mechanisms)
 - **Offer -> Packet -> Downlink** travel times:
   + Ideally would be within **milliseconds** (ms)
   + Acceptable when below **2 seconds**
   + Alarm and take action when above 5 seconds
 - **Offer Duration** should be within **milliseconds** (ms)
-  + This translates directly to latency of server response, *not* counting
-    Internet traffic latency
+  + This translates directly to latency of server response
+  + Excludes any Internet traffic latency
 
 For designing your own graphs, it helps bucketing by percentiles.  Common
 buckets are: 1%, 5%, 15%, 50%, 85%, 90%, 95%, 97%, 98%, 99% 100%, which
-gives the average/mean, an approximation of standard deviation (15%, 85%)
+give the average/mean, an approximation of standard deviation (15%, 85%)
 and most importantly the *outliers*.  Outliers are skewed here towards the
 troublesome high end for fine-grained tracking.  The 99th and 100th may be
 safely ignored when those values are indistinguishable from latency across
@@ -164,9 +165,11 @@ Key](https://docs.helium.com/use-the-network/console/my-account/#console-api-key
 which requires logging onto Console user interface (UI).  Everything else
 will be done by command-line interface (CLI).
 
-Store the newly generated Console API Key to this TOML file, and specify
-base URL of the console.  The default of `https://console.helium.com` is
-probably **not** what you want for purposes here.
+Store your new Console API Key generated from the UI to the TOML file
+below, and specify base URL of the console.  The default of
+`https://console.helium.com` is probably **not** what you want for
+purposes here.  This URL must match the Console corresponding to your
+Router instance.
 
 If using multiple organizations, create individual configuration files
 within each org's subdirectory; e.g., `org-01`, `org-02`, respectively.
@@ -177,7 +180,9 @@ for i in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
 done
 ```
 
-Persist each org's API key and Console base URL in its respective TOML file:
+Persist each org's API key and Console base URL in its respective TOML
+file:  
+(Note the dot preceding the file name)
 
 ```bash
 cd $WORKDIR/org-01/
@@ -337,7 +342,7 @@ This pair of latitude and longitude will be used below.
 ## Hexagons
 
 Find a hexagon for each gateway instance such that each hex is an
-equal distance from the router to be used.
+**equal distance** from the router to be used.
 
 > The importance of asserting a location for each hotspot:
 >
@@ -356,7 +361,7 @@ about Proof-of-Coverage (PoC) or an oversaturated Hex.
 
 Therefore:
 
-Keep it simple, and use Lat/Lon matching the router.
+Keep it simple, and use Lat/Lon matching your router.
 
 ([Router](https://github.com/helium/router) uses
 [h3](https://github.com/helium/erlang-h3) hexagonal hierarchical geospatial
@@ -453,7 +458,7 @@ echo $ROUTER_OUI
 
 Generate a custom `settings.toml` file for **each**
 [virtual LoRaWAN device](https://github.com/helium/virtual-lorawan-device)
-based upon data within the earlier `devices.json` file from each
+based upon data within the `devices.json` file generated above from each
 organization.
 
 Each device needs its own subdirectory for a set of configuration files.
@@ -475,6 +480,7 @@ for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
     out="device-$d/settings/settings.toml"
     echo 'default_server = "dev"'             > $out
     echo 'metrics_port = '$metrics_port       >> $out
+    # Must be unique across all devices:
     metrics_port=$((metrics_port + 1))
     echo ''                                   >> $out
     echo "[device.$d.credentials]"            >> $out
@@ -485,22 +491,23 @@ for o in $(seq --format="%02g" $FIRST_ORG $N_ORGS); do
     echo 'default_secs_between_transmits = 0' >> $out
     echo ''                                   >> $out
     echo '[packet_forwarder.default]'         >> $out
+    # Round-robin distribution:
     port=$((1680 + $d % $N_GATEWAYS))
     echo 'host = "localhost:'${port}'"'       >> $out
   done
 done
 ```
 
-Each device may require waiting upwards of 20 minutes for the router's XOR
-filter to run.  The device will be marked in Console with "Pending" status
-until then.
+Devices may require waiting upwards of 20 minutes (concurrently) for
+the router's XOR filter to run.  The device will be marked in Console
+with "Pending" status until then, and we check for this further below.
 
 ## Gateways
 
 This uses the `$P2P` value defined above in "Router Address" section.
 
-Each gateway must open a listening socket on a unique port, so this simply
-increments from the default base port.
+Each gateway must open a listening socket on a unique port number, so
+this simply increments from the default base port.
 
 Install default and *preliminary* configuration files:
 
@@ -611,9 +618,7 @@ Repeat with `--commit` flag, which **burns HNT from your wallet:**
 
 ```bash
 for i in $(seq --format="%02g" $FIRST_GW $N_GATEWAYS); do
-  # key=$(jq .key $gw-01/gw-info.json)
-  key=$(grep 'INFO starting server, key:' gw-$i/server.log | \
-        sed 's/^.*: \(.*\),.*$/\1/')
+  key=$(jq .key $gw-01/gw-info.json)
 
   helium-wallet \
      -f $WORKDIR/wallet/wallet.key \
@@ -634,7 +639,7 @@ curl --user-agent "$UA" \
 ```
 
 Ensure that your gateways appear within those results.  If not found, wait
-and check again later.
+several minutes and check again later.
 
 Other gateways appearing within the results is benign because a virtual
 LoRaWAN device will only reach those for which it was explicitly configured
@@ -685,7 +690,7 @@ done
 ```
 
 If any report as `false`, **wait one minute** at minimum before checking
-again:
+again to avoid being throttled or blocked:
 
 ```bash
 cd $WORKDIR
@@ -744,6 +749,8 @@ killall virtual-lorawan-device
 killall helium_gateway
 ```
 
+(Those must be names of each actual command-- not Bash aliases.)
+
 Confirm no longer running:
 
 ```bash
@@ -765,10 +772,9 @@ former value of `N_*` to avoid clobbering or creating duplicate devices.
 
 ## Comprehending The Results
 
-There should be a slow ramp-up of traffic such that we can "find the knee"
-of the graph *before* hitting the plateau (ceiling).  That plateau should be
-understood as an approximation due to the nature of simulated/artificial
-traffic.
+There should be a slow ramp-up of traffic such that we "find the knee"
+of the graph *before* hitting the plateau (ceiling).  Understand that
+plateau being an approximation due to the nature of generated traffic.
 
 A good rule-of-thumb:
 
@@ -779,14 +785,16 @@ for traffic spikes without being excessively oversized.
 
 When confirming any such measurements:
 
-**Run** the same scenario a **minimum of three consecutive** times.
+**Run** the same scenario a **minimum of three consecutive** times
+with consistent results.
 
 That *excludes* a preliminary run to invalidate the OS file-system cache.
 
-The rule of three requires consistency.  If results vary by more than
+This rule of three requires consistency.  If results vary by more than
 rounding error, keep running until getting 3 with similar results.
 
-If the only consistency is that results vary widely, look to other artifacts
-on the host OS that might be causing interference.  Consider migrating to a
-different server instance, if running on a virtualized/hypervisor
-environment such as AWS, GCP, Linode, etc.
+If the only consistency is that results vary widely, look to other
+artifacts on the host OS that might be causing interference.  Consider
+migrating to different host server hardware (via hard stop/start) if
+running on a virtualized/hypervisor environment such as AWS, GCP,
+Linode, etc.

--- a/docs/use-the-network/run-a-network-server/run-a-network-server.mdx
+++ b/docs/use-the-network/run-a-network-server/run-a-network-server.mdx
@@ -21,6 +21,11 @@ running.
 - Optionally [debug with sniffer](/use-the-network/run-a-network-server/debug-with-sniffer)
   to confirm router runtime behavior using a virtual LoRaWAN device and a
   software-based protocol sniffer
+- [Router benchmarking](/use-the-network/run-a-network-server/router-benchmarking)
+  for load & capacity of real LoRaWAN traffic in an isolated environment
+    + Use this to help determine size of server instance to deploy
+    + This document also gives insight to interactions of console, router,
+      gateways, organizations, devices and wallets as used in production
 
 Before pursuing this configuration though, it is worth considering.
 

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -189,7 +189,7 @@ module.exports = {
       {
           type: 'category',
           label: 'Run a Network Server',
-          items: ['use-the-network/run-a-network-server/buy-an-oui', 'use-the-network/run-a-network-server/run-console', 'use-the-network/run-a-network-server/deploy-console','use-the-network/run-a-network-server/debug-with-sniffer'],
+          items: ['use-the-network/run-a-network-server/buy-an-oui', 'use-the-network/run-a-network-server/run-console', 'use-the-network/run-a-network-server/deploy-console','use-the-network/run-a-network-server/debug-with-sniffer', 'use-the-network/run-a-network-server/router-benchmarking'],
           collapsed: false,
       },
   ],


### PR DESCRIPTION
Adds new doc, "Router Benchmarking" linked just under "debug with sniffer" on the page of "run a network server"

Preview URL:
https://deploy-preview-846--helium-docs.netlify.app/use-the-network/run-a-network-server/

- Addresses [router issue 677](https://github.com/helium/router/issues/677)
- Use this to help determine size of server instance to deploy
- Provides instructions for load & capacity of real LoRaWAN traffic in an isolated environment
- This document also gives insight to interactions of console, router, gateways, organizations, devices and wallets as used in production
- Also updates "debug with sniffer" 
    + because gateway-rs as of v1.0 has new usage
    + i.e., must start in server-mode before generating a txn to be signed by wallet for asserting location, etc.

This will be a DRAFT PR until the first 1-2 runs to confirm accuracy of the instructions but published here so the community may benefit sooner than later.

EDIT: added preview URL