### PR TITLE
remove default filter from docs as it is provided by CLI

### DIFF
--- a/docs/use-the-network/run-a-network-server/buy-an-oui.mdx
+++ b/docs/use-the-network/run-a-network-server/buy-an-oui.mdx
@@ -58,7 +58,7 @@ least US$900 in HNT (based on current HNT Oracle pricing).
 Submit a "create OUI" transaction:
 
 ```bash
-./helium-wallet oui create --subnet-size 8 --filter wVwCiewtCpEKAAAAAAAAAAAAcCK3fwAAAAAAAAAAAABI7IQOAHAAAAAAAAAAAAAAAQAAADBlAAAAAAAAAAAAADEAAAA2AAAAOgAAAA
+./helium-wallet oui create --subnet-size 8
 ```
 
 The filter is a dummy filter to initialize the OUI. When you get Console running, it will


### PR DESCRIPTION
It was reported that the most helium-wallet master branch no longer tolerates unpadded base64 when expecting base64 input.

Furthermore, the helium-wallet provides a default filter, so the user does not have to provide an empty filter anymore and the CLI will do this itself.