### PR TITLE
Update mobile-token.mdx

### DIFF
--- a/docs/tokens/mobile-token.mdx
+++ b/docs/tokens/mobile-token.mdx
@@ -51,17 +51,17 @@ throughout the Genesis period to live Mobile Network Hotspots. Year 1 for MOBILE
 The issuance is scheduled to have halvings every 2 years, aligning with HNT issuance halvings.
 
 The emission schedule was created in [HIP-53][hip-53-emissions], updated in
-[HIP-75][hip-75-emissions]and confirmed in [HIP-77][hip-77-emissions] and is as follows:
+[HIP-75][hip-75-emissions], confirmed in [HIP-77][hip-77-emissions] and updated in [HIP-79][hip-79]. It is as follows:
 
 | Year | MOBILE at Year Start | MOBILE Minted                     | Proof of Coverage <sup>(</sup>[^4]<sup>)</sup> | Hotspot Data <sup>(</sup>[^4]<sup>)</sup> | Mappers | Service Providers | Oracles <sup>(</sup>[^5]<sup>)</sup> | veHNT Stakers |
 | ---- | -------------------- | --------------------------------- | ---------------------------------------------- | ----------------------------------------- | ------- | ----------------- | ------------------------------------ | ------------- |
-| 1    | 50B                  | 110B <sup>(</sup>[^6]<sup>)</sup> | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 2    | 110B                 | 30B                               | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 3    | 140B                 | 30B                               | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 4    | 170B                 | 15B                               | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 5    | 185B                 | 15B                               | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 6    | 200B                 | 7.5B                              | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
-| 7    | 207.5B               | 7.5B                              | 20%                                            | 40%                                       | 10%     | 20%               | 4%                                   | 6%            |
+| 1    | 50B                  | 110B <sup>(</sup>[^6]<sup>)</sup> | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 2    | 110B                 | 30B                               | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 3    | 140B                 | 30B                               | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 4    | 170B                 | 15B                               | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 5    | 185B                 | 15B                               | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 6    | 200B                 | 7.5B                              | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
+| 7    | 207.5B               | 7.5B                              | 20%                                            | 40%                                       | 20%     | 10%               | 4%                                   | 6%            |
 
 > Full token emissions can be viewed in the MOBILE section of this document: [Token Emissions as of
 > Solana Migration][sol-emisions]
@@ -83,6 +83,7 @@ The emission schedule was created in [HIP-53][hip-53-emissions], updated in
 [hip-77-emissions]:
   https://github.com/helium/HIP/blob/main/0077-solana-parameters.md#emission-schedules
 [hip-77]: https://github.com/helium/HIP/blob/main/0077-solana-parameters.md
+[hip-79]: https://github.com/helium/HIP/blob/main/0079-mobile-poc-mappers-rewards.md
 [mobile-mint-addr]: https://explorer.solana.com/address/mb1eu7TzEc71KxDpsmsKoucSSuuoGLv1drys1oP2jh6
 [mobile]: /mobile/5g-on-helium
 [sol-emisions]:


### PR DESCRIPTION
Reward shares for Mappers and Service Providers were changed in HIP 79. Updated the respective parts of this doc accordingly. Feel free to double-check, if I got the URL to HIP-79 right.