### PR TITLE
Redirect Cleanup to Improve Algolia search results

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,166 +10,61 @@
   force = true
 [[redirects]]
   from = "/helium-tokens/sol-token"
-  to = "/sol-token"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/sol-token"
   to = "/tokens/sol-token"
   status = 301
   force = true
 [[redirects]]
-  from = "/hotspot-makers/maker-apps"
-  to = "/hotspot-makers"
+  from = "/api"
+  to = "/api/blockchain"
   status = 301
   force = true
 [[redirects]]
-  from = "/mine-hnt/full-hotspots/become-a-maker/*"
-  to = "/hotspot-makers/become-a-maker/:splat"
+  from = "/api/blockchain/*"
+  to = "/blockchain/api/:splat"
   status = 301
   force = true
 [[redirects]]
-  from = "/use-the-network/policies"
-  to = "/"
+  from = "/api/console"
+  to = "/console/api"
   status = 301
   force = true
 [[redirects]]
-  from = "/use-the-network/policies/terms"
-  to = "/"
+  from = "/archive/api"
+  to = "/api/blockchian"
   status = 301
   force = true
 [[redirects]]
-  from = "/use-the-network/policies/privacy"
-  to = "/"
+  from = "/wallets/ledger"
+  to = "/wallets/ledger-wallet"
   status = 301
   force = true
 [[redirects]]
-  from = "/solana/oracle-data"
-  to = "/oracles/oracle-data"
+  from = "/hotspot-makers/iot/data-only-hotspots"
+  to = "/iot/data-only-hotspots"
   status = 301
   force = true
 [[redirects]]
-  from = "/architecture/solana/migration/hotspot-owner"
-  to = "/architecture/solana/migration/hotspot-operator"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/blockchain/helium-token"
-  to = "/tokens/hnt-token"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/open-lns"
-  to = "/iot/lorawan-network-servers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/hotspot-makers/original-helium-hotspot"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/blockchain/oracles"
-  to = "/oracles/price-oracles"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/validators/*"
-  to = "/architecture/solana/migration/validator-operator"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/hotspot-makers/hotspot-manufacturers"
-  to = "/hotspot-makers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/hotspot-makers/5g-hardware-specification"
-  to = "/hotspot-makers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/hotspot-makers/5g-hotspot-requirements"
-  to = "/hotspot-makers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/crowdspot"
-  to = "/iot/crowdspot"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/denylist-removals"
-  to = "/iot/denylist-removals"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/denylist"
-  to = "/iot/denylist"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/lorawan-on-helium/*"
-  to = "/iot"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/troubleshooting/hotspot-led"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/troubleshooting/network-troubleshooting"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/understanding-hotspot-status"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/troubleshooting/replace-sd-card"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/troubleshooting/understanding-witnesses"
-  to = "/"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/console-marketplace"
-  to = "/console/marketplace"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/console/data-credits"
-  to = "/data-credit"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/maker-apps"
-  to = "/hotspot-makers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/helium-tokens/data-credit"
+  from = "/data-credit"
   to = "/tokens/data-credit"
   status = 301
   force = true
 [[redirects]]
-  from = "/helium-tokens/hnt"
+  from = "/data-credit-portal"
+  to = "/tokens/data-credit-portal"
+  status = 301
+  force = true
+[[redirects]]
+  from = "/hnt-token"
   to = "/tokens/hnt-token"
   status = 301
   force = true
 [[redirects]]
-  from = "/helium-tokens/iot"
+  from = "/iot-token"
   to = "/tokens/iot-token"
   status = 301
   force = true
 [[redirects]]
-  from = "/helium-tokens/mobile"
+  from = "/mobile-token"
   to = "/tokens/mobile-token"
   status = 301
   force = true
@@ -179,254 +74,13 @@
   status = 301
   force = true
 [[redirects]]
-  from = "/mine-iot"
-  to = "/tokens/mine-iot"
-  status = 301
-  force = true
-[[redirects]]
   from = "/use-the-network/devices/*"
   to = "/iot/devices/:splat"
   status = 301
   force = true
 [[redirects]]
-  from = "/use-the-network/community-projects"
-  to = "/archive/community-projects"
-  status = 301
-  force = true
-[[redirects]]
   from = "/use-the-network/console/*"
   to = "/console/:splat"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/console"
-  to = "/console"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/api/*"
-  to = "/blockchain/api/:splat"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/twelve-words"
-  to = "/wallets/wallet-seed-phrase"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/twenty-four-words"
-  to = "/wallets/wallet-seed-phrase"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/app-wallet"
-  to = "/wallets/helium-wallet-app"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/app-wallet/*"
-  to = "/wallets/helium-wallet-app"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/cli-wallet"
-  to = "/wallets/cli-wallet"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/ledger"
-  to = "/wallets/ledger-wallet"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/wallets/app-wallet/hexagons"
-  to = "/architecture/hexagons"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/hexagons"
-  to = "/architecture/hexagons"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/network-iot/hotspots-iot/data-only-hotspots"
-  to = "/iot/data-only-hotspots"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/network-iot/hotspots-iot/data-only/*"
-  to = "/iot/data-only/:splat"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/full-hotspots"
-  to = "/iot/iot-hotspot"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/open-lns"
-  to = "/iot/lorawan-network-servers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/open-lns-quickstart"
-  to = "/iot/run-a-lns"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network"
-  to = "/iot"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/run-a-network-server/buy-an-oui"
-  to = "/iot/buy-an-oui"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/devices/*"
-  to = "/network-iot/:splat"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/roaming"
-  to = "/iot/roaming"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/setup-a-packet-forwarder"
-  to = "/iot/setup-a-packet-forwarder"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/network-iot/transaction-fees"
-  to = "/iot/transaction-fees"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/blockchain/transaction-fees"
-  to = "/iot/transaction-fees"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/network-iot/setup-a-packet-forwarder"
-  to = "/iot/setup-a-packet-forwarder"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/network-iot/roaming"
-  to = "/iot/roaming"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/network-iot/hotspots-iot/light-hotspots"
-  to = "/iot/hotspots"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/region-plans"
-  to = "/iot/lorawan-region-plans"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/frequency-plans"
-  to = "/iot/lorawan-frequency-plans"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/coverage-mapping/adeunis-mapper"
-  to = "/iot/coverage-mapping/adeunis-mapper"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/coverage-mapping"
-  to = "/iot/coverage-mapping"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/coverage-mapping/mappers-api"
-  to = "/iot/coverage-mapping/api"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/coverage-mapping/mappers-quickstart"
-  to = "/iot/coverage-mapping/quickstart"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/use-the-network/coverage-mapping/mappers-roadmap"
-  to = "/iot/coverage-mapping/roadmap"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/community-governance/governance"
-  to = "/governance"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/mine-hnt/validators/validators-and-voting-power"
-  to = "/governance-faq"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/community-governance/community-voting"
-  to = "/governance/voting"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/vote-escrow/voting-power"
-  to = "/governance-faq"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/vote-escrow/realms"
-  to = "/governance/staking-with-realms"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/5g-poc"
-  to = "/mobile/proof-of-coverage"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/mining-5g"
-  to = "/mobile/proof-of-coverage"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/cbrs-radios"
-  to = "/mobile/cbrs-radios"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/mobile-mappers"
-  to = "/mobile/mobile-mappers"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/mobile-poc"
-  to = "/mobile/proof-of-coverage"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/5g-on-helium/service-providers"
-  to = "/mobile/service-providers"
-  status = 301
-  force = true
-[[redirects]]
-    from = "/mobile/mappers"
-    to = "/mobile/mobile-mappers"
-    status = 301
-    force = true
-[[redirects]]
-  from = "/iot/lorawan-roaming-quickstart"
-  to = "/iot/lorawan-roaming"
-  status = 301
-  force = true
-[[redirects]]
-  from = "/iot/roaming"
-  to = "/iot/lorawan-roaming"
   status = 301
   force = true
 [build.environment]


### PR DESCRIPTION
uses analytics data from the previous 90 days to remove redirects that have never been used or have been used in less thant 0.1% of total page views.

will assist in algolia crawling and indexing for improved search functionality.