### PR TITLE
Init vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.rulers": [100],
+  "editor.wordWrap": "off"
+}


### PR DESCRIPTION
Before:
default soft wrap doesn't align with the linter preference.
<img width="1334" alt="image" src="https://user-images.githubusercontent.com/1965053/184157119-88ebc10e-ed62-4d94-a3b5-540470119688.png">


After:
do not soft wrap. provide a ruler for linter preferred line length
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/1965053/184156901-753e5850-5ab9-4689-8eef-1587ec9ea519.png">
