### PR TITLE
Updates analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -114,8 +114,8 @@ module.exports = {
           remarkPlugins: [math],
           rehypePlugins: [katex],
         },
-        googleAnalytics: {
-          trackingID: 'UA-52432858-10',
+        gtag: {
+          trackingID: 'G-85D2WJWZNL',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
- Move to `@docusaurus/plugin-google-gtag` (https://docusaurus.io/docs/using-plugins#docusauruspreset-classic)
- Move from Universal Analytics to Google Analytics v4