### PR TITLE
Update voting.mdx

### DIFF
--- a/docs/governance/voting.mdx
+++ b/docs/governance/voting.mdx
@@ -126,9 +126,9 @@ example, a proposal affecting proof of coverage behavior for IoT Hotspots.
 ### veMOBILE
 
 The [MOBILE subNetwork][realms-mobile] is dedicated to the growth and expansion of the Helium
-Network in the mobile and telecommunications sectors. Staking your IOT tokens to the IOT subNetwork
-grants veIOT which can be used to vote on matters specific to the IOT network. For example, a
-proposal affecting proof of coverage behavior for IoT Hotspots.
+Network in the mobile and telecommunications sectors. Staking your MOBILE tokens to the MOBILE subNetwork
+grants veMOBILE which can be used to vote on matters specific to the MOBILE network. For example, a
+proposal affecting proof of coverage behavior for MOBILE Hotspots.
 
 ---
 


### PR DESCRIPTION
Corrected veMOBILE section -- previously the paragraph had incorrectly used IOT or veIOT multiple times, so updated those to MOBILE and veMOBILE