### PR TITLE
Update frequency-plans.mdx

### DIFF
--- a/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
+++ b/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
@@ -144,27 +144,27 @@ frequency plan for use in your country.
 
 #### A <a id="a"></a>
 
-| Country                 | Frequency Plan |
-| ----------------------- | -------------- |
-| Afghanistan             | Unknown        |
-| Aland Islands           | EU868          |
-| Albania                 | EU868          |
-| Algeria                 | AS923_3        |
-| American Samoa          | US915          |
-| Andorra                 | EU868          |
-| Angola                  | Unknown        |
-| Anguilla                | AU915          |
-| Antarctica - Chilean    | AU915          |
-| Antarctica - Australian | AU915          |
-| Antarctica - British    | EU868          |
-| Antarctica - Argentine  | AU915          |
-| Antigua and Barbuda     | Unknown        |
-| Argentina               | AU915          |
-| Armenia                 | EU868          |
-| Aruba                   | Unknown        |
-| Australia               | AS923-1/AU915 dualplan       |
-| Austria                 | EU868          |
-| Azerbaijan              | EU433          |
+| Country                 | Frequency Plan         |
+| ----------------------- | ---------------------- |
+| Afghanistan             | Unknown                |
+| Aland Islands           | EU868                  |
+| Albania                 | EU868                  |
+| Algeria                 | AS923_3                |
+| American Samoa          | US915                  |
+| Andorra                 | EU868                  |
+| Angola                  | Unknown                |
+| Anguilla                | AU915                  |
+| Antarctica - Chilean    | AU915                  |
+| Antarctica - Australian | AU915                  |
+| Antarctica - British    | EU868                  |
+| Antarctica - Argentine  | AU915                  |
+| Antigua and Barbuda     | Unknown                |
+| Argentina               | AU915                  |
+| Armenia                 | EU868                  |
+| Aruba                   | Unknown                |
+| Australia               | AS923-1/AU915 dualplan |
+| Austria                 | EU868                  |
+| Azerbaijan              | EU433                  |
 
 #### B <a id="b"></a>
 
@@ -180,7 +180,7 @@ frequency plan for use in your country.
 | Benin                           | EU868          |
 | Bermuda                         | US915          |
 | Bhutan                          | EU868          |
-| Bolivia                         | AS923_1          |
+| Bolivia                         | AS923_1        |
 | Bonaire Sint Eustatius and Saba | EU868          |
 | Bosnia and Herzegovina          | EU868          |
 | Botswana                        | EU868          |
@@ -195,31 +195,31 @@ frequency plan for use in your country.
 
 #### C <a id="c"></a>
 
-| Country                  | Frequency Plan |
-| ------------------------ | -------------- |
-| Cambodia                 | AS923_1        |
-| Cameroon                 | EU433          |
-| Canada                   | US915          |
-| Cape Verde               | EU868          |
-| Cayman Islands           | US915          |
-| Central African Republic | Unknown        |
-| Chad                     | Unknown        |
-| Chile                    | AU915          |
-| China                    | CN470          |
-| Christmas Island         | AS923-1/AU915 dualplan       |
-| Cocos [Keeling] Islands  | AS923-1/AU915 dualplan       |
-| Colombia                 | AU915          |
-| Comoros                  | EU868          |
-| Congo [DRC]              | Unknown        |
-| Congo [Republic]         | Unknown        |
-| Cook Islands             | AS923-1/AU915 dualplan       |
-| Costa Rica               | AS923_1        |
-| Côte d'Ivoire            | EU868          |
-| Croatia                  | EU868          |
-| Cuba                     | AS923_3        |
-| Curaçao                  | AS923_1        |
-| Cyprus                   | EU868          |
-| Czech Republic           | EU868          |
+| Country                  | Frequency Plan         |
+| ------------------------ | ---------------------- |
+| Cambodia                 | AS923_1                |
+| Cameroon                 | EU433                  |
+| Canada                   | US915                  |
+| Cape Verde               | EU868                  |
+| Cayman Islands           | US915                  |
+| Central African Republic | Unknown                |
+| Chad                     | Unknown                |
+| Chile                    | AU915                  |
+| China                    | CN470                  |
+| Christmas Island         | AS923-1/AU915 dualplan |
+| Cocos [Keeling] Islands  | AS923-1/AU915 dualplan |
+| Colombia                 | AU915                  |
+| Comoros                  | EU868                  |
+| Congo [DRC]              | Unknown                |
+| Congo [Republic]         | Unknown                |
+| Cook Islands             | AS923-1/AU915 dualplan |
+| Costa Rica               | AS923_1                |
+| Côte d'Ivoire            | EU868                  |
+| Croatia                  | EU868                  |
+| Cuba                     | AS923_3                |
+| Curaçao                  | AS923_1                |
+| Cyprus                   | EU868                  |
+| Czech Republic           | EU868                  |
 
 #### D <a id="d"></a>
 
@@ -280,13 +280,13 @@ frequency plan for use in your country.
 
 #### H <a id="h"></a>
 
-| Country                           | Frequency Plan |
-| --------------------------------- | -------------- |
-| Haiti                             | Unknown        |
-| Heard Island and McDonald Islands | AS923-1/AU915 dualplan       |
-| Honduras                          | AU915          |
-| Hong Kong                         | AS923_1        |
-| Hungary                           | EU868          |
+| Country                           | Frequency Plan         |
+| --------------------------------- | ---------------------- |
+| Haiti                             | Unknown                |
+| Heard Island and McDonald Islands | AS923-1/AU915 dualplan |
+| Honduras                          | AU915                  |
+| Hong Kong                         | AS923_1                |
+| Hungary                           | EU868                  |
 
 #### I <a id="i"></a>
 
@@ -366,23 +366,23 @@ frequency plan for use in your country.
 
 #### N <a id="n"></a>
 
-| Country                  | Frequency Plan |
-| ------------------------ | -------------- |
-| Namibia                  | EU868          |
-| Nauru                    | Unknown        |
-| Nepal                    | Unknown        |
-| Netherlands              | EU868          |
-| Netherlands Antilles     | EU868          |
-| New Caledonia            | EU868          |
-| New Zealand              | AS923-1/AU915 dualplan       |
-| Nicaragua                | AU915          |
-| Niger                    | IN865          |
-| Nigeria                  | EU868          |
-| Niue                     | AS923-1/AU915 dualplan       |
-| Norfolk Island           | AS923-1/AU915 dualplan       |
-| North Korea              | Unknown        |
-| Northern Mariana Islands | US915          |
-| Norway                   | EU868          |
+| Country                  | Frequency Plan         |
+| ------------------------ | ---------------------- |
+| Namibia                  | EU868                  |
+| Nauru                    | Unknown                |
+| Nepal                    | Unknown                |
+| Netherlands              | EU868                  |
+| Netherlands Antilles     | EU868                  |
+| New Caledonia            | EU868                  |
+| New Zealand              | AS923-1/AU915 dualplan |
+| Nicaragua                | AU915                  |
+| Niger                    | IN865                  |
+| Nigeria                  | EU868                  |
+| Niue                     | AS923-1/AU915 dualplan |
+| Norfolk Island           | AS923-1/AU915 dualplan |
+| North Korea              | Unknown                |
+| Northern Mariana Islands | US915                  |
+| Norway                   | EU868                  |
 
 #### O <a id="o"></a>
 
@@ -392,20 +392,20 @@ frequency plan for use in your country.
 
 #### P <a id="p"></a>
 
-| Country                 | Frequency Plan |
-| ----------------------- | -------------- |
-| Pakistan                | AS923          |
-| Palau                   | Unknown        |
-| Palestinian Territories | Unknown        |
-| Panama                  | AU915          |
-| Papua New Guinea        | AS923-1/AU915 dualplan       |
-| Paraguay                | AU915          |
-| Peru                    | AU915          |
-| Philippines             | AS923_3        |
-| Pitcairn Islands        | Unknown        |
-| Poland                  | EU868          |
-| Portugal                | EU868          |
-| Puerto Rico             | US915          |
+| Country                 | Frequency Plan         |
+| ----------------------- | ---------------------- |
+| Pakistan                | AS923                  |
+| Palau                   | Unknown                |
+| Palestinian Territories | Unknown                |
+| Panama                  | AU915                  |
+| Papua New Guinea        | AS923-1/AU915 dualplan |
+| Paraguay                | AU915                  |
+| Peru                    | AU915                  |
+| Philippines             | AS923_3                |
+| Pitcairn Islands        | Unknown                |
+| Poland                  | EU868                  |
+| Portugal                | EU868                  |
+| Puerto Rico             | US915                  |
 
 #### Q <a id="q"></a>
 
@@ -463,22 +463,22 @@ frequency plan for use in your country.
 
 #### T <a id="t"></a>
 
-| Country                  | Frequency Plan |
-| ------------------------ | -------------- |
-| Taiwan                   | AS923_1        |
-| Tajikistan               | Unknown        |
-| Tanzania                 | AS923_1        |
-| Thailand                 | AS923_1        |
-| Timor-Leste              | Unknown        |
-| Togo                     | EU433          |
-| Tokelau                  | AS923-1/AU915 dualplan       |
-| Tonga                    | AU915          |
-| Trinidad and Tobago      | AU915          |
-| Tunisia                  | EU868          |
-| Turkey                   | EU868          |
-| Turkmenistan             | Unknown        |
-| Turks and Caicos Islands | AU915          |
-| Tuvalu                   | Unknown        |
+| Country                  | Frequency Plan         |
+| ------------------------ | ---------------------- |
+| Taiwan                   | AS923_1                |
+| Tajikistan               | Unknown                |
+| Tanzania                 | AS923_1                |
+| Thailand                 | AS923_1                |
+| Timor-Leste              | Unknown                |
+| Togo                     | EU433                  |
+| Tokelau                  | AS923-1/AU915 dualplan |
+| Tonga                    | AU915                  |
+| Trinidad and Tobago      | AU915                  |
+| Tunisia                  | EU868                  |
+| Turkey                   | EU868                  |
+| Turkmenistan             | Unknown                |
+| Turks and Caicos Islands | AU915                  |
+| Tuvalu                   | Unknown                |
 
 #### U <a id="u"></a>
 

--- a/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
+++ b/docs/lorawan-on-helium/frequency-plans/frequency-plans.mdx
@@ -162,7 +162,7 @@ frequency plan for use in your country.
 | Argentina               | AU915          |
 | Armenia                 | EU868          |
 | Aruba                   | Unknown        |
-| Australia               | AS923/AU915 dualplan         |
+| Australia               | AS923-1/AU915 dualplan       |
 | Austria                 | EU868          |
 | Azerbaijan              | EU433          |
 
@@ -206,13 +206,13 @@ frequency plan for use in your country.
 | Chad                     | Unknown        |
 | Chile                    | AU915          |
 | China                    | CN470          |
-| Christmas Island         | AU915          |
-| Cocos [Keeling] Islands  | AU915          |
+| Christmas Island         | AS923-1/AU915 dualplan       |
+| Cocos [Keeling] Islands  | AS923-1/AU915 dualplan       |
 | Colombia                 | AU915          |
 | Comoros                  | EU868          |
 | Congo [DRC]              | Unknown        |
 | Congo [Republic]         | Unknown        |
-| Cook Islands             | AU915          |
+| Cook Islands             | AS923-1/AU915 dualplan       |
 | Costa Rica               | AS923_1        |
 | Côte d'Ivoire            | EU868          |
 | Croatia                  | EU868          |
@@ -283,7 +283,7 @@ frequency plan for use in your country.
 | Country                           | Frequency Plan |
 | --------------------------------- | -------------- |
 | Haiti                             | Unknown        |
-| Heard Island and McDonald Islands | AU915          |
+| Heard Island and McDonald Islands | AS923-1/AU915 dualplan       |
 | Honduras                          | AU915          |
 | Hong Kong                         | AS923_1        |
 | Hungary                           | EU868          |
@@ -374,12 +374,12 @@ frequency plan for use in your country.
 | Netherlands              | EU868          |
 | Netherlands Antilles     | EU868          |
 | New Caledonia            | EU868          |
-| New Zealand              | AU915          |
+| New Zealand              | AS923-1/AU915 dualplan       |
 | Nicaragua                | AU915          |
 | Niger                    | IN865          |
 | Nigeria                  | EU868          |
-| Niue                     | AU915          |
-| Norfolk Island           | AU915          |
+| Niue                     | AS923-1/AU915 dualplan       |
+| Norfolk Island           | AS923-1/AU915 dualplan       |
 | North Korea              | Unknown        |
 | Northern Mariana Islands | US915          |
 | Norway                   | EU868          |
@@ -398,7 +398,7 @@ frequency plan for use in your country.
 | Palau                   | Unknown        |
 | Palestinian Territories | Unknown        |
 | Panama                  | AU915          |
-| Papua New Guinea        | AU915          |
+| Papua New Guinea        | AS923-1/AU915 dualplan       |
 | Paraguay                | AU915          |
 | Peru                    | AU915          |
 | Philippines             | AS923_3        |
@@ -471,7 +471,7 @@ frequency plan for use in your country.
 | Thailand                 | AS923_1        |
 | Timor-Leste              | Unknown        |
 | Togo                     | EU433          |
-| Tokelau                  | AU915          |
+| Tokelau                  | AS923-1/AU915 dualplan       |
 | Tonga                    | AU915          |
 | Trinidad and Tobago      | AU915          |
 | Tunisia                  | EU868          |


### PR DESCRIPTION
Updated the following to the AS923/AU915 Dual plan region as default region in https://github.com/dewi-alliance/hplans/blob/main/regions.csv Christmas Island 
Cocos [Keeling] Islands 
Cook Islands 
Heard Island and McDonald Islands 
New Zealand
Niue 
Norfolk Island 
Papua New Guinea 
Tokelau