### PR TITLE
Remove 'creating a challenge' wording

### DIFF
--- a/docs/wallets/app-wallet/transfer-hotspot.mdx
+++ b/docs/wallets/app-wallet/transfer-hotspot.mdx
@@ -26,7 +26,7 @@ mining rewards.
 * Parties do not need to be physically next to the Hotspot for transfer to succeed.
 - This feature requires both users to have a valid Helium wallet account
 - The Seller pays the transaction fee of ~55,000 DC.
-- Hotspots must have had Proof-of-Coverage activity (creating a challenge, beaconing, or witnessing) in the last 1200 blocks (approximately 20 hours) in order to be transferred. This is to ensure the Hotspot is fully functional for the protection of the buyer.
+- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) in the last 1200 blocks (approximately 20 hours) in order to be transferred. This is to ensure the Hotspot is fully functional for the protection of the buyer.
 
 :::warning
 


### PR DESCRIPTION
Light hotspots don't create challenges, so that wording has been removed.