### PR TITLE
Add VSCode run config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Docusaurus",
+            "runtimeExecutable": "yarn",
+            "cwd": "${workspaceFolder}",
+            "runtimeArgs": ["start"]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Install Packages",
+            "runtimeExecutable": "yarn",
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
Allow users to run Docusaurus using the config within the VSCode IDE
<img width="204" alt="run button" src="https://github.com/helium/docs/assets/1965053/1f16aa35-4b23-4f3a-8573-7837b73ba689">
