### PR TITLE
Revert frequency plan Australia AU915

### DIFF
--- a/docs/network-iot/frequency-plans/frequency-plans.mdx
+++ b/docs/network-iot/frequency-plans/frequency-plans.mdx
@@ -61,6 +61,102 @@ Also known as **US902-928**
 | 7              | 927.5           | SF7BW500 to SF12BW500 (RX1) |
 | 0              | 923.3           | SF12BW500 (RX2)             |
 
+### AU915_SB1
+
+- AU915 sub-band 1 (ch 0 to 7)
+
+#### Uplink
+
+| Frequency (MHZ) | Spreading Factor      |
+| :-------------- | :-------------------- |
+| 915.2           | SF7BW125 to SF12BW125 |
+| 915.4           | SF7BW125 to SF12BW125 |
+| 915.6           | SF7BW125 to SF12BW125 |
+| 915.8           | SF7BW125 to SF12BW125 |
+| 916.0           | SF7BW125 to SF12BW125 |
+| 916.2           | SF7BW125 to SF12BW125 |
+| 916.4           | SF7BW125 to SF12BW125 |
+| 916.6           | SF7BW125 to SF12BW125 |
+| 915.9           | SF8BW500              |
+
+#### Downlink
+
+| Frequency (MHZ) | Spreading Factor            |
+| :-------------- | :-------------------------- |
+| 923.3           | SF7BW500 to SF12BW500 (RX1) |
+| 923.9           | SF7BW500 to SF12BW500 (RX1) |
+| 924.5           | SF7BW500 to SF12BW500 (RX1) |
+| 925.1           | SF7BW500 to SF12BW500 (RX1) |
+| 925.7           | SF7BW500 to SF12BW500 (RX1) |
+| 926.3           | SF7BW500 to SF12BW500 (RX1) |
+| 926.9           | SF7BW500 to SF12BW500 (RX1) |
+| 927.5           | SF7BW500 to SF12BW500 (RX1) |
+| 923.3           | SF12BW500 (RX2)             |
+
+### AU915_SB1
+
+- AU915 sub-band 1 (ch 8 to 15)
+
+#### Uplink
+
+| Frequency (MHZ) | Spreading Factor      |
+| :-------------- | :-------------------- |
+| 916.8           | SF7BW125 to SF12BW125 |
+| 917.0           | SF7BW125 to SF12BW125 |
+| 917.2           | SF7BW125 to SF12BW125 |
+| 917.4           | SF7BW125 to SF12BW125 |
+| 917.6           | SF7BW125 to SF12BW125 |
+| 917.8           | SF7BW125 to SF12BW125 |
+| 918.0           | SF7BW125 to SF12BW125 |
+| 918.2           | SF7BW125 to SF12BW125 |
+| 917.5           | SF8BW500              |
+
+#### Downlink
+
+| Frequency (MHZ) | Spreading Factor            |
+| :-------------- | :-------------------------- |
+| 923.3           | SF7BW500 to SF12BW500 (RX1) |
+| 923.9           | SF7BW500 to SF12BW500 (RX1) |
+| 924.5           | SF7BW500 to SF12BW500 (RX1) |
+| 925.1           | SF7BW500 to SF12BW500 (RX1) |
+| 925.7           | SF7BW500 to SF12BW500 (RX1) |
+| 926.3           | SF7BW500 to SF12BW500 (RX1) |
+| 926.9           | SF7BW500 to SF12BW500 (RX1) |
+| 927.5           | SF7BW500 to SF12BW500 (RX1) |
+| 923.3           | SF12BW500 (RX2)             |
+
+### AU915_SB6 (DualPlan)
+
+- AU915 sub-band 6 (ch 40 to 47) (for DualPlan only)
+
+#### Uplink
+
+| Frequency (MHZ) | Spreading Factor      |
+| :-------------- | :-------------------- |
+| 923.2           | SF7BW125 to SF12BW125 |
+| 923.4           | SF7BW125 to SF12BW125 |
+| 923.6           | SF7BW125 to SF12BW125 |
+| 923.8           | SF7BW125 to SF12BW125 |
+| 924.0           | SF7BW125 to SF12BW125 |
+| 924.2           | SF7BW125 to SF12BW125 |
+| 924.4           | SF7BW125 to SF12BW125 |
+| 924.6           | SF7BW125 to SF12BW125 |
+
+#### Downlink
+
+| Frequency (MHZ) | Spreading Factor            |
+| :-------------- | :-------------------------- |
+| 923.3           | SF7BW500 to SF12BW500 (RX1) |
+| 923.9           | SF7BW500 to SF12BW500 (RX1) |
+| 924.5           | SF7BW500 to SF12BW500 (RX1) |
+| 925.1           | SF7BW500 to SF12BW500 (RX1) |
+| 925.7           | SF7BW500 to SF12BW500 (RX1) |
+| 926.3           | SF7BW500 to SF12BW500 (RX1) |
+| 926.9           | SF7BW500 to SF12BW500 (RX1) |
+| 927.5           | SF7BW500 to SF12BW500 (RX1) |
+| 923.3           | SF12BW500 (RX2)             |
+
+
 ### EU868
 
 #### Uplink
@@ -230,66 +326,3 @@ Also known as **US902-928**
 | 507.9           | SF7BW125 to SF12BW125 (RX1) |
 | 508.1           | SF7BW125 to SF12BW125 (RX1) |
 | 505.3           | SF12BW125 (RX2)             |
-
-### AU915_SB1
-
-- AU915 sub-band 1 (ch 0 to 7)
-
-#### Uplink
-
-| Frequency (MHZ) | Spreading Factor      |
-| :-------------- | :-------------------- |
-| 915.2           | SF7BW125 to SF12BW125 |
-| 915.4           | SF7BW125 to SF12BW125 |
-| 915.6           | SF7BW125 to SF12BW125 |
-| 915.8           | SF7BW125 to SF12BW125 |
-| 916.0           | SF7BW125 to SF12BW125 |
-| 916.2           | SF7BW125 to SF12BW125 |
-| 916.4           | SF7BW125 to SF12BW125 |
-| 916.6           | SF7BW125 to SF12BW125 |
-| 915.9           | SF8BW500              |
-
-#### Downlink
-
-| Frequency (MHZ) | Spreading Factor            |
-| :-------------- | :-------------------------- |
-| 923.3           | SF7BW500 to SF12BW500 (RX1) |
-| 923.9           | SF7BW500 to SF12BW500 (RX1) |
-| 924.5           | SF7BW500 to SF12BW500 (RX1) |
-| 925.1           | SF7BW500 to SF12BW500 (RX1) |
-| 925.7           | SF7BW500 to SF12BW500 (RX1) |
-| 926.3           | SF7BW500 to SF12BW500 (RX1) |
-| 926.9           | SF7BW500 to SF12BW500 (RX1) |
-| 927.5           | SF7BW500 to SF12BW500 (RX1) |
-| 923.3           | SF12BW500 (RX2)             |
-
-### AU915_SB6 (DualPlan)
-
-- AU915 sub-band 6 (ch 40 to 47) (for DualPlan only)
-
-#### Uplink
-
-| Frequency (MHZ) | Spreading Factor      |
-| :-------------- | :-------------------- |
-| 923.2           | SF7BW125 to SF12BW125 |
-| 923.4           | SF7BW125 to SF12BW125 |
-| 923.6           | SF7BW125 to SF12BW125 |
-| 923.8           | SF7BW125 to SF12BW125 |
-| 924.0           | SF7BW125 to SF12BW125 |
-| 924.2           | SF7BW125 to SF12BW125 |
-| 924.4           | SF7BW125 to SF12BW125 |
-| 924.6           | SF7BW125 to SF12BW125 |
-
-#### Downlink
-
-| Frequency (MHZ) | Spreading Factor            |
-| :-------------- | :-------------------------- |
-| 923.3           | SF7BW500 to SF12BW500 (RX1) |
-| 923.9           | SF7BW500 to SF12BW500 (RX1) |
-| 924.5           | SF7BW500 to SF12BW500 (RX1) |
-| 925.1           | SF7BW500 to SF12BW500 (RX1) |
-| 925.7           | SF7BW500 to SF12BW500 (RX1) |
-| 926.3           | SF7BW500 to SF12BW500 (RX1) |
-| 926.9           | SF7BW500 to SF12BW500 (RX1) |
-| 927.5           | SF7BW500 to SF12BW500 (RX1) |
-| 923.3           | SF12BW500 (RX2)             |

--- a/docs/network-iot/frequency-plans/frequency-plans.mdx
+++ b/docs/network-iot/frequency-plans/frequency-plans.mdx
@@ -93,7 +93,7 @@ Also known as **US902-928**
 | 927.5           | SF7BW500 to SF12BW500 (RX1) |
 | 923.3           | SF12BW500 (RX2)             |
 
-### AU915_SB1
+### AU915_SB2
 
 - AU915 sub-band 1 (ch 8 to 15)
 
@@ -155,7 +155,6 @@ Also known as **US902-928**
 | 926.9           | SF7BW500 to SF12BW500 (RX1) |
 | 927.5           | SF7BW500 to SF12BW500 (RX1) |
 | 923.3           | SF12BW500 (RX2)             |
-
 
 ### EU868
 

--- a/docs/network-iot/frequency-plans/region-plans.mdx
+++ b/docs/network-iot/frequency-plans/region-plans.mdx
@@ -48,7 +48,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Argentina               | AU915_SB1      |
 | Armenia                 | EU868          |
 | Aruba                   | Unknown        |
-| Australia               | AS923_1        |
+| Australia               | AU915_SB2        |
 | Austria                 | EU868          |
 | Azerbaijan              | EU433          |
 
@@ -92,8 +92,8 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Chad                     | Unknown        |
 | Chile                    | AU915_SB1      |
 | China                    | CN470          |
-| Christmas Island         | AS923_1        |
-| Cocos [Keeling] Islands  | AS923_1        |
+| Christmas Island         | AU915_SB2        |
+| Cocos [Keeling] Islands  | AU915_SB2        |
 | Colombia                 | AU915_SB1      |
 | Comoros                  | EU868          |
 | Congo [DRC]              | Unknown        |
@@ -169,7 +169,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Country                           | Frequency Plan |
 | --------------------------------- | -------------- |
 | Haiti                             | Unknown        |
-| Heard Island and McDonald Islands | AS923_1        |
+| Heard Island and McDonald Islands | AU915_SB2        |
 | Honduras                          | AU915_SB1      |
 | Hong Kong                         | AS923_1        |
 | Hungary                           | EU868          |
@@ -265,7 +265,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Niger                    | IN865          |
 | Nigeria                  | EU868          |
 | Niue                     | AS923_1        |
-| Norfolk Island           | AS923_1        |
+| Norfolk Island           | AU915_SB2        |
 | North Korea              | Unknown        |
 | Northern Mariana Islands | US915          |
 | Norway                   | EU868          |

--- a/docs/network-iot/frequency-plans/region-plans.mdx
+++ b/docs/network-iot/frequency-plans/region-plans.mdx
@@ -13,9 +13,6 @@ slug: /iot/region-plans
 Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
 appropriate frequencies for gateway configuration for each region.
 
-The majority of countries support either EU868 (800 Mhz) or AS923 (900 Mhz) plans with the exception
-of North American continent countries that support the US915 (900 Mhz) plan.
-
 ## Frequency Plans by Country
 
 Where a frequency plan is "Unknown", it often means the local telecommnications or radio authority

--- a/docs/network-iot/frequency-plans/region-plans.mdx
+++ b/docs/network-iot/frequency-plans/region-plans.mdx
@@ -13,6 +13,9 @@ slug: /iot/region-plans
 Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
 appropriate frequencies for gateway configuration for each region.
 
+The majority of countries support either EU868 (800 Mhz) or AS923 (900 Mhz) plans with the exception
+of North American continent countries that support the US915 (900 Mhz) plan.
+
 ## Frequency Plans by Country
 
 Where a frequency plan is "Unknown", it often means the local telecommnications or radio authority
@@ -45,7 +48,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Argentina               | AU915_SB1      |
 | Armenia                 | EU868          |
 | Aruba                   | Unknown        |
-| Australia               | AU915_SB2        |
+| Australia               | AU915_SB2      |
 | Austria                 | EU868          |
 | Azerbaijan              | EU433          |
 
@@ -89,8 +92,8 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Chad                     | Unknown        |
 | Chile                    | AU915_SB1      |
 | China                    | CN470          |
-| Christmas Island         | AU915_SB2        |
-| Cocos [Keeling] Islands  | AU915_SB2        |
+| Christmas Island         | AU915_SB2      |
+| Cocos [Keeling] Islands  | AU915_SB2      |
 | Colombia                 | AU915_SB1      |
 | Comoros                  | EU868          |
 | Congo [DRC]              | Unknown        |
@@ -166,7 +169,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Country                           | Frequency Plan |
 | --------------------------------- | -------------- |
 | Haiti                             | Unknown        |
-| Heard Island and McDonald Islands | AU915_SB2        |
+| Heard Island and McDonald Islands | AU915_SB2      |
 | Honduras                          | AU915_SB1      |
 | Hong Kong                         | AS923_1        |
 | Hungary                           | EU868          |
@@ -262,7 +265,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Niger                    | IN865          |
 | Nigeria                  | EU868          |
 | Niue                     | AS923_1        |
-| Norfolk Island           | AU915_SB2        |
+| Norfolk Island           | AU915_SB2      |
 | North Korea              | Unknown        |
 | Northern Mariana Islands | US915          |
 | Norway                   | EU868          |


### PR DESCRIPTION
As per the Discord announcement [https://discord.com/channels/404106811252408320/730418759298318346/1097792212579913728](https://discord.com/channels/404106811252408320/730418759298318346/1097792212579913728) the frequency plan for Australia and territories has been changed.

This updates two content pages only to reflect those changes made on 2023-04-17.

- Region plans
  - Adds AU915_SB2 (copy of previous AU915)
  - moves AU915 to US915 as these are the two fixed ones
- Frequency plans change to AU915_SB2
  - Australia
  - NorfolkIsland
  - HeardIslandandMcDonaldIslands
  - ChristmasIsland
  - CocosIslands