### PR TITLE
Chain following is done -- remove descriptor limit

### DIFF
--- a/docs/mine-hnt/full-hotspots/become-a-maker/docker-integration.mdx
+++ b/docs/mine-hnt/full-hotspots/become-a-maker/docker-integration.mdx
@@ -139,21 +139,3 @@ Docker container. For example:
 You'll want to install
 [the Miner's DBus config](https://github.com/helium/miner/blob/master/config/com.helium.Miner.conf),
 typically at: `/etc/dbus-1/system.d/com.helium.Miner.conf`
-
-## Setting the ulimit
-
-Ensure the ulimit system is set to a _minimum_ of `64000`; anything lower will be insufficient but
-more is welcome.
-
-You'll want to include the Docker run argument `--ulimit nofile=64000:64000`.
-
-**In addition**, you'll need to verify that your Linux system allows for such file limits. For
-example,
-
-```bash
-$ ulimit -Sn
-64000
-```
-
-If the host system does not allow for 64,000 file handles, then the `docker run` argument will not
-be sufficient.


### PR DESCRIPTION
The directive to artificially expand the number of file descriptors available to the miner image is no longer needed. It is an artifact of earlier days, when each miner had to follow the blockchain, block for block. With the current hybrid approach and future Light Hotspot approach this is no longer necessary.