### PR TITLE
‘note’ admonitions easier to read

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -327,6 +327,15 @@ a.quicklinkred:hover {
   color: white;
 }
 
+.admonition-note p,
+.admonition-note h5 {
+  color: black;
+}
+
+.admonition-note h5 {
+  font-size: var(--ifm-h5-font-size);
+}
+
 .announcementnav {
   background: #474dff;
   border-radius: 9999px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -370,6 +370,18 @@ a.quicklinkred:hover {
   text-decoration: underline;
 }
 
+.admonition-note a {
+  color: grey;
+  opacity: 0.75;
+  text-decoration: underline;
+}
+
+.admonition-note a:hover {
+  color: lightgray;
+  opacity: 0.75;
+  text-decoration: underline;
+}
+
 a.block {
   display: block;
   width: fit-content;


### PR DESCRIPTION
white text on light grey background is hard to read, changed for higher contrast

![Untitlednotes-before-after](https://user-images.githubusercontent.com/1404219/173166063-068385a5-b195-4472-a8f2-cc9914c8bf19.png)
t