### PR TITLE
Updated rewardable-entites.mdx file

### DIFF
--- a/docs/solana/rewardable-entities.mdx
+++ b/docs/solana/rewardable-entities.mdx
@@ -416,5 +416,5 @@ const tx = await formTransaction({
   lazyDistributor: lazyDistributorPkey,
 })
 
-await provider.send(tx)
+await provider.sendAndConfirm(tx)
 ```


### PR DESCRIPTION
We don't have any function with `send` in the anchor, We have `sendAndConfirm` for executing the successful transaction in the anchor.