### PR TITLE
Update digital-matter-lorawan-gps.mdx

### DIFF
--- a/docs/use-the-network/devices/ready-to-use/digital-matter/digital-matter-lorawan-gps.mdx
+++ b/docs/use-the-network/devices/ready-to-use/digital-matter/digital-matter-lorawan-gps.mdx
@@ -1,5 +1,5 @@
 ---
-id: tutorial-dm-lorawan-gps
+id: digital-matter-lorawan-gps
 title: Tutorial DM LoRaWAN GPS
 pagination_label: Tutorial DM LoRaWAN GPS
 sidebar_label: Tutorial DM LoRaWAN GPS
@@ -23,12 +23,13 @@ Step-by-step tutorial guide on configuring and onboarding Digital Matter LoRaWAN
 
 ### Introduction
 
-The
-[Digital Matter Oyster3](https://www.digitalmatter.com/devices/oyster-lorawan/) / [Yabby Edge](https://www.digitalmatter.com/our-devices/yabby-edge/)
-are rugged IP68 rated battery powered GPS tracking devices. This guide will show you the hardware
-and software setup steps required to provision and onboard these devices on the Helium Network.
+The [Digital Matter Oyster3](https://www.digitalmatter.com/devices/oyster-lorawan/) /
+[Yabby Edge](https://www.digitalmatter.com/our-devices/yabby-edge/) are rugged IP68 rated battery
+powered GPS tracking devices. This guide will show you the hardware and software setup steps
+required to provision and onboard these devices on the Helium Network.
 
-Functionally, the Oyster3 and Yabby Edge are both battery powered GPS tracking devices. Their main differences lie in form factor and battery life.
+Functionally, the Oyster3 and Yabby Edge are both battery powered GPS tracking devices. Their main
+differences lie in form factor and battery life.
 
 ### Resources
 
@@ -48,18 +49,25 @@ Functionally, the Oyster3 and Yabby Edge are both battery powered GPS tracking d
 ### Software
 
 - [Helium Console](https://console.helium.com/)
-- [LoRaWAN Provisioning Tool](https://www.oemserver.com/tools/LoRaWANProvisioningTool/setup.exe) \(Windows\)
+- [LoRaWAN Provisioning Tool](https://www.oemserver.com/tools/LoRaWANProvisioningTool/setup.exe)
+  \(Windows\)
 
 ### Hardware Setup
 
 The Oyster3 takes 3 cells of AA battery; the Yabby Edge takes 2 cells of AAA battery.
 
-The Oyster3 and the Yabby Edge both use the [DM-Link Wired Provisioning Cable for LoRaWAN decives](https://www.digitalmatter.com/dmlink/).
+The Oyster3 and the Yabby Edge both use the
+[DM-Link Wired Provisioning Cable for LoRaWAN decives](https://www.digitalmatter.com/dmlink/).
 
-Compatibility with the DM-Link Wired Provisioning Cable for older Digital Matter LoRaWAN devices can be found at [Wired Provisioning Tool](https://support.digitalmatter.com/support/solutions/articles/16000104317-wired-provisioning-tool).
-On LoRaWAN devices, DM-Link is used to configure the region and JoinEUI to connect to a network. A DM-Link can also be used to configure device parameters prior to deployment, and update firmware and Almanac data where applicable.
+Compatibility with the DM-Link Wired Provisioning Cable for older Digital Matter LoRaWAN devices can
+be found at
+[Wired Provisioning Tool](https://support.digitalmatter.com/support/solutions/articles/16000104317-wired-provisioning-tool).
+On LoRaWAN devices, DM-Link is used to configure the region and JoinEUI to connect to a network. A
+DM-Link can also be used to configure device parameters prior to deployment, and update firmware and
+Almanac data where applicable.
 
-Once the devices have been provisioned and the batteries are populated, the enclosure can be sealed by using the included screws.
+Once the devices have been provisioned and the batteries are populated, the enclosure can be sealed
+by using the included screws.
 
 ---
 
@@ -70,9 +78,9 @@ That’s it for the hardware setup!
 ### Software Setup
 
 The Oyster3 / Yabby Edge ship with a pre-provisioned AppEUI and AppKey. If you choose to use these
-credentials, you can leave the AppEUI and AppKey fields blank in the Windows utility. If you would like
-to provision the device with new credentials, you must copy the AppEUI and AppKey from the device
-[created in Console](/use-the-network/console/adding-devices).
+credentials, you can leave the AppEUI and AppKey fields blank in the Windows utility. If you would
+like to provision the device with new credentials, you must copy the AppEUI and AppKey from the
+device [created in Console](/use-the-network/console/adding-devices).
 
 The basic parameters of interest are as follows:
 
@@ -153,22 +161,26 @@ When decoded becomes:
 ```
 
 To learn more about decoding this payload, you may use this
-[utility](https://www.oemserver.com/tools/Oyster3LoRaWAN/oyster3-lr-html-decoder.html). To view the JavaScript
-sample code, you can view source.
+[utility](https://www.oemserver.com/tools/Oyster3LoRaWAN/oyster3-lr-html-decoder.html). To view the
+JavaScript sample code, you can view source.
 
 ### Battery Life Estimate Calculator
 
-Download [Oyster3 LoRaWAN Battery Life Estimate Calculator](https://support.digitalmatter.com/helpdesk/attachments/16084686136)
+Download
+[Oyster3 LoRaWAN Battery Life Estimate Calculator](https://support.digitalmatter.com/helpdesk/attachments/16084686136)
 
-This spreadsheet will help estimate the approximate battery life of the Digital Matter Oyster3 LoRaWAN. Simply
-modify the fields to represent the desired number of transmissions within a day.
+This spreadsheet will help estimate the approximate battery life of the Digital Matter Oyster3
+LoRaWAN. Simply modify the fields to represent the desired number of transmissions within a day.
 
 ### myDevices/Cayenne Integration
 
-Helium now supports myDevices and the Cayenne LPP \(Low Power Payload\) format. Cayenne is a drag-and-drop IoT platform developed by myDevices, allowing developers, designers and engineers to quickly prototype and
-share their connected device projects.
+Helium now supports myDevices and the Cayenne LPP \(Low Power Payload\) format. Cayenne is a
+drag-and-drop IoT platform developed by myDevices, allowing developers, designers and engineers to
+quickly prototype and share their connected device projects.
 
-To learn more about myDevices Cayenne integration, visit [myDevices Cayenne](https://developers.mydevices.com/cayenne/features/) and their [documentation](https://developers.mydevices.com/cayenne/docs/intro/).
+To learn more about myDevices Cayenne integration, visit
+[myDevices Cayenne](https://developers.mydevices.com/cayenne/features/) and their
+[documentation](https://developers.mydevices.com/cayenne/docs/intro/).
 
 :::info
 

--- a/docs/use-the-network/devices/ready-to-use/digital-matter/digital-matter-lorawan-gps.mdx
+++ b/docs/use-the-network/devices/ready-to-use/digital-matter/digital-matter-lorawan-gps.mdx
@@ -1,18 +1,18 @@
 ---
-id: digital-matter-lorawan-gps
-title: Digital Matter LoRaWAN GPS
-pagination_label: Digital Matter LoRaWAN GPS
-sidebar_label: Digital Matter LoRaWAN GPS
+id: tutorial-dm-lorawan-gps
+title: Tutorial DM LoRaWAN GPS
+pagination_label: Tutorial DM LoRaWAN GPS
+sidebar_label: Tutorial DM LoRaWAN GPS
 description: Helium Documentation
 image: https://docs.helium.com/img/link-image.png
-slug: /use-the-network/devices/ready-to-use/digital-matter/digital-matter-lorawan-gps
+slug: /use-the-network/devices/ready-to-use/digital-matter/tutorial-dm-lorawan-gps
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-## Digital Matter LoRaWAN GPS
+## Tutorial DM LoRaWAN GPS
 
-Step-by-step guide on configuring and onboarding Digital Matter LoRaWAN GPS devices.
+Step-by-step tutorial guide on configuring and onboarding Digital Matter LoRaWAN GPS devices.
 
 <div style={{ textAlign: 'left' }}>
   <img src={useBaseUrl('img/use-the-network/devices/ready-to-use/digital-matter-oyster.png')} />
@@ -24,77 +24,53 @@ Step-by-step guide on configuring and onboarding Digital Matter LoRaWAN GPS devi
 ### Introduction
 
 The
-[Digital Matter Oyster](https://www.digitalmatter.com/devices/oyster-lorawan/)/[Yabby](https://www.digitalmatter.com/devices/yabby-lorawan/)
-are rugged IP67 rated battery powered GPS tracking devices. This guide will show you the hardware
+[Digital Matter Oyster3](https://www.digitalmatter.com/devices/oyster-lorawan/) / [Yabby Edge](https://www.digitalmatter.com/our-devices/yabby-edge/)
+are rugged IP68 rated battery powered GPS tracking devices. This guide will show you the hardware
 and software setup steps required to provision and onboard these devices on the Helium Network.
 
-Functionally, the Oyster and Yabby are both battery powered GPS tracking devices. Their main
-differences lie in form factor and battery life.
+Functionally, the Oyster3 and Yabby Edge are both battery powered GPS tracking devices. Their main differences lie in form factor and battery life.
 
 ### Resources
 
-[Oyster LoRaWAN Configuration Tool](https://www.oemserver.com/tools/OysterLoRaWAN/ConfigTool/setup.exe)
+[Oyster3 LoRaWAN Configuration and Usage Guide](https://support.digitalmatter.com/support/solutions/articles/16000133235-oyster-3-lorawan-configuration-and-usage-guide)
 
-[Oyster LoRaWAN Configuration and Usage Guide](https://support.digitalmatter.com/support/solutions/articles/16000063310-oyster-lorawan-configuration-and-usage-guide)
+[Yabby Edge LoRaWAN Configuration and Usage Guide](https://support.digitalmatter.com/support/solutions/articles/16000122827-yabby-edge-lorawan-configuration-and-usage-guide)
 
-[Yabby LoRaWAN Configuration Tool](https://www.oemserver.com/tools/YabbyLoRaWAN/ConfigTool/setup.exe)
-
-[Yabby LoRaWAN Configuration and Usage Guide](https://support.digitalmatter.com/support/solutions/articles/16000077618-configuration-and-usage-guide)
+[LoRaWAN Provisioning Tool](https://www.oemserver.com/tools/LoRaWANProvisioningTool/setup.exe)
 
 ### Hardware
 
-- Digital Matter Oyster/Yabby
-- 3 x AA 1.5V Batteries \(Oyster\)
-- 3 x AAA 1.5V Batteries \(Yabby\)
-- Digital Matter Configuration Cable
-- Digital Matter Yabby Configuration Cable Adapter \(Yabby only\)
+- Digital Matter Oyster3 / Yabby Edge
+- 3 x AA Lithium (LiFeS2) or Lithium Thionyl Chloride (LTC) batteries \(Oyster3\)
+- 2 x AAA Lithium (LiFeS2) batteries \(Yabby Edge\)
+- DM-Link Wired Provisioning Cable for LoRaWAN devices
 
 ### Software
 
 - [Helium Console](https://console.helium.com/)
-- [Oyster Configuration Tool ](https://www.oemserver.com/tools/OysterLoRaWAN/ConfigTool/setup.exe)\(Windows\)
-- [Yabby Configuration Tool ](https://www.oemserver.com/tools/YabbyLoRaWAN/ConfigTool/setup.exe)\(Windows\)
+- [LoRaWAN Provisioning Tool](https://www.oemserver.com/tools/LoRaWANProvisioningTool/setup.exe) \(Windows\)
 
 ### Hardware Setup
 
-The _Oyster and Yabby take 3 cells of their respective battery types. \(AA and AAA\)_
+The Oyster3 takes 3 cells of AA battery; the Yabby Edge takes 2 cells of AAA battery.
 
-The Oyster uses a
-[FTDI TTL to USB Serial Converter Cable](https://www.ftdichip.com/Support/Documents/DataSheets/Cables/DS_TTL-232RG_CABLES.pdf)
+The Oyster3 and the Yabby Edge both use the [DM-Link Wired Provisioning Cable for LoRaWAN decives](https://www.digitalmatter.com/dmlink/).
 
-<div style={{ textAlign: 'center' }}>
-  <img
-    src={useBaseUrl('img/use-the-network/devices/ready-to-use/digital-matter-oyster-cable.png')}
-  />
-</div>
+Compatibility with the DM-Link Wired Provisioning Cable for older Digital Matter LoRaWAN devices can be found at [Wired Provisioning Tool](https://support.digitalmatter.com/support/solutions/articles/16000104317-wired-provisioning-tool).
+On LoRaWAN devices, DM-Link is used to configure the region and JoinEUI to connect to a network. A DM-Link can also be used to configure device parameters prior to deployment, and update firmware and Almanac data where applicable.
 
-<div style={{ textAlign: 'center' }}>FTDI TTL to USB Serial Converter Cable</div>
-
-This cable plugs into the four-pin connector below the battery compartment.
-
-The Yabby uses the same cable, but will need an additional adapter for the Pogo pins.
-
-<div style={{ textAlign: 'center' }}>
-  <img
-    src={useBaseUrl('img/use-the-network/devices/ready-to-use/digital-matter-yabby-cable.png')}
-  />
-</div>
-
-<div style={{ textAlign: 'center' }}>Yabby Pogo Adapter Cable</div>
-
-Once the devices have been provisioned and the batteries are populated, the enclosure can be sealed
-by using the included screws.
+Once the devices have been provisioned and the batteries are populated, the enclosure can be sealed by using the included screws.
 
 ---
 
-That’s it for hardware setup!
+That’s it for the hardware setup!
 
 ---
 
 ### Software Setup
 
-The Oyster/Yabby ship with a pre-provisioned AppEUI and AppKey. If you choose to use these
-credentials, you can leave the AppEUI and AppKey fields blank in the Windows utility. If you’d like
+The Oyster3 / Yabby Edge ship with a pre-provisioned AppEUI and AppKey. If you choose to use these
+credentials, you can leave the AppEUI and AppKey fields blank in the Windows utility. If you would like
 to provision the device with new credentials, you must copy the AppEUI and AppKey from the device
 [created in Console](/use-the-network/console/adding-devices).
 
@@ -113,7 +89,7 @@ Basic LoRaWAN:
 
 ```
 
-#### Connecting your device
+### Connecting your device
 
 When you plug in your cable, your PC will assign it a COM port, which you can retrieve from the
 Device Manager from the _**Ports \(COM & LPT\).**_
@@ -121,7 +97,7 @@ Device Manager from the _**Ports \(COM & LPT\).**_
 To access the device manager, press the Windows key on your keyboard and search for "Device
 Manager".
 
-Windows Device Manager
+##### Windows Device Manager
 
 Select the corresponding port from the drop-down list in the top right of the utility and click
 _**Start**_.
@@ -129,7 +105,7 @@ _**Start**_.
 If the Program Firmware and Program Parameters boxes are left unchecked, the utility will
 continuously read and display the current device settings without applying changes.
 
-Current Device Settings and Transaction List
+##### Current Device Settings and Transaction List
 
 You can check logs by clicking the DevEUI List button on the top left, which will show a list of
 scanned DevEUIs and transactions. Each time a device is programmed, the parameter list will flash,
@@ -143,12 +119,12 @@ finished, you may hit _**Stop**_, and disconnect your device.
 Once the device has been configured, it will attempt to join the Helium Network by transmitting join
 requests. If the device has been configured properly in Console and has knowledge of the device’s
 AppEUI and AppKey, the Hotspot that hears the join request will send a join-accept message and allow
-the device to join the network and transmit data.
+the device to join the Network and transmit data.
 
 ### Usage
 
 These devices use an accelerometer to detect movement, allowing it to decide when an asset is
-in-trip and when it is stationary. This allows it schedule battery-hungry GPS fixes when
+in-trip and when it is stationary. This allows it to schedule battery-hungry GPS fixes when
 appropriate, to optimize battery life. Each time a status update is scheduled, the device will
 attempt a GPS fix, then transmit results \(regardless of whether a fix succeeded or not\).
 
@@ -177,23 +153,22 @@ When decoded becomes:
 ```
 
 To learn more about decoding this payload, you may use this
-[utility](https://www.oemserver.com/tools/OysterLoRaWAN/UplinkDecoder.html). To view the Javascript
+[utility](https://www.oemserver.com/tools/Oyster3LoRaWAN/oyster3-lr-html-decoder.html). To view the JavaScript
 sample code, you can view source.
 
-### Battery Life Estimate
+### Battery Life Estimate Calculator
 
-[Download Oyster LoRaWAN Battery Life Estimator](https://support.digitalmatter.com/helpdesk/attachments/16023300051)
+Download [Oyster3 LoRaWAN Battery Life Estimate Calculator](https://support.digitalmatter.com/helpdesk/attachments/16084686136)
 
-This spreadsheet will help estimate approximate battery life of the Digital Matter Oyster. Simply
+This spreadsheet will help estimate the approximate battery life of the Digital Matter Oyster3 LoRaWAN. Simply
 modify the fields to represent the desired number of transmissions within a day.
 
 ### myDevices/Cayenne Integration
 
-Helium now supports myDevices and the Cayenne LPP \(low power payload\) format. Cayenne features a
-simple drag and drop interface that allows developers, designers and engineers quickly prototype and
+Helium now supports myDevices and the Cayenne LPP \(Low Power Payload\) format. Cayenne is a drag-and-drop IoT platform developed by myDevices, allowing developers, designers and engineers to quickly prototype and
 share their connected device projects.
 
-To learn more about myDevices Cayenne integration, visit myDevices Cayenne
+To learn more about myDevices Cayenne integration, visit [myDevices Cayenne](https://developers.mydevices.com/cayenne/features/) and their [documentation](https://developers.mydevices.com/cayenne/docs/intro/).
 
 :::info
 
@@ -202,13 +177,11 @@ myDevices currently only includes the Digital Matter Oyster in their device libr
 :::
 
 When you are adding a device/widget in Cayenne, look for the **Digital Matter Oyster** under
-**Helium.**
+**Helium**.
 
-myDevices Cayenne - Adding a Digital Matter Oyster
+#### myDevices Cayenne - Adding a Digital Matter Oyster
 
 Copy the device's **DevEUI** into the field. This value should correspond to the associated Digital
-Matter Oyster DevEUI in **Console.** Then, click **Add device.**
-
-myDevices Cayenne - Adding a Digital Matter Oyster
+Matter Oyster DevEUI in **Console**. Then, click **Add device**.
 
 That's it for adding a Digital Matter Oyster in myDevices Cayenne!


### PR DESCRIPTION
Corrected spelling.
Deleted pictures converter cable. Both products use DM-Link v2 cable to do provisioning. The myDevice/Cayenne info is actually not applicable, because Digital Matter is not supported under Helium in Cayenne.  Is it possible to add the Oyster3 to Cayenne under Helium? I left the info in and updated it a bit, just in case we can get Oyster3 in. The picture in the beginning needs to be updated as well to new Oyster3 and Yabby Edge pictures.