### PR TITLE
Update transfer-hotspot.mdx

### DIFF
--- a/docs/wallets/app-wallet/transfer-hotspot.mdx
+++ b/docs/wallets/app-wallet/transfer-hotspot.mdx
@@ -14,19 +14,22 @@ owners of the Network to transfer their Hotspots to another owner.
 
 This feature enables Hotspot owners to transfer ownership of a Hotspot to another user. Once
 transferred, the new owner will receive all future Hotspot mining rewards.
+The Helium Wallet app (Black Icon) cannot transfer hotspots between wallets.
+As of today (2nd July 2022) the only app that can manage and transfer hotspots held on 24 word wallets is the Bobber App for Bobcats.
+Do not transfer hotspots to wallets created with 24 words unless the Hotspot Management App supports 24 words.
 
 ### Requirements
 
 - Only the wallet that owns the Hotspot on the blockchain can initiate a transfer.
-- These steps are for Seller with app version 3.10.0
+- These steps are for Seller with Helium Hotspot app (Blue Icon) version 3.10.0 or higher, other vendor Hotspot Management apps will make the same checks. 
 
 * Parties do not need to be physically next to the Hotspot for transfer to succeed.
 
-- This feature requires both users to have a valid Helium wallet account
+- This feature requires both users to have a valid Helium wallet account. 24 word wallets are not supported by the Helium Hotspot App
 - The Seller pays the transaction fee of ~55,000 DC.
-- Hotspots must have had Proof-of-Coverage activity (beaconing or witnessing) or Data Transfer
+- Hotspots must have had LoraWAN Proof-of-Coverage activity (Issued a Broadcast Beacon or Witnessed a valid or invalid Beacon) or performed LoraWAN Data Transfer
   activity in the last 1200 blocks (approximately 20 hours) in order to be transferred. This is to
-  ensure the Hotspot is fully functional for the protection of the buyer.
+  ensure the Hotspot is functioning on the network for the protection of the buyer.
 
 :::warning
 

--- a/docs/wallets/app-wallet/transfer-hotspot.mdx
+++ b/docs/wallets/app-wallet/transfer-hotspot.mdx
@@ -13,29 +13,34 @@ As requested by the Community via HIP13, the Transfer Hotspot feature is availab
 owners of the Network to transfer their Hotspots to another owner.
 
 This feature enables Hotspot owners to transfer ownership of a Hotspot to another user. Once
-transferred, the new owner will receive all future Hotspot mining rewards.
-The Helium Wallet app (Black Icon) cannot transfer hotspots between wallets.
-As of today (2nd July 2022) the only app that can manage and transfer hotspots held on 24 word wallets is the Bobber App for Bobcats.
-Do not transfer hotspots to wallets created with 24 words unless the Hotspot Management App supports 24 words.
+transferred, the new owner will receive all future Hotspot mining rewards. The
+[Helium Wallet app](/wallets/helium-wallet-app) cannot be used to transfer Hotspots between wallets.
+
+Do not transfer hotspots to wallets created with 24 words unless the Hotspot Management App supports
+24 words. If a Hotspot is transferred to a 24-word wallet, you can use the
+[Wallet CLI](/wallets/cli-wallet) to transfer the Hotspot to a 12-word wallet.
 
 ### Requirements
 
 - Only the wallet that owns the Hotspot on the blockchain can initiate a transfer.
-- These steps are for Seller with Helium Hotspot app (Blue Icon) version 3.10.0 or higher, other vendor Hotspot Management apps will make the same checks. 
+- These steps are for Seller with [Helium Hotspot app](/wallets/app-wallet) version 3.10.0 or
+  higher, other vendor Hotspot Management apps will make the same checks.
 
 * Parties do not need to be physically next to the Hotspot for transfer to succeed.
 
-- This feature requires both users to have a valid Helium wallet account. 24 word wallets are not supported by the Helium Hotspot App
+- This feature requires both users to have a valid Helium wallet account. Remember, 24-word wallets
+  are not supported by the Helium Hotspot App.
 - The Seller pays the transaction fee of ~55,000 DC.
-- Hotspots must have had LoraWAN Proof-of-Coverage activity (Issued a Broadcast Beacon or Witnessed a valid or invalid Beacon) or performed LoraWAN Data Transfer
-  activity in the last 1200 blocks (approximately 20 hours) in order to be transferred. This is to
-  ensure the Hotspot is functioning on the network for the protection of the buyer.
+- Hotspots must have had LoraWAN Proof-of-Coverage activity (Issued a Broadcast Beacon or Witnessed
+  a valid or invalid Beacon) or performed LoraWAN Data Transfer activity in the last 1200 blocks
+  (approximately 20 hours) to be transferred. This is to ensure the Hotspot is functioning on the
+  network for the protection of the buyer.
 
 :::warning
 
 Things to keep in mind: Helium assumes no liability on the functionality of Hotspot hardware defined
 in the Transfer Hotspot transaction. Buyers must verify with the Seller the Hotspot is in good,
-working condition and once transferred, understand there is no guarantee that the Hotspot hardware
+working condition and, once transferred, understand there is no guarantee that the Hotspot hardware
 will arrive in working condition.
 
 :::
@@ -72,7 +77,7 @@ will arrive in working condition.
 
 ## As a Buyer:
 
-Once the the transaction clears, a notification will appear in the Buyer’s notification center. The
+Once the transaction clears, a notification will appear in the Buyer’s notification center. The
 Hotspot will then show up in the Buyers wallet. Tap on the notification to view the transaction.
 
 <img src={useBaseUrl('img/wallets/helium-app/transfer-completed-transaction-v2.png')} />


### PR DESCRIPTION
Changes
(1)	State that the transfer hotspot happens in the “Helium Hotspot app” not the “Helium app” and that vendor Apps will make the same checks.
(2)	State that the Helium Wallet App cannot transfer hotspots between wallets
(3)	That as of 2nd July 2022 that only the Bobcat Bobber app can transfer hotspots in 24 word wallets
(4)	add a confirmation that both valid and invalid witnessing counts for activity in this section and use the Explorer terminology of Broadcast Beacon or Witnessed Beacon to this paragraph, and changed added LoraWAN to the requirements
(5)	Change “fully functional” to “functioning on the network”. As if the check is only that it beacons we are not checking it is able to witness or transfer data if the internal antenna cable is disconnected.