### PR TITLE
Fix "depreciation" typos

### DIFF
--- a/docs/mine-hnt/helium-hotspot-app.mdx
+++ b/docs/mine-hnt/helium-hotspot-app.mdx
@@ -1,6 +1,6 @@
 ---
 id: helium-hotspot-app
-title: Helium Hotspot App (Is Being Depreciated)
+title: Helium Hotspot App (Is Being Deprecated)
 pagination_label: Helium Hotspot App
 sidebar_label: 🚫 Helium Hotspot App 🚫
 description: Helium Documentation

--- a/docs/wallets/wallets.mdx
+++ b/docs/wallets/wallets.mdx
@@ -103,7 +103,7 @@ Some users may know "the Helium app" as the "Helium Hotspot App" or "the blue ap
 
 The existing Helium Hotspot app will be restricted to only the management of Original Helium
 Hotspots. Read more about this upcomging change on the
-[Helium Hotspot App (is Being Depreciated)](/mine-hnt/helium-hotspot-app) page.
+[Helium Hotspot App (is Being Deprecated)](/mine-hnt/helium-hotspot-app) page.
 
 :::
 


### PR DESCRIPTION
We're marking old software as obsolete, not writing off old assets on our taxes