### PR TITLE
update wallet link docs to point to helium-js lib

### DIFF
--- a/docs/wallets/app-wallet/deep-links-and-qr-codes.mdx
+++ b/docs/wallets/app-wallet/deep-links-and-qr-codes.mdx
@@ -11,7 +11,8 @@ slug: /wallets/app-wallet/deep-links-and-qr-codes
 
 This page refers to QR codes and deep links that are signed and submitted to the blockchain via the
 Helium Hotspot and Wallet Apps. Makers should not use the following information and instead use the
-[Helium React Native SDK](https://helium.github.io/react-native-helium/modules/WalletLink.html) to
+[Helium React Native SDK](https://helium.github.io/react-native-helium/index.html) and
+[WalletLink](https://helium.github.io/helium-js/modules/wallet_link.html) libraries to
 sign and submit transactions in their maker app.
 
 :::
@@ -87,7 +88,7 @@ https://wallet.helium.com/payment?payee={{payee}}&amount={{amount}}&memo={{memo}
 The Wallet App requires a maker app in order to sign Add Gateway, Assert Location, and Transfer
 Hotspot Transactions via deep links. Please see the
 [Helium React Native SDK](https://helium.github.io/react-native-helium/index.html) and
-[WalletLink](https://helium.github.io/react-native-helium/modules/WalletLink.html) documentation for
+[WalletLink](https://helium.github.io/helium-js/modules/wallet_link.html) documentation for
 more information.
 
 ## Internal QR Scanner


### PR DESCRIPTION
The WalletLink library was moved to the helium-js package at https://helium.github.io/helium-js/modules/wallet_link.html

This updates the links to the docs.