### PR TITLE
veHNT Positions Language

### DIFF
--- a/docs/vote-escrow/realms.mdx
+++ b/docs/vote-escrow/realms.mdx
@@ -16,52 +16,14 @@ Like many other Solana Ecosystem projects, Helium utilizes [Realms](https://real
 organize and manage vote escrow tokens, delegation, and more. Stakes can be created and later
 managed within Realms at any time.
 
-## Landrush
-
-For the first 10 days following the Solana migration, HNT holders are eligible to stake their HNT
-for a 'landrush' bonus of 3x the locked amount.<sup>(</sup>[^1]<sup>,</sup>[^2]<sup>)</sup>
-
-If a landrush stake is moved or split out of its original position after the first 10 days have
-lapsed, the landrush bonus is forfeited.
-
-<figure className="screensnippet-wrapper">
-  <img src={useBaseUrl('/img/realms/landrush.png')} />
-  <figcaption>
-    The 'landrush' banner indicates a position created within the first 10 days of the Solana
-    migration.
-  </figcaption>
-</figure>
-
-[^1]:
-    [HIP 70: Scaling the Helium Network](https://github.com/helium/HIP/blob/main/0070-scaling-helium.md)
-
-[^2]:
-    [HIP 77: Launch Parameters for Solana Migration](https://github.com/helium/HIP/blob/main/0077-solana-parameters.md)
-
-## Automatically Created Validator Stakes
-
-For existing validators, a veHNT position is automatically created based on the existing staked
-position previously tied to Validators. The
-[Validator migration guide](/solana/migration/validator-operator) is a valuable reference in
-understanding specific details for former Validator operators.
-
-These positions are not automatically delegated to a subDAO and are set with a constant
-[lockup period](#lockup-period) by default.
-
-As a note, these Validator positions will appear as one large stake. `hntyv...` is the Solana mint
-address for HNT.
-
-<figure className="screensnippet-wrapper">
-  <img src={useBaseUrl('/img/realms/validatorstake.png')} />
-  <figcaption>
-    A veHNT position representing two migrated validators (20,000 HNT) under one account.
-  </figcaption>
-</figure>
-
 ## Creating a Stake
 
 Anyone with HNT in a wallet can create a stake using Realms either using an in-wallet browser or a
 browser-connected wallet.
+
+While staking IOT or MOBILE tokens is possible through their respective subDAOs, those positions are
+only eligible for voting power and cannot currently be delegated for the purposes of earning
+rewards.
 
 This guide outlines using Realms with the [Helium Wallet App](/wallets/helium-wallet-app). To use
 Realms on a desktop browser, a Solana-compatible browser wallet can be used (such as Phantom or
@@ -195,7 +157,7 @@ the overall lockup multiplier.
 
 ### Confirming your Stake
 
-Once parameters are settled in the realms UI, you are now ready to create your veHNT position.
+Once parameters are settled in the Realms UI, you are now ready to create your veHNT position.
 
 The Helium Wallet App will ask for confirmation before issuing the Solana transaction that creates
 the veHNT position.
@@ -235,7 +197,7 @@ veHNT position to multiple networks (IOT or MOBILE) or set different lockup time
 positions.
 
 Be warned, splitting a [landrush](#landrush) position after the initial 10 day period will result in
-losing the multiplier for the tokens being split or transferred off the position.
+losing the multiplier for the position being split or transferred off the position.
 
 You must undelegate before splitting a stake. You can redelegate after the split is complete.
 
@@ -244,12 +206,11 @@ be relinquished from the active vote.
 
 ### Transfer a Stake
 
-Neither staked tokens nor the NFT representing a stake can be transferred from one wallet to
-another. Stakes can only be transferred from one position to another within the same wallet.
-Positions can only transfer to positions of greater or equal duration. This functionality is useful
-for consolidating positions. Landrush positions cannot have more locked tokens transferred into them
-after the landrush period. Any veHNT transferred out of a landrush position will lose the 3x
-multiplier bonus.
+Staked positions cannot be transferred from one account to another. Stakes can only be transferred
+from one position to another within the same account. Positions can only transfer to positions of
+greater or equal duration. This functionality is useful for consolidating positions. Landrush
+positions cannot have more locked tokens transferred into them after the landrush period. Any veHNT
+transferred out of a landrush position will lose the 3x multiplier bonus.
 
 You must undelegate both positions before transferring a stake between positions. Transferring to a
 new position requires the original position to be undelegated. You can redelegate one or both
@@ -285,6 +246,48 @@ before the Close Position button is available as an option.
   <img src={useBaseUrl('/img/realms/stakewlockup.png')} style={{ maxHeight: 300 }} />
   <figcaption>
     This position will unlock over the period of 2 years once the unlock has been initiated.
+  </figcaption>
+</figure>
+
+## Landrush
+
+For the first 10 days following the Solana migration, HNT holders were eligible to stake their HNT
+for a 'landrush' bonus of 3x the locked amount.<sup>(</sup>[^1]<sup>,</sup>[^2]<sup>)</sup>
+
+If a landrush stake is moved or split out of its original position after the first 10 days have
+lapsed, the landrush bonus is forfeited.
+
+<figure className="screensnippet-wrapper">
+  <img src={useBaseUrl('/img/realms/landrush.png')} />
+  <figcaption>
+    The 'landrush' banner indicates a position created within the first 10 days of the Solana
+    migration.
+  </figcaption>
+</figure>
+
+[^1]:
+    [HIP 70: Scaling the Helium Network](https://github.com/helium/HIP/blob/main/0070-scaling-helium.md)
+
+[^2]:
+    [HIP 77: Launch Parameters for Solana Migration](https://github.com/helium/HIP/blob/main/0077-solana-parameters.md)
+
+## Automatically Created Validator Stakes
+
+For existing validators, a veHNT position is automatically created based on the existing staked
+position previously tied to Validators. The
+[Validator migration guide](/solana/migration/validator-operator) is a valuable reference in
+understanding specific details for former Validator operators.
+
+These positions are not automatically delegated to a subDAO and are set with a constant
+[lockup period](#lockup-period) by default.
+
+As a note, these Validator positions will appear as one large stake. `hntyv...` is the Solana mint
+address for HNT.
+
+<figure className="screensnippet-wrapper">
+  <img src={useBaseUrl('/img/realms/validatorstake.png')} />
+  <figcaption>
+    A veHNT position representing two migrated validators (20,000 HNT) under one account.
   </figcaption>
 </figure>
 

--- a/docs/vote-escrow/vehnt.mdx
+++ b/docs/vote-escrow/vehnt.mdx
@@ -12,38 +12,39 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 <img className="docsheader" src={useBaseUrl('/img/blockchain/veHNT.png')} />
 
-In the Helium ecosystem, HNT holders can receive veHNT by locking their HNT on-chain for a specified
-period in exchange for voting power and subDAO delegation income in the Helium DAO as defined in
-HIP-51. After the lock-up period ends, and the locked position is closed the amount of HNT is
-released to the owner's wallet and is once again transferable.
+In the Helium ecosystem, HNT holders can receive veHNT positions by locking their HNT on-chain for a
+specified period in exchange for voting power and subDAO delegation income in the Helium DAO. After
+the lock-up period ends, and the locked position is closed the amount of HNT is released to the
+owner's wallet and is once again transferable.
 
-veHNT, or voting-escrowed HNT, is a token introduced as part of the Helium Network's transition to
-the Solana blockchain and the new governance model. veHNT was designed to empower Helium token
-holders by allowing them to participate in the governance of the network and benefit from its
-growth. By understanding the veHNT token and the governance model, Helium stakeholders can make
-informed decisions and actively participate in shaping the network's future.
+veHNT, or voting-escrowed HNT, is a position introduced as part of
+[HIP 51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md). veHNT was designed to empower
+Helium token holders by allowing them to participate in the governance of the network and benefit
+from its growth. By understanding the veHNT token and the governance model, Helium stakeholders can
+make informed decisions and actively participate in shaping the network's future.
 
 ## How veHNT Works
 
-When HNT is locked into the voting escrow, it is converted to veHNT, which can be used to
+When HNT is locked into the voting escrow, it is converted to a veHNT position, which can be used to
 participate in network governance and decision-making. veHNT is the only way to vote in the Helium
 Network. The primary purpose of veHNT is to incentivize long-term commitment to the network and
 align stakeholders' interests with the network's long-term success.
 
-veHNT is not a separate token but rather a derivative of HNT. The amount of veHNT received when
-locking HNT depends on the lock-up period chosen by the user, with longer lock-up periods resulting
-in a higher veHNT multiplier.
+The amount of veHNT received when locking HNT depends on the lock-up period chosen by the user, with
+longer lock-up periods resulting in a higher veHNT multiplier.
 
 ## SubDAOs
 
 The Helium Network serves as the overarching system that enables a multitude of networks (subDAOs)
-to exist via the novel incentive mechanism of HNT.
+to exist via the HNT token.
 
-Each subDAO governs a specific area of the network and receives a portion of the network's token
-emissions, distributed proportionately among veHNT holders who have delegated their veHNT to that
-subDAO. The distribution of tokens is determined by the amount of veHNT delegated to each subDAO and
-the individual lock-up periods. Initially, two subDAOs are introduced: IOT and MOBILE. Voting on the
-IOT and MOBILE networks will require veIOT and veMOBILE respectively.
+Those who delegate their veHNT position to a subDAO are eligible to receive a portion of that
+network's token emissions.
+
+Each subDAO governs a specific area of the network. The distribution of HNT tokens available to the
+subDAO is determined by the amount of veHNT delegated to each subDAO. HNT is minted in proportion to
+the veHNT staked to each. Initially, two subDAOs are introduced: IOT and MOBILE. Voting on matters
+specific to the IOT and MOBILE networks will require veIOT and veMOBILE respectively.
 
 ### IOT subDAO
 
@@ -53,13 +54,13 @@ projects and initiatives that further the IoT ecosystem on the Helium Network.
 
 ### MOBILE subDAO
 
-The MOBILE subDAO is dedicated to the growth and expansion of the Helium Network in the mobile and
-telecommunications sectors. Delegating veHNT to the MOBILE subDAO will help finance projects and
-initiatives aimed at integrating Helium technology into mobile devices and networks.
+The MOBILE subDAO is dedicated to the growth and expansion of the Helium Network in the cellular
+communications sector of the network. Delegating veHNT to the MOBILE subDAO will help finance
+projects and initiatives aimed at integrating Helium technology into mobile devices and networks.
 
 ## Delegating veHNT
 
-To earn rewards from the token emissions, veHNT holders must delegate their veHNT to one or more
+To earn rewards from the token emissions, veHNT holders must delegate their position to one or more
 subDAOs. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
 resulting in a higher veHNT multiplier. Users can also change their delegations at any time to
 optimize their earnings from the subDAOs.
@@ -73,10 +74,10 @@ veTokens can be managed through [Realms](/vote-escrow/realms) using the in-app b
 
 ### Impacts to subDAO Rewards
 
-SubDAO rewards are calculated and paid to the lock-up position each 24hr reward period. At
-approximately 00:30 UTC time. Currently, the IOT and MOBILE subDAO each have a 6% token emission
-pool for veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subDAO
-at the end of each epoch.
+SubDAO rewards are calculated and paid to the lock-up position each 24hr reward period, at
+approximately 00:30 UTC. Currently, the IOT and MOBILE subDAO each have a 6% token emission pool for
+veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subDAO at the
+end of each epoch.
 
 **subDAO rewards may increase when:**
 


### PR DESCRIPTION
notably:
- refer to veHNT as positions not tokens
- move land rush and validator stake content to bottom of realms doc.

am editing this a bit under the weather so a careful eye is appreciated in review. 🙏 