### PR TITLE
add ErrorLens extension to workspace recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-	"recommendations": [
-		"esbenp.prettier-vscode",
-		"znck.grammarly",
-	]
+  "recommendations": ["esbenp.prettier-vscode", "znck.grammarly", "usernamehw.errorlens"]
 }


### PR DESCRIPTION
[Error Lens VSCode extension](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens) displays errors inline

With Error Lens:
<img width="517" alt="image" src="https://github.com/helium/docs/assets/1404219/ba00cb69-da66-45ef-9c49-ea73baed0168">


Without Error Lens:
<img width="517" alt="image" src="https://github.com/helium/docs/assets/1404219/2cc87f3c-2f9d-4958-8f07-f4cd12d0b8b8">
