### PR TITLE
Update lorawan-region-plans.mdx

### DIFF
--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -72,7 +72,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Bosnia and Herzegovina         | EU868          |
 | Botswana                       | EU868          |
 | Bouvet Island                  | EU868          |
-| Brazil                         | AU915_SB1      |
+| Brazil                         | AU915_SB2      |
 | British Indian Ocean Territory | Unknown        |
 | British Virgin Islands         | AU915_SB1      |
 | Brunei                         | AS923_1        |


### PR DESCRIPTION
Brazil frequency to AU915_SB2 from SB1, was incorrect since it never switched. 