### PR TITLE
Use current docslab version (0.3.7)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,10 +132,7 @@ module.exports = {
           trackingID: 'G-85D2WJWZNL',
         },
         theme: {
-          customCss: [
-            require.resolve('./node_modules/docslab/lib/main.css'),
-            require.resolve('./src/css/custom.css'),
-          ],
+          customCss: require.resolve('./src/css/custom.css'),
         },
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,7 +132,10 @@ module.exports = {
           trackingID: 'G-85D2WJWZNL',
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: [
+            require.resolve('./node_modules/docslab/lib/main.css'),
+            require.resolve('./src/css/custom.css'),
+          ],
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@solana/web3.js": "^1.66.1",
     "axios": "^1.3.4",
     "clsx": "^1.1.1",
-    "docslab-docusaurus": "^0.2.6",
+    "docslab-docusaurus": "^0.2.7",
     "hast-util-is-element": "1.1.0",
     "mdx-embed": "^1.1.2",
     "process": "^0.11.10",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@solana/web3.js": "^1.66.1",
     "axios": "^1.3.4",
     "clsx": "^1.1.1",
-    "docslab-docusaurus": "^0.2.4",
+    "docslab-docusaurus": "^0.2.6",
     "hast-util-is-element": "1.1.0",
     "mdx-embed": "^1.1.2",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4408,17 +4408,17 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docslab-docusaurus@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/docslab-docusaurus/-/docslab-docusaurus-0.2.4.tgz#6ba69bf73916d797511a30599a2c0868ce2ca93f"
-  integrity sha512-i52m+z6/Lfdh8B9aXnghGy0ijgLlu4pRDNPJ+/w5GAoneLSiwxRyEri+8HSkcWcoxFqUyepqgMOYLtFCBAWh+Q==
+docslab-docusaurus@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/docslab-docusaurus/-/docslab-docusaurus-0.2.6.tgz#fa3f5201bff6db42508efac791b24a64ed375b4e"
+  integrity sha512-9J2DMPNJTLvlMM4Y4lp2xTnRnH3kS+Z8KQRFFKrG5+gfTXa2qrjnXYkOAaG3hgbACMeV7mgleUk+r45JqA8nPw==
   dependencies:
-    docslab "^0.3.5"
+    docslab "^0.3.7"
 
-docslab@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/docslab/-/docslab-0.3.5.tgz#bff12412c9af913f628e43bc9d33759eeb7e35bf"
-  integrity sha512-A1hqU/48L93ZBEvBT1faQuw8iT3wwowjtrK5YIQog7T7w0Md7J1lIg74lR2lD+TCZYXFMx3pBa8KvL2dhTxo0g==
+docslab@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/docslab/-/docslab-0.3.7.tgz#7b0e25676979d3dac211412e936b391d20f3004b"
+  integrity sha512-7sUcsfB1do2cB/uNPJzdZAwJNuTlvsY9ivPFGUpuY89o9kXGEDIoIhJ2cmJZiDemrxBfFUnGpAqQy7WBrQ04mA==
   dependencies:
     ace-code "^1.23.4"
     xterm "^5.2.1"


### PR DESCRIPTION
This pull request updates the [docslab-docusaurus dependency](https://www.npmjs.com/package/docslab-docusaurus), which in turn has the current [docslab](https://github.com/rerobots/docslab). It fixes a bug with toggling hide/show in the code editor and moves styling to an external CSS file.

Also, in each sandbox, the current version includes a small "powered by docslab" that links to the repository, which might help drive participation with development, reporting bugs, etc.