### PR TITLE
Update voting.mdx 67% supermajority

### DIFF
--- a/docs/governance/voting.mdx
+++ b/docs/governance/voting.mdx
@@ -138,7 +138,7 @@ example, a proposal affecting proof of coverage behavior for MOBILE Hotspots.
 ## Supermajority
 
 A proposition is deemed 'Approved' and accepted by the community if it achieves a super-majority of
-66% of the Voting Power. This is not a new rule for the Helium Community and was first established
+67% of the Voting Power. This is not a new rule for the Helium Community and was first established
 in Phase 2 of Governance.
 
 The duration for which a proposal must be made available for voting is not predetermined. Generally,


### PR DESCRIPTION
Changed 66% to 67% as 67% is what we use.
66% was a realms default we never recognised.
Urgent PR to match current votes.