### PR TITLE
Fix installation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation for the Helium network.
 
 ## Installation
 
-- [Installation Guide](https://docs.helium.com/open-source/docs/installation/)
+- [Installation Guide](https://docs.helium.com/open-source/docs-installation/)
 
 ## Contributing
 


### PR DESCRIPTION
The documentation for installing the documentation has a bug. This commit fixes that bug, allowing one to accurately deploy a test instance of the documentation.