### PR TITLE
Add python downlink example, minor cleaning

### DIFF
--- a/docs/blockchain/oracles.mdx
+++ b/docs/blockchain/oracles.mdx
@@ -44,7 +44,7 @@ Every `10` blocks (roughly every 10 minutes) the blockchain will attempt to esta
 
 **What's the current HNT Oracle Price?**
 
-- [Click here.](https://api.helium.io/v1/oracle/prices/current)
+- [HNT Oracle Price at api.helium.io](https://api.helium.io/v1/oracle/prices/current)
 
 ### Who are the HNT Price Oracles?
 

--- a/docs/use-the-network/console/functions.mdx
+++ b/docs/use-the-network/console/functions.mdx
@@ -15,24 +15,25 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 You can now execute functions on Console! With the Decoder Function, users can transform and/or
 parse a raw payload before it is posted to an endpoint.
 
-When a Decoder Function is applied to a device or integration the Decoder Function code is executed
-on the payload sent by the device. The Decoder Function can be written using custom JavaScript code
+When a Decoder Function is applied to a device or integration, the Decoder Function code is executed
+on the payload sent by the device, and the result is passed to the Integration. 
+The Decoder Function can be written using custom JavaScript code
 provided by the user or selected from prebuilt decoders \(currently Browan Object Locator and
 Cayenne LPP\).
 
 Console decoders are compatible with The Things Network \(TTN\) decoders, which are already
 available for a wide variety of devices.
 
-In addition, to providing a custom decoder a growing list of community-created functions can be
-found [here](https://github.com/helium/console-decoders).
+In addition to creating a custom decoder, Helium maintains a [growing list of community-created
+functions](https://github.com/helium/console-decoders).
 
-For more information on how to create and attach functions, check out our Tips and Tricks video
-[here](https://youtu.be/UNUOLbIKXww).
+For more information on how to create and attach functions, check out our
+[Tips and Tricks video](https://youtu.be/UNUOLbIKXww).
 
 ## A Primer on Encoding and Decoding
 
-LoRaWAN networks are, by design, low bandwidth. This means that we must make the very most out of
-every byte that we send over the air. This also means that we shouldn't send inefficient types like
+LoRaWAN networks are, by design, low bandwidth. Thus, developers make the most out of
+every byte sent over the air. Developers also shouldn't send inefficient types like
 characters and strings. For example, to represent a single English letter with the widely used ASCII
 encoding standard, you have to use an entire byte. This makes sense if your data can only be stored
 as English words, but in the case of IoT devices, there is often only the need to store numeric
@@ -43,16 +44,18 @@ device data such as
 
 These types of standards allow you to easily encode your data much more efficiently. Once your data
 has been received over the air by the network, there is no longer the necessity of encoding the data
-with a standard that can make it more challenging for humans to interpret. This is where Function
-Decoders come in. They allow you to decode your device data so that you can interpret it for
-debugging issues or translate it before sending it to your application or another service.
+with a standard that can make it more challenging for humans to interpret.
+
+**Function Decoders** allow you to decode your device data within the Helium Console so that you
+can interpret it for debugging issues and/or translate \(decode\) it before sending it to your
+application/service via an Integration \(e.g., HTTP\).
 
 ## Creating a Decoder Function
 
 :::info **Decoder Library on GitHub**
 
 If you have purchased an off-the-shelf device, it is likely that there already exists a decoder you
-can use! We have a [repository ](https://github.com/helium/console-decoders)that contains decoders
+can use! We have a [repository](https://github.com/helium/console-decoders) that contains decoders
 for a number of popular devices.
 
 :::
@@ -106,12 +109,11 @@ field. An example of the decoded field is shown below.
 
 You need to attach functions to:
 
-- a device or a group of devices (via a label): This results in the function only being applied to
+- a device or a group of devices (via a label): the function is only applied to
   the device payload in the Debug utility.
 
-- a device or group of devices (via a label) and an integration: This results in the function being
+- a device or group of devices (via a label) and an integration: the function is
   applied to payloads before being sent to the integration.
 
-Easily attach functions to devices, labels, and integations in the Flows Workspace. For more
-information about Flows click here
-[https://docs.helium.com/use-the-network/console/flows](/use-the-network/console/flows/)
+Easily attach functions to devices, labels, and integations in the
+[Flows Workspace](/use-the-network/console/flows).

--- a/docs/use-the-network/console/integrations/http.mdx
+++ b/docs/use-the-network/console/integrations/http.mdx
@@ -22,34 +22,34 @@ in this case, the **HTTP** integration.
 The next step is to paste the HTTP endpoint.
 
 If you're still testing, you can find popular sites that can create HTTP endpoints for you and
-inspect packets. [Requestbin](https://www.requestbin.com) and [Beeceptor](https://www.beeceptor.com)
+inspect packets. [Requestbin](https://requestbin.com) and [Beeceptor](https://www.beeceptor.com)
 provide tools to make an HTTP endpoint quickly and easily.
 
 ### Uplink \(Receive Data from Device\)
 
-Uplink refers to your device sending data to be received by the network. With regards to the HTTP
-integration, this will be the device data that is sent to your HTTP endpoint of choice.
+Uplinking refers to your device sending data to be received by the network. For the HTTP
+integration, this will be the data from the device that is sent to your HTTP endpoint of choice.
 
 ### RequestBin Example
 
-Create an endpoint by going to requestbin.com and click **Create a Request Bin**. Once created, copy
+Create an endpoint by going to [requestbin.com](https://requestbin.com/) and click **Create a Request Bin**. Once created, copy
 the endpoint.
 
 <img
   src={useBaseUrl('img/use-the-network/console/integrations/integrations-http-request-bin.png')}
 />
 
-... and paste it in Console.
+... and paste it in Console's **Endpoint URL** field.
 
 <img src={useBaseUrl('img/use-the-network/console/integrations/integrations-http-details.png')} />
 
-**HTTP Header** and **Value** are not required and those can be left blank.
+**HTTP Header** and **Value** are not required, and can be left blank.
 
 Lastly, provide a name for the integration. Names do not have to be unique.
 
 Click **Add Integration**.
 
-Your new integration is now ready for use! Please read about the JSON schema to understand how to
+Your new integration is now ready for use! Please read about the [JSON Schema](/use-the-network/console/integrations/json-schema) to understand how to
 parse data received.
 
 ### Integration Details
@@ -121,16 +121,16 @@ shown below, see more details on the fields
 
 The easiest way to send a downlink to your device is to use the built-in downlink tool in Console.
 You will find it on the right side of every device page, as shown below. In order to use the
-downlink tool, you must have an HTTP integration attached to the device.
+downlink tool, you must have an HTTP Integration attached to the device.
 
 <img
   src={useBaseUrl('img/use-the-network/console/integrations/integrations-http-downlink-button.png')}
 />
 
-Once you have the downlink tool open, you can input the downlink payload string in the payload
+Once you have the downlink tool open, input the downlink payload string in the payload
 field. Select _Encoded_ if you are inputting a string that is already Base64 encoded, and _Plain_ if
-it is plain text. Last, select your Fport, whether or not you want to send a confirmed downlink, and
-click the downlink send button as shown below.
+it is plain text. Last, select your FPort, whether or not you want to send a confirmed downlink, and
+then click the downlink send button, as shown below.
 
 <img
   src={useBaseUrl(
@@ -158,7 +158,7 @@ downlink message to your device.
 4. Select `raw` as your body type.
 5. Select `JSON` as the body format.
 6. Enter your JSON message with the required fields.
-7. Finally press `Send` to transmit the message.
+7. Finally, press `Send` to transmit the message.
 8. You should see a response of `Downlink scheduled` if successful.
 
 <img
@@ -166,6 +166,42 @@ downlink message to your device.
     'img/use-the-network/console/integrations/integrations-http-downlink-postman-example.png',
   )}
 />
+
+### Python Example
+
+Python is a popular programming language. The following code generates a request to the Helium 
+Network to downlink data to a device.
+
+```python
+import requests
+import base64
+
+# copy the Device ID from the Device page in the Helium Console
+device_id = '...'
+
+# copy the Downlink URL from the Helium Console (HTTP Integration), replacing "{:optional_device_id}" with "+ device_id"
+url = f'https://console.helium.com/api/v1/down/a0a0a0a0-10a0-1018-a0a0-a0a0a0a0a0a0/asdfasdfasdf_asdfasdfasdfasdf/' + device_id
+
+payload_str = 'TEST'
+payload_b64 = base64.b64encode(payload_str.encode('utf-8')).decode('ascii')
+
+print(f"Payload (base64): {payload_b64}")
+
+data = {
+	"payload_raw": payload_b64,
+	"port": 1,
+	"confirmed": True,
+}
+
+r = requests.post(url, json=data)
+
+print(f"HTTP Response: {r}. Text: {r.text}")
+
+# data appears as hex on receiver-side (on many units)
+import binascii
+print(f"Received client-side hex: {binascii.hexlify(payload_str.encode('utf-8')).decode('ascii').upper()}")
+
+```
 
 ## Connecting Integrations to Devices
 
@@ -182,8 +218,7 @@ Quick video tutorial connecting devices to an integration
 :::
 
 Node elements (devices, labels, integrations) need to be created before they're available on the
-Flows Workspace. More information about Flows
-[here](https://docs.helium.com/use-the-network/console/flows/).
+[Flows Workspace](/use-the-network/console/flows).
 
 ## Advanced - JSON Message Template
 
@@ -194,13 +229,14 @@ templates.
 
 :::
 
-Users can customize the JSON Message structure sent to Integrations. Includes the ability to write
-custom JSON Messages and use supplied predefined JSON templates for Cayenne, and Browan.
+Users can customize the JSON Message structure sent to Integrations (i.e., to the HTTP endpoint, 
+from the Helium Console). This feature includes the ability to write
+custom JSON Messages, decoder functions, and use supplied predefined JSON templates for Cayenne and Browan.
 
 ### Decoding base64 payloads
 
-Users can send decoded base64 payloads (to hex or bytes) from device to desired integration without
-creating a decoder function for brevity.
+Users can send decoded base64 payloads (to hex or bytes) from device to desired integration, without
+creating a [decoder function](/use-the-network/console/functions) for brevity.
 
 To decode the base64 payload simply use `base64_to_hex()` or `base64_to_bytes()` in your integration
 JSON like the following (other keys are optional):

--- a/docs/use-the-network/console/integrations/json-schema.mdx
+++ b/docs/use-the-network/console/integrations/json-schema.mdx
@@ -12,7 +12,7 @@ slug: /use-the-network/console/integrations/json-schema
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-When receiving or transmitting data with an integration there is a consistent JSON Schema for the
+When receiving or transmitting data with an integration, there is a consistent JSON Schema for the
 data.
 
 ## Uplink: Receiving Data from a Device
@@ -113,11 +113,13 @@ Here is an example of data received:
 
 | Field           | Description |                                                                                                                                                                          |
 | :-------------- | :---------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **payload_raw** | String      | Data transmitted to your device as a base64 encoded String. Most computer languages will have some built-in libraries for parsing this \(e.g. base64.encode\(payload\)\) |
-| **port**        | Number      | LoRaWAN FPort on which the data was transmitted; this can be useful for routing data within the application                                                              |
-| **confirmed**   | Bool        | Whether or not a device acknowledgement is required                                                                                                                      |
+| **payload_raw** | String      | Data transmitted to your device as a base64 encoded String. Most programming languages will have some built-in libraries for parsing/encoding this \(e.g., Python's `payload = base64.b64encode(payload_str.encode('utf-8')).decode('ascii')`\) |
+| **port**        | Number      | LoRaWAN FPort on which the data is to be transmitted; this can be useful for routing data within the application                                                              |
+| **confirmed**   | Bool        | Whether a device acknowledgement (ACK) is required                                                                                                                      |
+
+Note that many devices will show the downlinked payload (submitted as base64 in the JSON schema) as hex (base-16).
 
 ### Clearing a Device Queue
 
-If the **payload_raw** field is the base64 encoded value `'__clear_downlink_queue__'` any downlinks
-queued for that device will be removed.
+If the **payload_raw** field is set to the base64 encoded value 
+`'__clear_downlink_queue__'`, all downlinks queued for that device will be removed.


### PR DESCRIPTION
- Add python downlink example
- Improve writing style
- Replace "click here" text in links with better explanation of what the link is 
- Add better linking to adjacent pages throughout 