### PR TITLE
Update hotspots.mdx

### DIFF
--- a/docs/api/blockchain/hotspots.mdx
+++ b/docs/api/blockchain/hotspots.mdx
@@ -2102,7 +2102,7 @@ _Query Parameters_
 
 | param               | Type     | Note                                        |
 | ------------------- | -------- | ------------------------------------------- |
-| max_time (required) | _string_ | Last timestamp to include rewards for       |
+| max_time (optional) | _string_ | Last timestamp to include rewards for       |
 | min_time (required) | _string_ | First timestamp to include rewards for      |
 | bucket (optional)   | _string_ | Get data in buckets ( hour / month / week ) |
 


### PR DESCRIPTION
max_time is always optional. Changed "required" to "optional" on GET https://api.helium.io/v1/hotspots/:address/rewards/sum