### PR TITLE
Remove Port Forwarding Info

### DIFF
--- a/docs/faq/security.mdx
+++ b/docs/faq/security.mdx
@@ -12,9 +12,8 @@ connection is necessary, it is only used to provide backhaul to the Hotspot for 
 peer-to-peer and LongFi networking. As security concerns are ever present, here is what we have
 done, and are doing, to combat potential risks:
 
-- The most common attack vector to get into a device like the Hotspot is inbound ports. The Helium
-  Hotspot only requires one port open in both directions - **TCP Port 44158**. All other inbound
-  ports can be secured behind a firewall per your personal security needs.
+- The most common attack vector to get into a device like the Hotspot is inbound ports. As of May
+  2022, the Helium Hotspot no longer requires any inbound ports to be open or forwarded.
 - Helium-enabled LoRaWAN devices are hardware-secured to protect the traffic from the utilized
   spectrum. This means the security is built-in since devices using the network have AES private key
   encryption at the chip level.


### PR DESCRIPTION
Since port forwarding is no longer needed, this security document should be updated accordingly. Feel free to make any other necessary changes as part of this PR.