### PR TITLE
Update vehnt.mdx

### DIFF
--- a/docs/governance/vehnt.mdx
+++ b/docs/governance/vehnt.mdx
@@ -66,7 +66,7 @@ projects and initiatives aimed at integrating Helium technology into mobile devi
 To earn rewards from the token emissions, veHNT holders must delegate their position to one or more
 subDAOs. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
 resulting in a higher veHNT multiplier. Users can also change their delegations at any time to
-optimize their rewards from the subDAOs.
+optimize their rewards from the subDAOs. For the accrued rewards to be sent to a veHNT holder's wallet, they need to be claimed manually.
 
 veTokens can be managed through [Realms](/governance/staking-with-realms) using the in-app browser
 on the [Helium Wallet App](/wallets/helium-wallet-app):

--- a/docs/governance/vehnt.mdx
+++ b/docs/governance/vehnt.mdx
@@ -9,9 +9,6 @@ slug: /governance/vehnt
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
-<LegacyContentBanner />
 
 <img className="docsheader" src={useBaseUrl('/img/blockchain/veHNT.png')} />
 
@@ -66,7 +63,8 @@ projects and initiatives aimed at integrating Helium technology into mobile devi
 To earn rewards from the token emissions, veHNT holders must delegate their position to one or more
 subDAOs. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
 resulting in a higher veHNT multiplier. Users can also change their delegations at any time to
-optimize their rewards from the subDAOs. For the accrued rewards to be sent to a veHNT holder's wallet, they need to be claimed manually.
+optimize their rewards from the subDAOs. For the accrued rewards to be sent to a veHNT holder's
+wallet, they need to be claimed manually.
 
 veTokens can be managed through [Realms](/governance/staking-with-realms) using the in-app browser
 on the [Helium Wallet App](/wallets/helium-wallet-app):


### PR DESCRIPTION
Added a sentence that rewards need to be claimed manually to be sent to a veHNT holder's wallet. That information was missing.