### PR TITLE
Remove syncing terminology from 5g mining page

### DIFF
--- a/docs/5g-on-helium/mining-5g.mdx
+++ b/docs/5g-on-helium/mining-5g.mdx
@@ -99,9 +99,9 @@ pre-mined MOBILE tokens. MOBILE tokens will be redeemable for HNT after the Gene
 
 :::
 
-Once a 5G Hotspot is completely deployed, you as the
-owner are not required to do anything else to earn MOBILE. Your 5G Hotspot will perform all of its
-activities on its own and will be rewarded for maintaining a valid connection to the SAS.
+Once a 5G Hotspot is completely deployed, you as the owner are not required to do anything else to
+earn MOBILE. Your 5G Hotspot will perform all of its activities on its own and will be rewarded for
+maintaining a valid connection to the SAS.
 
 ## Emissions Curve
 

--- a/docs/5g-on-helium/mining-5g.mdx
+++ b/docs/5g-on-helium/mining-5g.mdx
@@ -99,7 +99,7 @@ pre-mined MOBILE tokens. MOBILE tokens will be redeemable for HNT after the Gene
 
 :::
 
-Once a 5G Hotspot is completely deployed and fully synced with the Helium Blockchain, you as the
+Once a 5G Hotspot is completely deployed, you as the
 owner are not required to do anything else to earn MOBILE. Your 5G Hotspot will perform all of its
 activities on its own and will be rewarded for maintaining a valid connection to the SAS.
 


### PR DESCRIPTION
With the light hotspot upgrade, hotspots no longer need to be synced with the Helium Blockchain.
Therefore I suggest removing the text that tells a hotspot needs to be synced in order to start earning MOBILE tokens.