### PR TITLE
Switch MNTD/RAK App Links to Hotspotty Connect

### DIFF
--- a/docs/hotspot-makers/maker-apps.mdx
+++ b/docs/hotspot-makers/maker-apps.mdx
@@ -272,8 +272,8 @@ FreedomFi Hotspots can now use the Helium Hotspot App to onboard and manage
 ### MNTD / RAK Wireless
 
 - Discord : https://discord.gg/j92Nu5nmP9
-- iOS App: https://apps.apple.com/ch/app/mntd-helium-hotspot-manager/id1595569593
-- Android App: https://play.google.com/store/apps/details?id=com.getmntd.wallet
+- iOS App: https://apps.apple.com/app/hotspotty-connect/id1622212036
+- Android App: https://play.google.com/store/apps/details?id=com.hotspottyconnect
 
 ---
 

--- a/docs/hotspot-makers/maker-apps.mdx
+++ b/docs/hotspot-makers/maker-apps.mdx
@@ -271,6 +271,12 @@ FreedomFi Hotspots can now use the Helium Hotspot App to onboard and manage
 
 ### MNTD / RAK Wireless
 
+:::note Use Hotspotty Connect
+
+Note that Hotspotty Connect has taken over management of the MNTD/RAK maker app. the links below are accurate for the Hotspotty Connect apps which should be used with all MNTD and RAK Wireless Hotspots.
+
+:::
+
 - Discord : https://discord.gg/j92Nu5nmP9
 - iOS App: https://apps.apple.com/app/hotspotty-connect/id1622212036
 - Android App: https://play.google.com/store/apps/details?id=com.hotspottyconnect

--- a/docs/hotspot-makers/maker-apps.mdx
+++ b/docs/hotspot-makers/maker-apps.mdx
@@ -273,7 +273,7 @@ FreedomFi Hotspots can now use the Helium Hotspot App to onboard and manage
 
 :::note Use Hotspotty Connect
 
-Note that Hotspotty Connect has taken over management of the MNTD/RAK maker app. the links below are accurate for the Hotspotty Connect apps which should be used with all MNTD and RAK Wireless Hotspots.
+Hotspotty Connect has taken over management of the MNTD/RAK maker app. The links below are accurate for the Hotspotty Connect apps which should be used with all MNTD and RAK Wireless Hotspots.
 
 :::
 


### PR DESCRIPTION
Official announcement from MNTD indicating that the MNTD app is not supported after the Solana migration and will be removed from app stores soon, and that Hotspotty Connect should be used moving forward: https://cdn.discordapp.com/attachments/404106811252408322/1099171159368544346/image.png