### PR TITLE
Removes contextual alternates when rendering wallet addresses

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -884,3 +884,7 @@ html[data-theme='dark'] .badge--secondary:hover {
   width: 70%;
   height: 300px;
 }
+
+.font-disable-calt {
+  font-feature-settings:'calt' 0,'calt'0;
+}

--- a/src/theme/DisplayLegacyWallet.tsx
+++ b/src/theme/DisplayLegacyWallet.tsx
@@ -8,7 +8,7 @@ export const DisplayLegacyWallet = () => {
   const [wallet, setWallet] = useState<string>("");
 
   return (
-    <div className="display-legacy-wallet">
+    <div className="display-legacy-wallet font-disable-calt">
       <input
         type="text"
         name="wallet"

--- a/src/theme/MigrateWallet.tsx
+++ b/src/theme/MigrateWallet.tsx
@@ -56,7 +56,7 @@ export const MigrateWallet = () => {
   })
 
   return (
-    <div style={{ paddingBottom: '20px' }}>
+    <div className="font-disable-calt" style={{ paddingBottom: '20px' }}>
       {errorInflate && (
         <div class="alert alert--danger" role="alert">
           {errorInflate.message}


### PR DESCRIPTION
Before:
<img width="558" alt="image" src="https://github.com/helium/docs/assets/1965053/522cd53c-225a-4cac-85f7-0414a672daf5">


After:
<img width="554" alt="image" src="https://github.com/helium/docs/assets/1965053/023bf1ab-557d-4583-8605-7dc920ae17d1">

More on Inter font and calt: https://rsms.me/inter/#features