### PR TITLE
Add vscode suggested extensions (+ configurations)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"esbenp.prettier-vscode",
+		"znck.grammarly",
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,13 @@
 {
   "editor.rulers": [100],
-  "editor.wordWrap": "off",
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#a334fb",
     "titleBar.activeForeground": "#fff"
-  }
+  },
+  "prettier.proseWrap": "always",
+  "[mdx]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "grammarly.files.include": ["**/*.mdx", "**/*.md"]
 }


### PR DESCRIPTION
Suggests Prettier and Grammarly plugins within vscode. User can optionally install the suggested plugins. 
<kbd><img width="495" alt="image" src="https://user-images.githubusercontent.com/1965053/236646740-ddb443b7-e25d-48d6-97d2-6227d0c2a40a.png"></kbd>

# Prettier
Configured to format on save. In this example it formats the table and leading space.  
These changes only apply on save to `mdx` files.
<kbd>![Prettier screen recording](https://user-images.githubusercontent.com/1965053/236646513-1201c605-37aa-4c58-8485-b793fce725c2.gif)</kbd>

# Grammarly
Works with or without a Grammarly account. Brings helpful suggestions into the editing experience. Thank you to @DrowningWhale for this suggestion.  
Only applies to `md` and `mdx` files.
<kbd><img width="735" alt="image" src="https://user-images.githubusercontent.com/1965053/236646666-185c8c7a-7da8-402b-8455-896f8482f332.png"></kbd>
