### PR TITLE
Add info about DeWi ETL to the "Blockchain ETL" page

### DIFF
--- a/docs/architecture/solana/migration/blockchain-etl.mdx
+++ b/docs/architecture/solana/migration/blockchain-etl.mdx
@@ -15,12 +15,18 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 [Blockchain ETL](https://github.com/helium/blockchain-etl) will halt along with the blockchain
 during the migration. Hosted instances of this service may choose to continue offering historical
-data from the Helium L1 via these synced ETLs. 
+data from the Helium L1 via these synced ETLs.
 
-A full snapshot of the Helium L1 has been retained and
-uploaded for public availability; see [Blockchain API](/solana/migration/blockchain-api) page for a torrent link.
+A full snapshot of the Helium L1 has been retained and uploaded for public availability; see
+[Blockchain API](/solana/migration/blockchain-api) page for a torrent link.
 
-The Helium Foundation also hosts a publicly queryable instance of Helium L1 data at [DeWi ETL](https://etl.dewi.org/). Note this server is in maintenance mode, and availability and query performance are not guaranteed. Google Auth login is required. The [Account Details](https://etl.dewi.org/dashboard/131-account-details?days=30) or [Hotspot Details](https://etl.dewi.org/dashboard/7-hotspot-details?days=30) dashboards are good jumping-off points. Please consult the `#data-analysis` channel in the Helium Discord server if you have questions.
+The Helium Foundation also hosts a publicly queryable instance of Helium L1 data at
+[DeWi ETL](https://etl.dewi.org/). Note this server is in maintenance mode, and availability and
+query performance are not guaranteed. Google Auth login is required. The
+[Account Details](https://etl.dewi.org/dashboard/131-account-details?days=30) or
+[Hotspot Details](https://etl.dewi.org/dashboard/7-hotspot-details?days=30) dashboards are good
+jumping-off points. Please consult the `#data-analysis` channel in the Helium Discord server if you
+have questions.
 
 For ongoing insight into the operation of the Helium Network post-migration, please refer to the
 [Oracle Data](/oracles/oracle-data) documentation.

--- a/docs/architecture/solana/migration/blockchain-etl.mdx
+++ b/docs/architecture/solana/migration/blockchain-etl.mdx
@@ -20,7 +20,7 @@ data from the Helium L1 via these synced ETLs.
 A full snapshot of the Helium L1 has been retained and
 uploaded for public availability; see [Blockchain API](/solana/migration/blockchain-api) page for a torrent link.
 
-The Helium Foundation also hosts a publicly queryable instance of Helium L1 data at [DeWi ETL](https://etl.dewi.org/). Note this server is in maintenance mode, and availability and performance are not garaunteed. Google Auth login is required. The [Account Details](https://etl.dewi.org/dashboard/131-account-details?days=30) or [Hotspot Details](https://etl.dewi.org/dashboard/7-hotspot-details?days=30) dashboards are good jumping-off points. Please consult the `#data-analysis` channel in the Helium Discord server if you have questions.
+The Helium Foundation also hosts a publicly queryable instance of Helium L1 data at [DeWi ETL](https://etl.dewi.org/). Note this server is in maintenance mode, and availability and query performance are not guaranteed. Google Auth login is required. The [Account Details](https://etl.dewi.org/dashboard/131-account-details?days=30) or [Hotspot Details](https://etl.dewi.org/dashboard/7-hotspot-details?days=30) dashboards are good jumping-off points. Please consult the `#data-analysis` channel in the Helium Discord server if you have questions.
 
 For ongoing insight into the operation of the Helium Network post-migration, please refer to the
 [Oracle Data](/oracles/oracle-data) documentation.

--- a/docs/architecture/solana/migration/blockchain-etl.mdx
+++ b/docs/architecture/solana/migration/blockchain-etl.mdx
@@ -15,8 +15,12 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 [Blockchain ETL](https://github.com/helium/blockchain-etl) will halt along with the blockchain
 during the migration. Hosted instances of this service may choose to continue offering historical
-data from the Helium L1 via these synced ETLs. A full snapshot of the Helium L1 will be retained and
-uploaded for public availability post-migration.
+data from the Helium L1 via these synced ETLs. 
+
+A full snapshot of the Helium L1 has been retained and
+uploaded for public availability; see [Blockchain API](/solana/migration/blockchain-api) page for a torrent link.
+
+The Helium Foundation also hosts a publicly queryable instance of Helium L1 data at [DeWi ETL](https://etl.dewi.org/). Note this server is in maintenance mode, and availability and performance are not garaunteed. Google Auth login is required. The [Account Details](https://etl.dewi.org/dashboard/131-account-details?days=30) or [Hotspot Details](https://etl.dewi.org/dashboard/7-hotspot-details?days=30) dashboards are good jumping-off points. Please consult the `#data-analysis` channel in the Helium Discord server if you have questions.
 
 For ongoing insight into the operation of the Helium Network post-migration, please refer to the
 [Oracle Data](/oracles/oracle-data) documentation.


### PR DESCRIPTION
Still online and queryable for L1 info, though not an API

Separate PR incoming for some other info on the "Blockchain API" page