### PR TITLE
Update mining-5g.mdx

### DIFF
--- a/docs/5g-on-helium/mining-5g.mdx
+++ b/docs/5g-on-helium/mining-5g.mdx
@@ -130,11 +130,11 @@ they are indoor or outdoor, as well as their power output, as follows:
 
 | Small Cell Radio Model      | Reward Weight | Small Cell Radio Type |
 | :-------------------------- | :-----------: | :-------------------- |
-| Baicells Nova 436H          |     2.0x      | High-Power Outdoor    |
-| Baicells Nova 430i          |     1.5x      | Outdoor               |
-| MosoLabs Outdoor Small Cell |     1.5x      | Outdoor               |
-| FreedomFi Indoor Small Cell |     1.0x      | Indoor                |
-| MosoLabs Indoor Small Cell  |     1.0x      | Indoor                |
+| Baicells Nova 436H          |     4.0x      | High-Power Outdoor    |
+| Baicells Nova 430i          |     2.5x      | Outdoor               |
+| MosoLabs Outdoor Small Cell |     2.5x      | Outdoor               |
+| FreedomFi/MosoLabs          |     1.0x      | Indoor                |
+| Indoor Small Cell           |               |                       |
 | Baicells Neutrino 430H      |     1.0x      | Indoor                |
 
 Individual rewards per period are calculated as a proportion of the total weighted reward units.


### PR DESCRIPTION
Request from Nova Labs:
Due to complexity of installation of high power outdoor cells and larger areа they cover with signal, we've decided that it would be more fair to have the following rewards weights 1:2.5:4  instead of 1:1.5:2.