### PR TITLE
Fix broken link to Helium Console

### DIFF
--- a/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
+++ b/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
@@ -68,7 +68,7 @@ with the Helium Console.
 
 - [VSCode \(IDE)](https://code.visualstudio.com/)
   - [PlatformIO \(VScode Extension)](https://platformio.org/)
-- [Helium Console](https://www.helium.com/console)
+- [Helium Console](/console)
 
 ## Hardware Setup <a id="hardware-setup"></a>
 


### PR DESCRIPTION
The tutorial at <https://docs.helium.com/network-iot/devices/development/heltec/cubecell-dev-board/platformio#software> has a nonoperational link to Helium Console. I propose to change this to <https://docs.helium.com/console/>, rather than a direct link to <https://console.helium.com/>, so readers have more information about deprecation and other options.