### PR TITLE
Update find-a-lns-provider.mdx

### DIFF
--- a/docs/use-the-network/find-a-lns-provider.mdx
+++ b/docs/use-the-network/find-a-lns-provider.mdx
@@ -25,6 +25,7 @@ businesses and individuals.
 | [BrDot][brdot]                                             | Americas       | Shared & Private by request | Brazil                 | Fixed monthly for active devices plus message plan for public & private service.                   |
 | [Qnectd][qnectd]                                           | Global         | Shared & Private by request | Eastern Europe         | Per-device monthly subscription cost, custom for private servers.                                  |
 | [Parley Labs][parley-labs] **(Coming Soon)**               | USA            | Shared & Private by request | USA                    | Contact for pricing.                                                                               |
+| [MeteoScientific][meteoscientific] (by Gristle King Inc)   | USA            | Publicly Accessible         | Europe                 | Pay-per-message for public use, otherwise use Helium IoT Europe above                                                                               |
 
 If you offer public LNS services and would like to add your company to this list, please make a pull
 request and include information for each listed field.
@@ -42,3 +43,4 @@ given provider.
 [ingeniousthings]: https://www.ingeniousthings.fr/
 [parley-labs]: https://parleylabs.com/
 [qnectd]: https://qnectd.com/
+[meteoscientific]: https://console.meteoscientific.com/front/


### PR DESCRIPTION
Adding Gristle King's MeteoScientifc as another LNS provider (including the URL). Makes Gristle King's own (incomplete) pull request to do the same unnecessary.