### PR TITLE
Update governance.mdx

### DIFF
--- a/docs/governance/governance.mdx
+++ b/docs/governance/governance.mdx
@@ -24,7 +24,7 @@ model, or meta-governance changes, is governed by the global community of Helium
 Helium token (HNT, IOT, MOBILE) owners include Hotspot owners, Network users, wireless network
 operators, hardware manufacturers, and more.
 
-Tokens are created by providing some form of work for the Network. For example, transmitting data
+Tokens are distributed as rewards for providing some forms of work or service for the Network. For example, transmitting data
 packets through the internet on behalf of a network user. Hotspot owners provide public, accessible
 wireless coverage. Network users must acquire and burn tokens to send data over the network. Tokens
 must be locked for voting on network changes, ensuring long-term stakeholder alignment.
@@ -38,7 +38,7 @@ voting power determined by the number of locked tokens and the lock duration. A 
 the quorum passes proposals.
 
 The Helium Foundation serves as a steward for the governance process. The Foundation established the
-initial framework and managed the open Helium GitHub repositories. The Foundation does not vote on
+initial framework and manages the open Helium GitHub repositories. The Foundation does not vote on
 HIPs but does vet proposals for compliance with the law and technical feasibility. The Foundation’s
 role is to provide expert advice and guidance and to implement HIPs after they have passed.
 


### PR DESCRIPTION
- Post migration, tokens are created by the Solana blockchain and then distributed as rewards. They aren't created any more by providing the rewarded work/service.
- I assume HF still manages Github repositories