### PR TITLE
Add rewards chain vars, add ranges for PoC rewards in mining.mdx

### DIFF
--- a/docs/blockchain/mining/mining.mdx
+++ b/docs/blockchain/mining/mining.mdx
@@ -25,14 +25,14 @@ Every epoch, the current consensus group mines approximately 30 blocks on the
 blockchain. In each block, Hotspots perform various types of work and are awarded
 according to the following distribution:
 
-| Reward Type           | Description                                                                                                       |
-| :-------------------- | :---------------------------------------------------------------------------------------------------------------- |
-| PoC Challenger        | Rewarded to any Hotspot that creates a valid PoC challenge and submits the corresponding receipt to the blockchain. |
-| PoC Challengees       | Awarded to any Hotspot that transmits a PoC packet after being targeted by the challenger.                                                   |
-| Witnesses             | Distributed to all Hotspots that witness a beacon packet as part of a PoC Challenge.                                       |
-| Consensus Group       | Divided equally among the Validators that are part of the outgoing Consensus Group, responsible for mining blocks.     |
-| Security              | Awarded to Helium, Inc and other Network investors who hold Security Tokens.                                      |
-| Network Data Transfer | Distributed each epoch to Hotspots that route LongFi sensor data for sensors on the Network during that epoch.      |
+| Reward Type           | Chain Variable          | Description                                                                                                       |
+| :-------------------- | :-----------------------| :---------------------------------------------------------------------------------------------------------------- |
+| PoC Challenger        | poc_challengers_percent | Rewarded to any Hotspot that creates a valid PoC challenge and submits the corresponding receipt to the blockchain. |
+| PoC Challengees       | poc_challengees_percent | Awarded to any Hotspot that transmits a PoC packet after being targeted by the challenger.                                                   |
+| Witnesses             | poc_witnesses_percent   | Distributed to all Hotspots that witness a beacon packet as part of a PoC Challenge.                                       |
+| Consensus Group       | consensus_percent       | Divided equally among the Validators that are part of the outgoing Consensus Group, responsible for mining blocks.     |
+| Security              | securities_percent      | Awarded to Helium, Inc and other Network investors who hold Security Tokens.                                      |
+| Network Data Transfer | dc_percent              | Distributed each epoch to Hotspots that route LongFi sensor data for sensors on the Network during that epoch.      |
 
 **_Do I Have To Actively Participate to Earn Rewards Once My Hotspot is
 Deployed?_**
@@ -78,15 +78,15 @@ Below are the mining rewards per epoch as of August 1, 2021. For every complete 
 election of a new Consensus Group, all the `HNT` produced are distributed over
 the following reward types:
 
-| Reward Type           | Percentage    | HNT Earned by Reward Type |
-| :-------------------- | :------------ | :------------------------ |
-| PoC Challenger        | 0.90%         | 15.6250               |
-| PoC Challengees       | 5.02%         | 87.1527               |
-| Witnesses             | 20.08%        | 348.6111              |
-| Consensus Group       | 6%            | 104.1666              |
-| Security Tokens       | 33%           | 572.9166              |
-| Network Data Transfer | _Up to 35%_   | _Up to 607.6389_      |
-| **Total**             | **100%**      | **1736.1111**         |
+| Reward Type           | Percentage      | HNT Earned by Reward Type |
+| :-------------------- | :------------   | :------------------------ |
+| PoC Challenger        | 0.90% - 2.11%   | 15.6250 - 36.6319         |
+| PoC Challengees       | 5.02% - 11.78%  | 87.1527 - 204.5139        |
+| Witnesses             | 20.08% - 47.11% | 348.6111 - 817.8819       |
+| Consensus Group       | 6%              | 104.1666                  |
+| Security Tokens       | 33%             | 572.9166                  |
+| Network Data Transfer | _Up to 35%_     | _Up to 607.6389_          |
+| **Total**             | **100%**        | **1736.1111**             |
 
 **Rewards Change Over Time**
 


### PR DESCRIPTION
Updates the rewards table to reflect range of possible rewards that PoC group can receive if there's an excess of Network Data Transfer tokens.
