### PR TITLE
Update console-hosting-providers.mdx

### DIFF
--- a/docs/use-the-network/console/console-hosting-providers.mdx
+++ b/docs/use-the-network/console/console-hosting-providers.mdx
@@ -30,9 +30,6 @@ out to the given provider.
   [here](https://www.helium-iot.eu/use-helium-with-helium-iot-europe/).
 - Ubidots - Power your IoT and cloud applications with Ubidots. Sign up for beta
   [here](https://bit.ly/3JygTvn).
-- Foundation Console - For demo and educational purposes. Capped at 10 devices and a single
-  Organization. Sign up [here](https://console.helium.com/). No API v1 endpoint access on the
-  Foundation Console.
 - BrDot Console - Console Hosting Provider based in Brazil. For more information contact
   sales@brdot.co.
 - MeteoScientific - Public and permissionless access to a Console, get an account along with free DC


### PR DESCRIPTION
Remove link to Foundation Console, as it is being phased out and by offering a free option directly competes with providers offering paid options.  