### PR TITLE
Remove non-sensical paragraph

### DIFF
--- a/docs/network-iot/frequency-plans/region-plans.mdx
+++ b/docs/network-iot/frequency-plans/region-plans.mdx
@@ -13,6 +13,8 @@ slug: /iot/region-plans
 Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
 appropriate frequencies for gateway configuration for each region.
 
+The majority of countries support either 800Mhz (EU868, IN865) or 900 Mhz (US915, AU915, AS923) plans.
+
 ## Frequency Plans by Country
 
 Where a frequency plan is "Unknown", it often means the local telecommnications or radio authority

--- a/docs/network-iot/frequency-plans/region-plans.mdx
+++ b/docs/network-iot/frequency-plans/region-plans.mdx
@@ -13,9 +13,6 @@ slug: /iot/region-plans
 Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
 appropriate frequencies for gateway configuration for each region.
 
-The majority of countries support either EU868 (800 Mhz) or AS923 (900 Mhz) plans with the exception
-of North American continent countries that support the US915 (900 Mhz) plan.
-
 ## Frequency Plans by Country
 
 Where a frequency plan is "Unknown", it often means the local telecommnications or radio authority


### PR DESCRIPTION
The paragraph does not provide any use as it is non-sensical. 

It's factually incorrect and potentially misleading. It should be removed.