### PR TITLE
Moved references location in text on IOT Token page

### DIFF
--- a/docs/tokens/iot-token.mdx
+++ b/docs/tokens/iot-token.mdx
@@ -17,9 +17,6 @@ Network through the community proposal [HIP-52][hip-52] and is further defined i
 HIPs<sup>(</sup>[^1]<sup>,</sup>[^2]<sup>)</sup>. The first IOT tokens were minted following the
 Solana migration on April 18, 2023.
 
-[^1]: [HIP-70: Scaling the Helium Network][hip-70]
-[^2]: [HIP-77: Solana Parameters][hip-77]
-
 The IOT token is mined by LoRaWAN Hotspots through both data transfer proceeds as well as Proof of
 Coverage.
 
@@ -64,9 +61,6 @@ The emissions schedule was created in [HIP-52][hip-52-emisions] and confirmed in
 > Full token emissions can be viewed in the IOT section of this document: [Token Emissions as of
 > Solana Migration][migration-emissions].
 
-[^3]: Any IOT not rewarded for data transfer is rolled into Proof of Coverage.
-[^4]: Oracles are not rewarded until additional Oracle operators deploy services.
-
 [github]: https://github.com/helium
 [hip-52-emisions]: https://github.com/helium/HIP/blob/main/0052-iot-dao.md#emissions-curve
 [hip-52]: https://github.com/helium/HIP/blob/main/0052-iot-dao.md
@@ -80,3 +74,8 @@ The emissions schedule was created in [HIP-52][hip-52-emisions] and confirmed in
   https://github.com/helium/HIP/blob/main/HIP-solana-parameters/token-emissions-as-of-solana-migration.pdf
 [wallet-app]: /wallets/helium-wallet-app
 [explorer-stats]: https://explorer.helium.com/stats
+
+[^1]: [HIP-70: Scaling the Helium Network][hip-70]
+[^2]: [HIP-77: Solana Parameters][hip-77]
+[^3]: Any IOT not rewarded for data transfer is rolled into Proof of Coverage.
+[^4]: Oracles are not rewarded until additional Oracle operators deploy services.


### PR DESCRIPTION
To see if that fixes the references numbering incorrectly issue