### PR TITLE
clarify port forward instructions

### DIFF
--- a/docs/mine-hnt/full-hotspots/become-a-maker/basic-miner-operation.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/basic-miner-operation.mdx
@@ -88,6 +88,8 @@ Docker!
 
 ### Port Forwarding
 
+A quick note on these port forwarding instructions.  For those of you who have a Hotspot and are wondering if you should open these ports on your home router, NO, you should not.  Open these ports ONLY if you're running a cloud miner and a separate packet forwarder.
+
 Before launching the Miner, you will want to configure ports on your network to
 forward two ports:
 


### PR DESCRIPTION
Hotspot owners were finding the instructions to open ports 1680 and wondering if it applied to production Hotspots.