### PR TITLE
Update data-credits.mdx hotspot owner/user distinction

### DIFF
--- a/docs/faq/data-credits.mdx
+++ b/docs/faq/data-credits.mdx
@@ -9,12 +9,15 @@ slug: /faq/data-credits
 
 ### What are Data Credits? Do I need them?
 
-If you’re a Hotspot owner, you generally do not need to worry about
-[Data Credits](/blockchain/helium-token/#data-credits-and-burn-and-mint-economics) unless you also
-plan to build sensors and devices to transmit data. Data Credits are
-[used to pay all transaction fees](/blockchain/transaction-fees/#transaction-fees) such as adding
-Hotspots, sending HNT, and asserting location. When needed, they are burned automatically through
+If you’re a Hotspot owner, you do not need to worry about holding individual 
+[Data Credits](/blockchain/helium-token/#data-credits-and-burn-and-mint-economics).
+
+Data Credits for hotspot owners are created on-demand through implicit burn and 
+[used to pay all hotspot transaction fees](/blockchain/transaction-fees/#transaction-fees) such as adding
+Hotspots, sending HNT, and asserting location. These data credits are burned automatically through
 the app from the available HNT in your wallet and can also be burned via the CLI.
+
+For sensor users/developers who wish to transmit data (LoRaWAN/LongFi/etc) via the Helium Network your transactions will require the use of discrete Data Credits held in a Helium Console account.  
 
 One Data Credit pays for 24 bytes of LoRaWAN payload. Any number that exceeds 24 bytes is rounded
 up, so a packet with a 25-byte payload would cost the same as one with 47 bytes - two Data Credits.

--- a/docs/faq/data-credits.mdx
+++ b/docs/faq/data-credits.mdx
@@ -9,19 +9,27 @@ slug: /faq/data-credits
 
 ### What are Data Credits? Do I need them?
 
-If you’re a Hotspot owner, you do not need to worry about holding individual 
+If you’re a Hotspot owner, you do not need to worry about holding individual
 [Data Credits](/blockchain/helium-token/#data-credits-and-burn-and-mint-economics).
 
-Data Credits for hotspot owners are created on-demand through implicit burn and 
-[used to pay all hotspot transaction fees](/blockchain/transaction-fees/#transaction-fees) such as adding
-Hotspots, sending HNT, and asserting location. These data credits are burned automatically through
-the app from the available HNT in your wallet and can also be burned via the CLI.
+Data Credits for Hotspot owners are created on-demand through the implicit burn mechanism and
+[used to pay all Hotspot transaction fees](/blockchain/transaction-fees/#transaction-fees) such as
+adding Hotspots, sending HNT, and asserting location. These Data Credits are burned automatically
+from the available HNT in your wallet or by the CLI.
 
-For sensor users/developers who wish to transmit data (LoRaWAN/LongFi/etc) via the Helium Network your transactions will require the use of discrete Data Credits held in a Helium Console account.  
+Device users and developers who wish to transmit data via the Helium Network, your transactions will
+require the use of discrete Data Credits held in a Helium Console account.
 
-One Data Credit pays for 24 bytes of LoRaWAN payload. Any number that exceeds 24 bytes is rounded
-up, so a packet with a 25-byte payload would cost the same as one with 47 bytes - two Data Credits.
+One Data Credit pays for 24 bytes of LoRaWAN payload. Payloads exceeding 24 bytes are rounded up to
+the next 24 bytes, so a packet with a 25-byte payload would cost two Data Credits, the same as one
+with 48 bytes.
 
-Although Data Credits are produced by burning HNT, the price of Data Credits is fixed in USD. Data
-Credits are non-transferrable, and can only be used by their original owner. Data Credits cannot be
-re-sold or traded. Data Credits are similar to pre-paid cellphone minutes or airline miles.
+Although Data Credits are produced by burning HNT, the price of a Data Credit is fixed in USD. Data
+Credits are non-transferable and are only usable by their original owner. Data Credits cannot be
+re-sold or traded.
+
+:::info
+
+Data Credits are similar to pre-paid cellphone minutes or airline miles.
+
+:::


### PR DESCRIPTION
Novice attempt to clarify that the data credits for developers or sensor users cannot be used for any hotspot transactions