### PR TITLE
fixup redirect loop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -79,11 +79,6 @@
   status = 301
   force = true
 [[redirects]]
-  from = "/iot"
-  to = "/lorawan-on-helium"
-  status = 301
-  force = true
-[[redirects]]
   from = "/hotspot-makers/hotspot-manufacturers"
   to = "/hotspot-makers"
   status = 301


### PR DESCRIPTION
circular redirect was preventing browsers from opening the docs.helium.com/iot page