### PR TITLE
Update data-credit.mdx

### DIFF
--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -131,19 +131,11 @@ In addition to network data transfer, DCs are also utilized for certain network-
 | Action            | Fee                                             |
 | ----------------- | ----------------------------------------------- |
 | Device Onboarding | $40                                             |
-| Assert Location   | $5<sup>(</sup>[^1]<sup>, </sup>[^2]<sup>)</sup> |
+| Assert Location   | $10                                             |
 | OUI               | $100                                            |
-| DevAddr           | $100 ($800)<sup>(</sup>[^3]<sup>)</sup>         |
+| DevAddr           | $100 ($800)<sup>(</sup>[^1]<sup>)</sup>         |
 
-[^1]:
-    [HIP-69](https://github.com/helium/HIP/blob/main/0069-reassertion-fee-reduction.md) set the
-    assert location fee to $5 for three months following the Solana migration.
-
-[^2]:
-    [HIP-91](https://github.com/helium/HIP/blob/main/0091-data-driven-extension-reduced-iot-assertion-cost.md)
-    further extended the $5 location assert for 6 months to January 20, 2024.
-
-[^3]: DevAddrs must be purchased in slabs of 8.
+[^1]: DevAddrs must be purchased in slabs of 8.
 
 ## Data Credits and Mobile {#dc-and-mobile}
 


### PR DESCRIPTION
Replaced $5 location assert fee with $10 and removed references to HIPs 69 and 91, as they're not applicable anymore.