### PR TITLE
Fix reward claiming example.

### DIFF
--- a/docs/solana/rewardable-entities.mdx
+++ b/docs/solana/rewardable-entities.mdx
@@ -417,6 +417,7 @@ You can then get a transaction to submit to the solana blockchain using those re
 ```js
 
 import { formTransaction } from "@helium/distributor-oracle";
+import { sendAndConfirmWithRetry } from "@helium/spl-utils";
 
 const tx = await formTransaction({
   program,
@@ -426,5 +427,12 @@ const tx = await formTransaction({
   lazyDistributor: lazyDistributorPkey,
 })
 
-await provider.sendAndConfirm(tx)
+const signed = await provider.wallet.signTransaction(tx);
+
+await sendAndConfirmWithRetry(
+  provider.connection,
+  Buffer.from(signed.serialize()),
+  { skipPreflight: true },
+  'confirmed',
+);
 ```


### PR DESCRIPTION
The process of claiming rewards requires at least one call to the distributor oracle to ask it to countersign the rewards transaction. In doing so, the oracle will fill in the "recent block hash" for the transaction and provide its signature over the same. This means that the client code which uses this transaction must leave the recent block hash alone when signing and submitting the transaction to the chain.

`provider.sendAndConfirm()`, however, implicitly resets the recent block hash and thus invalidates the transaction.

The fix here is to use a different submission method that leaves the recent block hash as is.