### PR TITLE
Fix dead hotspot-makers links in all docs

### DIFF
--- a/docs/mine-hnt/full-hotspots/become-a-maker/burn-hnt-to-maker-wallet.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/burn-hnt-to-maker-wallet.mdx
@@ -8,7 +8,7 @@ slug: /mine-hnt/full-hotspots/become-a-maker/burn-hnt-to-maker-wallet
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-Any [approved Hotspot Maker](/mine-hnt/hotspot-makers/approved-makers) is responsible for supplying Data Credits (DCs) to the onboarding server for Hotspots they sell. They do this by burning HNT to their
+Any [approved Hotspot Maker](/mine-hnt/full-hotspots) is responsible for supplying Data Credits (DCs) to the onboarding server for Hotspots they sell. They do this by burning HNT to their
 specific maker address. 
 
 :::info 
@@ -19,7 +19,7 @@ A full list of approved maker wallet addresses [can be seen via this API](https:
 
 ## Maker Wallet Address Integration
 
-As an approved Maker, you will supply the Helium Foundation with the onboarding details for all the Hotspots you manufacture and distribute. In turn, the Helium Foundation adds them to the onboarding server. When a Hotspot is onboarded by your end customer, the onboarding server knows to associate it with your Maker ID, and associated Maker Wallet address. If, when a Hotspot is onboarded, it's present in the onboarding server and you have ample Data Credits to pay the onboarding fees, the blockchain will add the Hotspot. And if you've [integrated your Hotspot in the Hotspot App onboarding flow](/mine-hnt/hotspot-makers/hotspot-integration-testing), the Wallet knows to use your approved Maker Wallet address. At this point, the Data Credits will be used for the transactions with your wallet address as the payer. 
+As an approved Maker, you will supply the Helium Foundation with the onboarding details for all the Hotspots you manufacture and distribute. In turn, the Helium Foundation adds them to the onboarding server. When a Hotspot is onboarded by your end customer, the onboarding server knows to associate it with your Maker ID, and associated Maker Wallet address. If, when a Hotspot is onboarded, it's present in the onboarding server and you have ample Data Credits to pay the onboarding fees, the blockchain will add the Hotspot. And if you've [integrated your Hotspot in the Hotspot App onboarding flow](/mine-hnt/full-hotspots/become-a-maker/hotspot-integration-testing), the Wallet knows to use your approved Maker Wallet address. At this point, the Data Credits will be used for the transactions with your wallet address as the payer. 
 
 
 ## Hotspot Data Credit Fees

--- a/docs/mine-hnt/full-hotspots/become-a-maker/hotspot-wifi-configuration.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/hotspot-wifi-configuration.mdx
@@ -8,7 +8,7 @@ slug: /mine-hnt/full-hotspots/become-a-maker/hotspot-wifi-configuration
 
 import useBaseUrl from "@docusaurus/useBaseUrl";
 
-The Helium Hotspot provides a WiFi configuration interface via the device's[ BLE services](/mine-hnt/hotspot-makers/hotspot-ble-services). The following are instructions for how to configure a Hotspot's WiFi.
+The Helium Hotspot provides a WiFi configuration interface via the device's[ BLE services](/mine-hnt/full-hotspots/become-a-maker/hotspot-ble-services). The following are instructions for how to configure a Hotspot's WiFi.
 
 ### Connecting to the Hotspot over Bluetooth Low Energy
 
@@ -61,12 +61,12 @@ The Helium Hotspot provides a WiFi configuration interface via the device's[ BLE
 
    `UUID: d7515033-7e7b-45be-803f-c8737b171a29`
 
-2. De-serialize the binary value into the WiFi Services [Protocol Buffers](https://developers.google.com/protocol-buffers) message found in [BLE Services Docs](/mine-hnt/hotspot-makers/hotspot-ble-services#wifiservices-characteristic). This will give you a list of available WiFi SSID string names.
+2. De-serialize the binary value into the WiFi Services [Protocol Buffers](https://developers.google.com/protocol-buffers) message found in [BLE Services Docs](/mine-hnt/full-hotspots/become-a-maker/hotspot-ble-services#wifiservices---characteristic). This will give you a list of available WiFi SSID string names.
 
 ### Set Credentials For WiFi Network
 
 1. Using the SSID string from the scan, and password string provided by you, do the following to set the credentials.
-   1. Serialize your WiFi Connect [Protocol Buffer](https://developers.google.com/protocol-buffers) message, the definition of which is found in the [BLE Services Sheet](/mine-hnt/hotspot-makers/hotspot-ble-services#wificonnect-characteristic).
+   1. Serialize your WiFi Connect [Protocol Buffer](https://developers.google.com/protocol-buffers) message, the definition of which is found in the [BLE Services Sheet](/mine-hnt/full-hotspots/become-a-maker/hotspot-ble-services#wificonnect---characteristic).
    2. Write serialized Value to
 
       Service

--- a/docs/mine-hnt/full-hotspots/become-a-maker/security-requirements.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/security-requirements.mdx
@@ -35,7 +35,7 @@ manufacturing process [here](https://github.com/helium/gateway_mfr). By using
 this utility, not only do you automatically comply with the ECC608 provisioning
 process, but you also create compatability with the Helium Miner with no
 modifications (other than some configuration to the
-[Docker overlay](/mine-hnt/hotspot-makers/docker-integration/#enable-ecc608-and-d-bus)).
+[Docker overlay](/mine-hnt/full-hotspots/become-a-maker/docker-integration#enable-ecc608-and-d-bus)).
 
 You are free to compile the `gateway_mfr` repository from source or use the
 [Docker image available here (for aarch64 only)](https://helium-media.s3-us-west-2.amazonaws.com/gateway_mfr-aarch64.tar).
@@ -120,4 +120,4 @@ docker exec provision gateway_mfr ecc onboarding
 ```
 
 This is what you will want to provide to the
-[onboarding server](/mine-hnt/hotspot-makers/hotspot-integration-testing/#adding-hotspots-to-the-onboarding-server).
+[onboarding server](/mine-hnt/full-hotspots/become-a-maker/hotspot-integration-testing#adding-hotspots-to-the-onboarding-server).

--- a/docs/mine-hnt/mine-hnt.mdx
+++ b/docs/mine-hnt/mine-hnt.mdx
@@ -20,10 +20,10 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
                     <h1 style={{marginTop:0}}>Mine HNT</h1>
                     <h2 className="subtitle">Helium Hotspots mine $HNT and were originally built by Helium, Inc. but are now built by our growing ecosystem of approved manufacturers.</h2>
                     <div>
-                        <a href="/mine-hnt/hotspot-makers/approved-makers"><span class="badge badge--secondary">Approved Makers</span></a>
-                        <a href="/mine-hnt/hotspot-makers/maker-approval-auditing"><span class="badge badge--secondary">Maker Approval</span></a>
-                        <a href="/mine-hnt/hotspot-makers/maker-apps"><span class="badge badge--secondary">Maker Apps</span></a>
-                        <a href="/mine-hnt/hotspot-makers/understanding-hotspot-status"><span class="badge badge--secondary">Understanding Hotspot Status</span></a>
+                        <a href="/mine-hnt/full-hotspots"><span class="badge badge--secondary">Approved Makers</span></a>
+                        <a href="/mine-hnt/full-hotspots/become-a-maker/maker-approval-auditing"><span class="badge badge--secondary">Maker Approval</span></a>
+                        <a href="/mine-hnt/maker-apps"><span class="badge badge--secondary">Maker Apps</span></a>
+                        <a href="/mine-hnt/understanding-hotspot-status"><span class="badge badge--secondary">Understanding Hotspot Status</span></a>
                         <a href="/mine-hnt/validators"><span class="badge badge--secondary">Run a Validator</span></a>	
                     </div>
                 </div>


### PR DESCRIPTION
Fixes dead links to hotspot-makers in: 

- docs/mine-hnt/full-hotspots/become-a-maker/burn-hnt-to-maker-wallet.mdx
- docs/mine-hnt/full-hotspots/become-a-maker/hotspot-wifi-configuration.mdx
- docs/mine-hnt/full-hotspots/become-a-maker/security-requirements.mdx
- docs/mine-hnt/mine-hnt.mdx