### PR TITLE
Add data transfer as an option for recent activity

### DIFF
--- a/docs/wallets/app-wallet/transfer-hotspot.mdx
+++ b/docs/wallets/app-wallet/transfer-hotspot.mdx
@@ -24,7 +24,7 @@ transferred, the new owner will receive all future Hotspot mining rewards.
 
 - This feature requires both users to have a valid Helium wallet account
 - The Seller pays the transaction fee of ~55,000 DC.
-- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) in the last 1200
+- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) or data transfer activity in the last 1200
   blocks (approximately 20 hours) in order to be transferred. This is to ensure the Hotspot is fully
   functional for the protection of the buyer.
 

--- a/docs/wallets/app-wallet/transfer-hotspot.mdx
+++ b/docs/wallets/app-wallet/transfer-hotspot.mdx
@@ -24,7 +24,9 @@ transferred, the new owner will receive all future Hotspot mining rewards.
 
 - This feature requires both users to have a valid Helium wallet account
 - The Seller pays the transaction fee of ~55,000 DC.
-- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) or data transfer activity in the last 1200
+- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) or Data Transfer
+  activity in the last 1200 blocks (approximately 20 hours) in order to be transferred. This is to
+  ensure the Hotspot is fully functional for the protection of the buyer.
   blocks (approximately 20 hours) in order to be transferred. This is to ensure the Hotspot is fully
   functional for the protection of the buyer.
 


### PR DESCRIPTION
As of the 4.1.1 update, data transfer counts as recent activity to permit hotspot transfers, so that verbiage has been added.