### PR TITLE
Link to `realms.heliumvote.com` rather than `realms.today`

### DIFF
--- a/docs/governance/staking-with-realms.mdx
+++ b/docs/governance/staking-with-realms.mdx
@@ -15,9 +15,9 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <img className="docsheader" src={useBaseUrl('/img/blockchain/realmsheader.png')} />
 
-Like many other Solana Ecosystem projects, Helium utilizes [Realms](https://realms.today) to
+Like many other Solana Ecosystem projects, Helium utilizes [Realms](https://realms.heliumvote.com/) to
 organize and manage vote escrow tokens, delegation, and more. Stakes can be created and later
-managed within Realms at any time.
+managed within Realms at any time at <https://realms.heliumvote.com/>
 
 ## Creating a Stake
 


### PR DESCRIPTION
The former provides additional voting-related functionality, and claiming rewards works better w/ Ledgers