### PR TITLE
Add acronyms and minor fixes to blockchain-primitives.mdx

### DIFF
--- a/docs/blockchain/blockchain-primitives/blockchain-primitives.mdx
+++ b/docs/blockchain/blockchain-primitives/blockchain-primitives.mdx
@@ -58,7 +58,7 @@ cleared and the serialized protobuf is signed by the actor.
 [The protobuf definitions are available here](https://github.com/helium/proto).
 
 All transactions occur on-chain, and all transactions require Helium Data
-Credits to be submitted and confirmed. The following is a list of the supported
+Credits (DCs) to be submitted and confirmed. The following is a list of the supported
 transactions:
 
 - `add gateway` - Add a new gateway to the Helium Network. For the purposes of
@@ -66,14 +66,14 @@ transactions:
   mining and providing coverage.
 - `assert location` - Assert a gateway’s location on the Helium Network. This
   happens after a gateway has been added via the add gateway transaction. Once
-  asserted, this location is then used as part of Proof of Coverage challenges.
+  asserted, this location is then used as part of Proof of Coverage (PoC) challenges.
   A Miner’s location can be asserted more than once but each subsequent
-  assertion will a) cost a fee and b) reset that Miner’s score to neutral (.15)
+  assertion will cost a fee.
 - `chain vars` - Change a chain variable.
 - `coinbase` - Similar to the bitcoin blockchain’s coinbase transaction but used
   only during testnet phases of the Helium blockchain. The `rewards` transaction
   has taken its place.
-- `coinbase data credits` - Created the initial 10,000 Data Credits required to
+- `coinbase data credits` - Created the initial 10,000 DCs required to
   bring the first group of Miners online.
 - `consensus group` - Marks the election of a new consensus group, responsible
   for mining during the next epoch.
@@ -86,14 +86,14 @@ transactions:
 - `genesis gateway` - Used to define the initial group of Miners that
   bootstrapped the blockchain.
 - `multi-payment` - Used to send $HNT from one wallet to multiple wallets.
-- `OUI` - Create a OUI for a new router on the Helium network. In the Helium
+- `OUI` - Create an Organization Unique Identifier (OUI) for a new router on the Helium network. In the Helium
   blockchain, Miners forward packets to Routers that own them based on their OUI
   as stored in the blockchain.
 - `payment` - Used to send $HNT from one wallet to another.
-- `proof of coverage receipts` - The result of a POC submitted to the network
+- `proof of coverage receipts` - The result of a PoC submitted to the network
   upon completion.
-- `redeem hashed timelock` - Redeem the transaction created using the create
-  hashed timelock transaction.
+- `redeem hashed timelock` - Redeem the transaction created using the `create
+  hashed timelock` transaction.
 - `reward` - A token payout for a specific event on the network such as
   submitting a valid proof of coverage request, participating in a consensus
   group, etc.
@@ -103,8 +103,8 @@ transactions:
 - `security coinbase` - Distribution of security tokens in the genesis block.
 - `security exchange` - The transfer of security tokens from one address to
   another.
-- `state channel open` - Opens a new state channel on a Helium Router
-- `state channel close` - Closes a specific state channel on a Helium Router
+- `state channel open` - Opens a new state channel on a Helium Router.
+- `state channel close` - Closes a specific state channel on a Helium Router.
 - `token burn exchange rate` - Change the exchange rate for burning $HNT to DCs.
 - `stake validator` - Stake a new Validator on the Helium Network.
 - `transfer validator` - Transfer a staked Validator to a new owner or a new Validator.
@@ -120,7 +120,7 @@ transactions:
 Chain Variables, often referred to as `chain vars`, are a series of
 configuration settings for the Helium blockchain. Chain Variables can be used to
 change things like target block time, target epoch time, the minimum number of
-targets in a POC Challenge, and much more. Chain Variables can be altered by
+targets in a PoC Challenge, and much more. Chain Variables can be altered by
 submitting a transaction containing the chain variable to be changed, its new
 value, and a signature of the chain variable master key.
 


### PR DESCRIPTION
- Adds missing acronyms,
- Fixes minor typos,
- Removes no longer used Miner’s score chain var reference.