### PR TITLE
Update all AU915-SB1 to SB2

### DIFF
--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -40,13 +40,13 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | American Samoa          | US915          |
 | Andorra                 | EU868          |
 | Angola                  | Unknown        |
-| Anguilla                | AU915_SB1      |
+| Anguilla                | AU915_SB2      |
 | Antarctica - Chilean    | Unknown        |
 | Antarctica - Australian | Unknown        |
 | Antarctica - British    | Unknown        |
 | Antarctica - Argentine  | Unknown        |
 | Antigua and Barbuda     | Unknown        |
-| Argentina               | AU915_SB1      |
+| Argentina               | AU915_SB2      |
 | Armenia                 | EU868          |
 | Aruba                   | Unknown        |
 | Australia               | AU915_SB2      |
@@ -60,10 +60,10 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Bahamas                        | US915          |
 | Bahrain                        | EU868          |
 | Bangladesh                     | AS923_1        |
-| Barbados                       | AU915_SB1      |
+| Barbados                       | AU915_SB2      |
 | Belarus                        | EU868          |
 | Belgium                        | EU868          |
-| Belize                         | AU915_SB1      |
+| Belize                         | AU915_SB2      |
 | Benin                          | EU868          |
 | Bermuda                        | US915          |
 | Bhutan                         | EU868          |
@@ -74,7 +74,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Bouvet Island                  | EU868          |
 | Brazil                         | AU915_SB2      |
 | British Indian Ocean Territory | Unknown        |
-| British Virgin Islands         | AU915_SB1      |
+| British Virgin Islands         | AU915_SB2      |
 | Brunei                         | AS923_1        |
 | Bulgaria                       | EU868          |
 | Burkina Faso                   | Unknown        |
@@ -91,11 +91,11 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Cayman Islands           | US915          |
 | Central African Republic | Unknown        |
 | Chad                     | Unknown        |
-| Chile                    | AU915_SB1      |
+| Chile                    | AU915_SB2      |
 | China                    | CN470          |
 | Christmas Island         | AU915_SB2      |
 | Cocos [Keeling] Islands  | AU915_SB2      |
-| Colombia                 | AU915_SB1      |
+| Colombia                 | AU915_SB2      |
 | Comoros                  | EU868          |
 | Congo [DRC]              | Unknown        |
 | Congo [Republic]         | Unknown        |
@@ -114,16 +114,16 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | ------------------ | -------------- |
 | Denmark            | EU868          |
 | Djibouti           | Unknown        |
-| Dominica           | AU915_SB1      |
-| Dominican Republic | AU915_SB1      |
+| Dominica           | AU915_SB2      |
+| Dominican Republic | AU915_SB2      |
 
 #### E <a id="e"></a>
 
 | Country              | Frequency Plan |
 | -------------------- | -------------- |
-| Ecuador              | AU915_SB1      |
+| Ecuador              | AU915_SB2      |
 | Egypt                | EU868          |
-| El Salvador          | AU915_SB1      |
+| El Salvador          | AU915_SB2      |
 | Equatorial Guinea    | EU868          |
 | Eritrea              | Unknown        |
 | Estonia              | EU868          |
@@ -156,10 +156,10 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Gibraltar     | EU868          |
 | Greece        | EU868          |
 | Greenland     | EU868          |
-| Grenada       | AU915_SB1      |
+| Grenada       | AU915_SB2      |
 | Guadeloupe    | EU868          |
 | Guam          | US915          |
-| Guatemala     | AU915_SB1      |
+| Guatemala     | AU915_SB2      |
 | Guernsey      | EU868          |
 | Guinea        | EU433          |
 | Guinea-Bissau | Unknown        |
@@ -171,7 +171,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | --------------------------------- | -------------- |
 | Haiti                             | Unknown        |
 | Heard Island and McDonald Islands | AU915_SB2      |
-| Honduras                          | AU915_SB1      |
+| Honduras                          | AU915_SB2      |
 | Hong Kong                         | AS923_1        |
 | Hungary                           | EU868          |
 
@@ -193,7 +193,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 
 | Country | Frequency Plan |
 | ------- | -------------- |
-| Jamaica | AU915_SB1      |
+| Jamaica | AU915_SB2      |
 | Japan   | AS923_1        |
 | Jersey  | EU868          |
 | Jordan  | IN865          |
@@ -246,7 +246,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Monaco           | EU868          |
 | Mongolia         | Unknown        |
 | Montenegro       | EU868          |
-| Montserrat       | AU915_SB1      |
+| Montserrat       | AU915_SB2      |
 | Morocco          | EU433          |
 | Mozambique       | Unknown        |
 | Myanmar [Burma]  | AS923_1        |
@@ -262,7 +262,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Netherlands Antilles     | EU868          |
 | New Caledonia            | EU868          |
 | New Zealand              | AS923_1C       |
-| Nicaragua                | AU915_SB1      |
+| Nicaragua                | AU915_SB2      |
 | Niger                    | IN865          |
 | Nigeria                  | EU868          |
 | Niue                     | AS923_1        |
@@ -284,10 +284,10 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Pakistan                | AS923          |
 | Palau                   | Unknown        |
 | Palestinian Territories | Unknown        |
-| Panama                  | AU915_SB1      |
+| Panama                  | AU915_SB2      |
 | Papua New Guinea        | AS923_1        |
-| Paraguay                | AU915_SB1      |
-| Peru                    | AU915_SB1      |
+| Paraguay                | AU915_SB2      |
+| Peru                    | AU915_SB2      |
 | Philippines             | AS923_3        |
 | Pitcairn Islands        | Unknown        |
 | Poland                  | EU868          |
@@ -316,11 +316,11 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Sahrawi Arab Democratic Republic             | Unknown        |
 | Saint Barthelemy                             | EU868          |
 | Saint Helena                                 | Unknown        |
-| Saint Kitts and Nevis                        | AU915_SB1      |
-| Saint Lucia                                  | AU915_SB1      |
+| Saint Kitts and Nevis                        | AU915_SB2      |
+| Saint Lucia                                  | AU915_SB2      |
 | Saint Martin                                 | EU868          |
 | Saint Pierre and Miquelon                    | EU868          |
-| Saint Vincent and the Grenadines             | AU915_SB1      |
+| Saint Vincent and the Grenadines             | AU915_SB2      |
 | Samoa                                        | EU868          |
 | San Marino                                   | EU868          |
 | São Tomé and Príncipe                        | Unknown        |
@@ -341,7 +341,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Spain                                        | EU868          |
 | Sri Lanka                                    | AS923_1        |
 | Sudan                                        | Unknown        |
-| Suriname                                     | AU915_SB1      |
+| Suriname                                     | AU915_SB2      |
 | Svalbard and Jan Mayen                       | EU868          |
 | Swaziland see Eswatini                       | -              |
 | Sweden                                       | EU868          |
@@ -359,12 +359,12 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Timor-Leste              | Unknown        |
 | Togo                     | EU433          |
 | Tokelau                  | AS923_1        |
-| Tonga                    | AU915_SB1      |
-| Trinidad and Tobago      | AU915_SB1      |
+| Tonga                    | AU915_SB2      |
+| Trinidad and Tobago      | AU915_SB2      |
 | Tunisia                  | EU868          |
 | Turkey                   | EU868          |
 | Turkmenistan             | Unknown        |
-| Turks and Caicos Islands | AU915_SB1      |
+| Turks and Caicos Islands | AU915_SB2      |
 | Tuvalu                   | Unknown        |
 
 #### U <a id="u"></a>
@@ -378,7 +378,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | United Arab Emirates        | EU868          |
 | United Kingdom              | EU868          |
 | United States               | US915          |
-| Uruguay                     | AU915_SB1      |
+| Uruguay                     | AU915_SB2      |
 | Uzbekistan                  | EU433          |
 
 #### V <a id="v"></a>
@@ -389,7 +389,7 @@ band. Countries with EU433 should consider regulations to support the 800 or 900
 | Vatican City (Holy See) | EU868          |
 | Venezuela               | AS923_1        |
 | Vietnam                 | AS923_2        |
-| Virgin Islands (UK)     | AU915_SB1      |
+| Virgin Islands (UK)     | AU915_SB2      |
 
 #### W <a id="w"></a>
 


### PR DESCRIPTION
Helium's default AU915 is AU915-SB2
SB1 was deployed to Brazil but reverted before deployment elsewhere https://github.com/dewi-alliance/hplans/commit/e2a3a57a86c71e05064037576b3bc5f910ef5267#diff-484b47b13864c913b930e726a40a54b126e50402b3ef374ca4090f51a0a2813bL33