### PR TITLE
Correct the Indoor and Outdoor Small Cell Brand

### DIFF
--- a/docs/5g-on-helium/mining-5g.mdx
+++ b/docs/5g-on-helium/mining-5g.mdx
@@ -117,8 +117,8 @@ they are indoor or outdoor, as well as their power output, as follows:
 | :-------------- | :-----------: | :-------------------- |
 | Nova 436H       |     2.0x      | High Power Outdoor    |
 | Nova 430i       |     1.5x      | Outdoor               |
-| Sercomm Outdoor |     1.5x      | Outdoor               |
-| Sercomm Indoor  |     1.0x      | Indoor                |
+| MosoLabs Outdoor |     1.5x      | Outdoor               |
+| MosoLabs/FreedomFi Indoor  |     1.0x      | Indoor                |
 | Neutrino 430    |     1.0x      | Indoor                |
 
 Individual rewards per period are calculated as a proportion of the total weighted reward units.


### PR DESCRIPTION
In "Small Cell Radio Reward Scaling" table:
Change Sercomm Indoor -> MosoLabs/FreedomFi Indoor
Change Sercomm Outdoor -> MosoLabs Outdoor