### PR TITLE
Fix misprints in CubeCell, WisBlock PlatformIO tutorials

### DIFF
--- a/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
+++ b/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
@@ -364,7 +364,7 @@ with an example Helium network-enabled application.
 
 To update the sample application created above:
 
-- open, within PlatformIO, your projects src/main.ccp file
+- open, within PlatformIO, your projects src/main.cpp file
 - replace this template main.cpp with the content of the sample application found
   [here](https://github.com/helium/longfi-platformio/blob/master/Heltec-CubeCell-Board/examples/cubecell-helium-us915-basic/src/main.cpp).
   Copy and paste the entirety of it.

--- a/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
+++ b/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
@@ -97,7 +97,7 @@ device driver code. Most hardware developer board vendors will supply directions
 accomplished.
 
 For our example installation directions can be found on Heltec's documentation website
-[here](https://heltec-automation-docs.readthedocs.io/en/latest/general/establish_serial_connection.html).
+[here](https://docs.heltec.org/general/establish_serial_connection.html).
 
 ## Software Setup <a id="software-setup"></a>
 

--- a/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
+++ b/docs/network-iot/devices/development/heltec/cubecell-dev-board/platformio.mdx
@@ -38,7 +38,7 @@ professional tool for embedded systems engineers and software developers who wri
 embedded products.
 
 Here, we will detail the steps required to integrate a specific board type, one of the
-[Heltec CubeCell AB0x](https://heltec.org/proudct_center/lora/cubecell/) family of boards.
+[Heltec CubeCell AB0x](https://heltec.org/cubecell_overview/) family of boards.
 
 However, this guide can be also used to on-board many other types of target devices. In most cases
 one can just substitute your target device in place of the CubeCell developer board.
@@ -58,7 +58,7 @@ may work but have not been tested
 
 ### Hardware
 
-- [Heltec CubeCell Development Boards (AB01, AB02x, Capsule)](https://heltec.org/proudct_center/lora/cubecell/)
+- [Heltec CubeCell Development Boards (AB01, AB02x, Capsule)](https://heltec.org/cubecell_overview/)
 - Micro USB Type B Cable -
   [Example](https://www.amazon.com/AmazonBasics-Male-Micro-Cable-Black/dp/B0719H12WD/ref=sr_1_2_sspa?)
 
@@ -128,7 +128,7 @@ unfamiliar interface.
 [https://docs.platformio.org/en/latest/integration/ide/vscode.html\#quick-start](https://docs.platformio.org/en/latest/integration/ide/vscode.html#quick-start)
 
 In this tutorial, as an example, we will be using the
-[Heltec CubeCell AB0x](https://heltec.org/proudct_center/lora/cubecell/). One can substitute your
+[Heltec CubeCell AB0x](https://heltec.org/cubecell_overview/). One can substitute your
 target device as needed as you progress through these steps.
 
 Once PlatformIO is installed, you should be welcomed to VSCode with the following "PIO Home" screen:

--- a/docs/network-iot/devices/development/rakwireless/wisblock-4631/platformio.mdx
+++ b/docs/network-iot/devices/development/rakwireless/wisblock-4631/platformio.mdx
@@ -68,7 +68,7 @@ with the Helium Console.
 
 - [VSCode \(IDE)](https://code.visualstudio.com/)
   - [PlatformIO \(VScode Extension)](https://platformio.org/)
-- [Helium Console](https://www.helium.com/console)
+- [Helium Console](/console)
 
 ## Hardware Setup
 

--- a/docs/network-iot/devices/development/rakwireless/wisblock-4631/platformio.mdx
+++ b/docs/network-iot/devices/development/rakwireless/wisblock-4631/platformio.mdx
@@ -441,7 +441,7 @@ board with an example Helium network enabled application.
 
 To update the sample application created above:
 
-- open, within PlatformIO, your projects src/main.ccp file
+- open, within PlatformIO, your projects src/main.cpp file
 - replace this template main.cpp with the content of the sample application found
   [here](https://github.com/helium/longfi-platformio/blob/master/RAKWireless-WisBlock/examples/LoRaWan_OTAA/src/main.cpp).
   Copy and paste the entirety of it.


### PR DESCRIPTION
I am reviewing the tutorials about development on the Helium IoT network and found several out-of-date URLs and misprints. This pull request proposes corrections.