### PR TITLE
Several updates in the 'IoT Network' subsections

### DIFF
--- a/docs/network-iot/devices/devices.mdx
+++ b/docs/network-iot/devices/devices.mdx
@@ -10,10 +10,10 @@ slug: /iot/devices
 
 import { DevicesPage } from './Devices'
 
-The Helium IoT Network supports any LoRaWAN-capable device meeting the v1.0.2, v1.0.3, or v1.0.4
-specification.
+The Helium IoT Network supports any LoRaWAN&trade;-capable device meeting the v1.0.2, v1.0.3, or
+v1.0.4 specification.
 
-There are thousands of compatible LoRaWAN devices. The devices shown here do not represent all
-available devices.
+There are thousands of compatible LoRaWAN&trade; devices. The devices shown here do not represent
+all available devices.
 
 <DevicesPage />

--- a/docs/network-iot/devices/devices.mdx
+++ b/docs/network-iot/devices/devices.mdx
@@ -10,10 +10,10 @@ slug: /iot/devices
 
 import { DevicesPage } from './Devices'
 
-The Helium IoT Network supports any LoRaWAN-capable device meeting the v1.0.2, v1.0.3, or
-v1.0.4 specification.
+The Helium IoT Network supports any LoRaWAN-capable device meeting the v1.0.2, v1.0.3, or v1.0.4
+specification.
 
-There are thousands of compatible LoRaWAN devices. The devices shown here do not represent
-all available devices.
+There are thousands of compatible LoRaWAN devices. The devices shown here do not represent all
+available devices.
 
 <DevicesPage />

--- a/docs/network-iot/devices/devices.mdx
+++ b/docs/network-iot/devices/devices.mdx
@@ -10,10 +10,10 @@ slug: /iot/devices
 
 import { DevicesPage } from './Devices'
 
-The Helium IoT Network supports any LoRaWAN&trade;-capable device meeting the v1.0.2, v1.0.3, or
+The Helium IoT Network supports any LoRaWAN-capable device meeting the v1.0.2, v1.0.3, or
 v1.0.4 specification.
 
-There are thousands of compatible LoRaWAN&trade; devices. The devices shown here do not represent
+There are thousands of compatible LoRaWAN devices. The devices shown here do not represent
 all available devices.
 
 <DevicesPage />

--- a/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
@@ -14,20 +14,20 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <br />
 <br />
 
-Any LoRaWAN gateway can be used to transfer data through the Helium Network. Data-only Hotspots are
-eligible for **network data transfer rewards** but not **Proof-of-Coverage rewards**. This class of
-Hotspot offers a flexible path for companies and organizations looking to leverage the Helium
-Network for their IoT needs.
+Any LoRaWAN&trade; gateway can be used to transfer data through the Helium Network. Data-Only
+Hotspots are eligible for **network data transfer rewards** but not **Proof-of-Coverage rewards**.
+This class of Hotspot offers a flexible path for companies and organizations looking to leverage the
+Helium Network for their IoT needs.
 
-Since data-only Hotspots do not earn Proof-of-Coverage rewards, they may be permissionlessly added
-to the network. When added to the blockchain, they will earn [IOT Tokens](/tokens/iot-token) for
+Since Data-Only Hotspots do not earn Proof-of-Coverage rewards, they may be permissionlessly added
+to the Network. When added to the Blockchain, they will earn [IOT Tokens](/tokens/iot-token) for
 transferring network data.
 
 ## Basic Architecture
 
-The [gateway-rs](https://github.com/helium/gateway-rs) client backs both data-only Hotspots as well
-as proof-of-coverage enabled Hotspots. Gateway-rs is designed to run alongside a packet forwarder
-and handles communications with the Helium Packet Router.
+The [gateway-rs](https://github.com/helium/gateway-rs) client backs both Data-Only Hotspots as well
+as Proof-of-Coverage enabled IoT Hotspots. Gateway-rs is designed to run alongside a packet
+forwarder and handles communications with the Helium Packet Router (HPR).
 
 ```mermaid
 graph LR;
@@ -54,7 +54,6 @@ Gateway-rs is designed to interact with the
 installed on the target hardware, follow the manufacturer's instructions using their documentation
 or one of the tutorials below.
 
-- [COTX X1 Lite](https://support.cotxnetworks.com/support/solutions/articles/73000567327-cotx-x1-lite-cli-user-guide)
 - [Dragino LPS8/DLOS8](/iot/data-only/dragino-data-only-hotspot)
 - [Dragino Concentrator PG1301 + Raspberry Pi](/iot/data-only/dragino-pg1301)
 - [Kerlink Gateways](/iot/data-only/kerlink-data-only-hotspot)
@@ -66,45 +65,44 @@ or one of the tutorials below.
 ### Gateway-rs
 
 Gateway-rs is the lightweight client that handles message signing and communications with Helium
-Packet Router, the backbone of the IoT Network.
+Packet Router (HPR), the backbone of the IoT Network.
 
 Gateway-rs is designed to be installed directly adjacent to the packet forwarder on the gateway. For
-the latest releases and build notes, refer to the repository readme on GitHub.
-
-- https://github.com/helium/gateway-rs/
+the latest releases and build notes, refer to the repository
+[readme](https://github.com/helium/gateway-rs/blob/main/README.md) on GitHub.
 
 For guidance on using gateway-rs, view the
-[Data-Only Onboarding](/iot/data-only-hotspots-onboarding) guide.
+[Data-Only Hotspot Onboarding](/iot/data-only-hotspots-onboarding) section.
 
 ## Transactions & Cost
 
-A data-only Hotspot is capable of transferring network traffic without being onboarded. However,
+A Data-Only Hotspot is capable of transferring network traffic without being onboarded. However,
 rewards for data transfer will not be issued.
 
-To enable the Helium Network to reward a data-only Hotspot for network traffic and to report a
-location, two criteria must be met.
+To enable the Helium Network to reward a Data-Only Hotspot for network traffic and to report a
+location, two criteria must be met:
 
-1. The Hotspot must be 'onboarded' to the network.  
+1. The Data-Only Hotspot must be 'onboarded' to the Helium IoT Network.  
    The **Add Hotspot** transaction links the Hotspot's key (`swarm_key`) to a user's
-   [account](/wallets) and makes the Hotspot known to the network. This allows the Hotspot to be
-   rewarded for data transfer.
-1. The specific location of the Hotspot should be declared.  
-   This allows the network define regional parameters and aids in location-solving for certain
-   sensor applications. The **Assert Location** transaction provides the physical location
-   (lat/long), elevation (in meters), and antenna EIRP (in dBi) data for the Hotspot. A Hotspot must
-   be onboarded before its location can be asserted.
+   [account](/wallets) and makes the Hotspot known to the Helium IoT Network. This allows the
+   Hotspot to be rewarded for data transfer.
+1. The specific location of the Data-Only Hotspot should be declared.  
+   This allows the Helium IoT Network define regional parameters and aids in location-solving for
+   certain sensor applications. The **Assert Location** transaction provides the physical location
+   (lat/long), elevation (in meters), and antenna EIRP (in dBi) data for the Data-Only Hotspot. A
+   Data-Only Hotspot must be onboarded before its location can be asserted.
 
 The network fees are as follows:
 
 - **Add Data-Only Hotspot**: 1,000,000 Data Credits (USD $10)
 - **Assert Location**: 500,000 Data Credits (USD $5)
 
-These fees are paid using [Data Credits](/tokens/data-credit).
+These fees are paid using [Data Credits](/tokens/data-credit) (DCs).
 
-Transactions are submitted using the [CLI wallet](/wallets/cli-wallet). The wallet CLI should
+Transactions are submitted using the [CLI Wallet](/wallets/cli-wallet). The CLI Wallet should
 **not** be installed on the gateway, doing so could expose account keys to the open internet if the
 gateway is not properly secured. Existing accounts generated using the Helium Wallet App can be
 [imported to the CLI](/wallets/cli-wallet#import-seed-phrase-account-into-cli).
 
 For guidance on submitting these transactions, view the
-[Data-Only Onboarding](/iot/data-only-hotspots-onboarding) guide.
+[Data-Only Hotspot Onboarding](/iot/data-only-hotspots-onboarding) section.

--- a/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
@@ -82,7 +82,7 @@ rewards for data transfer will not be issued.
 To enable the Helium Network to reward a data-only Hotspot for network traffic and to report a
 location, two criteria must be met:
 
-1. The Data-Only Hotspot must be 'onboarded' to the network.  
+1. The data-only Hotspot must be 'onboarded' to the network.  
    The **Add Hotspot** transaction links the Hotspot's key (`swarm_key`) to a user's
    [account](/wallets) and makes the Hotspot known to the network. This allows the Hotspot to be
    rewarded for data transfer.

--- a/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
@@ -14,20 +14,20 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <br />
 <br />
 
-Any LoRaWAN gateway can be used to transfer data through the Helium Network. Data-Only
-Hotspots are eligible for **network data transfer rewards** but not **Proof-of-Coverage rewards**.
-This class of Hotspot offers a flexible path for companies and organizations looking to leverage the
-Helium Network for their IoT needs.
+Any LoRaWAN gateway can be used to transfer data through the Helium Network. Data-only Hotspots are
+eligible for **network data transfer rewards** but not **Proof-of-Coverage rewards**. This class of
+Hotspot offers a flexible path for companies and organizations looking to leverage the Helium
+Network for their IoT needs.
 
-Since Data-Only Hotspots do not earn Proof-of-Coverage rewards, they may be permissionlessly added
-to the Network. When added to the Blockchain, they will earn [IOT Tokens](/tokens/iot-token) for
+Since data-only Hotspots do not earn Proof-of-Coverage rewards, they may be permissionlessly added
+to the network. When added to the blockchain, they will earn [IOT Tokens](/tokens/iot-token) for
 transferring network data.
 
 ## Basic Architecture
 
-The [gateway-rs](https://github.com/helium/gateway-rs) client backs both Data-Only Hotspots as well
+The [gateway-rs](https://github.com/helium/gateway-rs) client backs both data-only Hotspots as well
 as Proof-of-Coverage enabled IoT Hotspots. Gateway-rs is designed to run alongside a packet
-forwarder and handles communications with the Helium Packet Router (HPR).
+forwarder and handles communications with the Helium Packet Router.
 
 ```mermaid
 graph LR;
@@ -65,7 +65,7 @@ or one of the tutorials below.
 ### Gateway-rs
 
 Gateway-rs is the lightweight client that handles message signing and communications with Helium
-Packet Router (HPR), the backbone of the IoT Network.
+Packet Router, the backbone of the IoT Network.
 
 Gateway-rs is designed to be installed directly adjacent to the packet forwarder on the gateway. For
 the latest releases and build notes, refer to the repository
@@ -76,28 +76,28 @@ For guidance on using gateway-rs, view the
 
 ## Transactions & Cost
 
-A Data-Only Hotspot is capable of transferring network traffic without being onboarded. However,
+A data-only Hotspot is capable of transferring network traffic without being onboarded. However,
 rewards for data transfer will not be issued.
 
-To enable the Helium Network to reward a Data-Only Hotspot for network traffic and to report a
+To enable the Helium Network to reward a data-only Hotspot for network traffic and to report a
 location, two criteria must be met:
 
-1. The Data-Only Hotspot must be 'onboarded' to the Helium IoT Network.  
+1. The Data-Only Hotspot must be 'onboarded' to the network.  
    The **Add Hotspot** transaction links the Hotspot's key (`swarm_key`) to a user's
-   [account](/wallets) and makes the Hotspot known to the Helium IoT Network. This allows the
-   Hotspot to be rewarded for data transfer.
-1. The specific location of the Data-Only Hotspot should be declared.  
-   This allows the Helium IoT Network define regional parameters and aids in location-solving for
-   certain sensor applications. The **Assert Location** transaction provides the physical location
-   (lat/long), elevation (in meters), and antenna EIRP (in dBi) data for the Data-Only Hotspot. A
-   Data-Only Hotspot must be onboarded before its location can be asserted.
+   [account](/wallets) and makes the Hotspot known to the network. This allows the Hotspot to be
+   rewarded for data transfer.
+1. The specific location of the Hotspot should be declared.  
+   This allows the network define regional parameters and aids in location-solving for certain
+   sensor applications. The **Assert Location** transaction provides the physical location
+   (lat/long), elevation (in meters), and antenna EIRP (in dBi) data for the Hotspot. A Hotspot must
+   be onboarded before its location can be asserted.
 
 The network fees are as follows:
 
 - **Add Data-Only Hotspot**: 1,000,000 Data Credits (USD $10)
 - **Assert Location**: 500,000 Data Credits (USD $5)
 
-These fees are paid using [Data Credits](/tokens/data-credit) (DCs).
+These fees are paid using [Data Credits](/tokens/data-credit).
 
 Transactions are submitted using the [CLI Wallet](/wallets/cli-wallet). The CLI Wallet should
 **not** be installed on the gateway, doing so could expose account keys to the open internet if the

--- a/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
@@ -14,7 +14,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <br />
 <br />
 
-Any LoRaWAN&trade; gateway can be used to transfer data through the Helium Network. Data-Only
+Any LoRaWAN gateway can be used to transfer data through the Helium Network. Data-Only
 Hotspots are eligible for **network data transfer rewards** but not **Proof-of-Coverage rewards**.
 This class of Hotspot offers a flexible path for companies and organizations looking to leverage the
 Helium Network for their IoT needs.

--- a/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
@@ -19,7 +19,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <br />
 <br />
 
-This guide walks through the process of onboarding a Data-Only Hotspot to the Helium Network. The
+This guide walks through the process of onboarding a data-only Hotspot to the Helium Network. The
 onboarding procedure expects a gateway configured with the Semtech Packet Forwarder and Helium
 Gateway-rs.
 
@@ -27,7 +27,7 @@ Gateway-rs.
 
 - LoRaWAN Gateway with Gateway-rs installed.
 - Helium Wallet CLI with a funded account imported.
-- Token balances to onboard Data-Only Hotspot.
+- Token balances to onboard data-only Hotspot.
   - 1,500,000 Data Credits (DCs)
     - 1,000,000 ($10) Data-Only Onboard
     - 500,000 ($5) Location Assert
@@ -123,9 +123,9 @@ sudo nano /etc/helium_gateway/settings.toml
 
 #### [Optional] Region Plan
 
-Setting the gateway's region is only required if the Data-Only Hotspot is not added and asserted to
-the Blockchain. For onboarded Data-Only Hotspots, the region is retrieved via the asserted location
-stored on-chain. The Data-Only Hotspot will not transfer data unless one of these criteria is met.
+Setting the gateway's region is only required if the Hotspot is not added and asserted to the
+blockchain. For onboarded Hotspots, the region is retrieved via the asserted location stored
+on-chain. The Hotspot will not transfer data unless one of these criteria is met.
 
 ```toml title="Uncomment this line by removing the #. Set the appropriate region"
 # region = "US915"
@@ -138,13 +138,13 @@ region plan in the Semtech Packet Forwarder.
 #### [Optional] Define `gateway_key.bin` Location
 
 The default path is `/etc/helium_gateway/gateway_key.bin`. If using a different path, update the key
-location in settings.toml.
+location in `settings.toml`.
 
-The `gateway_key.bin` file stores the information used to identify the Data-Only Hotspot on the
-Network. The key file will allow gateway-rs to securely sign all messages transferred from the
-Data-Only Hotspot. Key signing allows the Helium Network to confirm that data payloads are delivered
-from verifiable sources. The gateway_key will be generated during the first run of the server if no
-existing key is found.
+The `gateway_key.bin` file stores the information used to identify the Hotspot on the Network. The
+key file will allow gateway-rs to securely sign all messages transferred from the Hotspot. Key
+signing allows the Helium Network to confirm that data payloads are delivered from verifiable
+sources. The gateway_key will be generated during the first run of the server if no existing key is
+found.
 
 ```toml
 # File based:
@@ -156,8 +156,8 @@ onboarding process.
 
 ### First Run
 
-With gateway-rs installed on the gateway, initialize the key for the Data-Only Hotspot. If creating
-the gateway_key in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
+With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the
+`gateway_key` in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
 
 ```sh title="Generate a swarm_key by running gateway-rs."
 sudo helium_gateway server
@@ -220,7 +220,7 @@ commands to test and monitor.
 ## Prepare the Helium Wallet CLI
 
 The Helium Wallet CLI will be used to sign and submit the transaction generated. The Helium Wallet
-CLI should not be installed on the Data-Only Hotspot.
+CLI should not be installed on the Hotspot.
 
 For details on setting up the Helium Wallet CLI and using an existing account, see the
 [CLI Wallet](/wallets/cli-wallet) documentation.
@@ -229,7 +229,7 @@ For details on setting up the Helium Wallet CLI and using an existing account, s
 ./helium-wallet -f <path/to/>wallet.key info
 ```
 
-The `info` command will return the Wallet addresses for both the Solana blockchain and the legacy
+The `info` command will return the wallet addresses for both the Solana blockchain and the legacy
 Helium L1.
 
 ```json
@@ -245,7 +245,7 @@ Helium L1.
 
 ## Generate the `add` Transaction Using Gateway-rs
 
-Connect to the Data-Only Hotspot using SSH or the interface provided by the hardware manufacturer.
+Connect to the Hotspot using SSH or the interface provided by the hardware manufacturer.
 
 Gateway-rs provides tooling to generate a transaction using the gateway_key. Use the Solana address
 for the `<OWNER>` and `<PAYER>` fields.
@@ -254,9 +254,9 @@ for the `<OWNER>` and `<PAYER>` fields.
 helium_gateway add --owner <OWNER> --payer <PAYER>
 ```
 
-The owner and payer accounts can both be the same. To onboard the Data-Only Hotspot, the payer
-account will need to sign the transaction and pay the DC onboarding fee. The owner will be the
-recipient of the Data-Only Hotspot.
+The owner and payer accounts can both be the same. To onboard the Hotspot, the payer account will
+need to sign the transaction and pay the DC onboarding fee. The owner will be the recipient of the
+Hotspot.
 
 The add command will generate the transaction that can be used in the onboarding step.
 
@@ -296,33 +296,32 @@ up using a Solana block explorer such as [Solana Explorer](https://explorer.sola
 
 ## Asserting Hotspot Location
 
-Asserting the location of the Data-Only Hotspot can be performed with either the Helium Wallet App
-or the Helium CLI Wallet. Once onboarded to the IoT Network, asserting the location of a Data-Only
-Hotspot is the same experience as any other IoT Hotspot.
+Asserting the location of the Hotspot can be performed with either the Helium Wallet App or the
+Helium CLI Wallet. Once onboarded to the network, asserting the location of a data-only Hotspot is
+the same experience as any other Hotspot.
 
 ### Asserting Using the Helium Wallet App
 
-Once the Data-Only Hotspot has been onboarded, it will be visible in the Wallet for the account
-indicated with `--owner` in the previous `helium_gateway add` transaction. Follow the in-app steps
-to assert the location of the Data-Only Hotspot.
+Once the Hotspot has been onboarded, it will be visible in the wallet for the account indicated with
+`--owner` in the previous `helium_gateway add` transaction. Follow the in-app steps to assert the
+location of the Hotspot.
 
 ### Asserting Using the Helium CLI Wallet
 
-To assert the location of the Data-Only Hotspot using the Helium CLI Wallet, use the command
+To assert the location of the Hotspot using the Helium CLI Wallet, use the command
 `helium-wallet hotspots assert`.
 
 Make sure the paying account has at least 500,000 Data Credits available to complete the assert
 transaction. The transactions take place on the Solana blockchain, so a small amount of SOL is also
 required to cover Solana fees.
 
-Before running the assert command, get the public key from the Data-Only Hotspot.
+Before running the assert command, get the public key from the data-only Hotspot.
 
 ```sh
 helium_gateway key info
 ```
 
-The `key info` command will return the Data-Only Hotspot's 'animal name' along with the Hotspot's
-public key.
+The `key info` command will return the Hotspot's 'animal name' along with the Hotspot's public key.
 
 ```json
 {
@@ -332,9 +331,9 @@ public key.
 }
 ```
 
-Use the "key" value along with the Data-Only Hotspot's physical latitude and longitude to assert its
-location to the IoT Network. A utility like [latlong.net](https://www.latlong.net) is helpful for
-looking up coordinates. Gain is set in dBm and elevation is set in meters.
+Use the "key" value along with the Hotspot's physical latitude and longitude to assert its location
+to the network. A utility such as [latlong.net](https://www.latlong.net) is helpful for looking up
+coordinates. Gain is set in dBm and elevation is set in meters.
 
 ```
 helium-wallet hotspots assert iot <Hotspot Public Key> --lat=37.771150 --lon=-122.419200 --gain 1.2 --elevation 7 --commit

--- a/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
@@ -1,8 +1,8 @@
 ---
 id: data-only-hotspots-onboarding
-title: Data-Only Onboarding
-pagination_label: Data-Only Onboarding
-sidebar_label: Data-Only Onboarding
+title: Data-Only Hotspot Onboarding
+pagination_label: Data-Only Hotspot Onboarding
+sidebar_label: Data-Only Hotspot Onboarding
 description: Helium Documentation
 image: https://docs.helium.com/img/link-image.png
 slug: /iot/data-only-hotspots-onboarding
@@ -19,16 +19,16 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <br />
 <br />
 
-This guide walks through the process of onboarding a data-only Hotspot to the Helium Network. The
+This guide walks through the process of onboarding a Data-Only Hotspot to the Helium Network. The
 onboarding procedure expects a gateway configured with the Semtech Packet Forwarder and Helium
 Gateway-rs.
 
-## Prerequsites
+## Prerequisites
 
-- LoRaWAN Gateway with Gateway-rs installed.
+- LoRaWAN&trade; Gateway with Gateway-rs installed.
 - Helium Wallet CLI with a funded account imported.
-- Token balances to onboard data-only Hotspot.
-  - 1,500,000 Data Credits
+- Token balances to onboard Data-Only Hotspot.
+  - 1,500,000 Data Credits (DCs)
     - 1,000,000 ($10) Data-Only Onboard
     - 500,000 ($5) Location Assert
   - SOL (Solana's native cryptocurrency) to cover transaction fees (~0.1 Sol)
@@ -36,13 +36,12 @@ Gateway-rs.
 ## Installing Gateway-rs
 
 If the gateway is already configured with gateway-rs, skip to
-[Prepare the Helium Wallet CLI](#prepare-the-helium-wallet-cli).
+[Prepare the Helium Wallet CLI](/iot/data-only-hotspots-onboarding/#prepare-the-helium-wallet-cli).
 
 If the gateway does not already have gateway-rs installed, follow these steps to install and
 configure it.  
 For more in-depth guides, refer to the available tutorials.
 
-- [COTX X1 Lite](https://support.cotxnetworks.com/support/solutions/articles/73000567327-cotx-x1-lite-cli-user-guide)
 - [Dragino LPS8/DLOS8](/iot/data-only/dragino-data-only-hotspot)
 - [Dragino Concentrator PG1301 + Raspberry Pi](/iot/data-only/dragino-pg1301)
 - [Kerlink Gateways](/iot/data-only/kerlink-data-only-hotspot)
@@ -87,9 +86,9 @@ directory.
 
 ## Prepare Gateway-rs
 
-To simplify running the helium_gateway program, place it in a folder that is easily accessible or in
-the `/usr/bin/` directory. Placing `helium_gateway` in this bin directory will automatically add it
-to the shell path.
+To simplify running the `helium_gateway` program, place it in a folder that is easily accessible or
+in the `/usr/bin/` directory. Placing `helium_gateway` in this bin directory will automatically add
+it to the shell path.
 
 ```sh title="Copying the helium_gateway program to /usr/bin/"
 sudo cp gateway-rs/target/release/helium_gateway /usr/bin/
@@ -124,16 +123,16 @@ sudo nano /etc/helium_gateway/settings.toml
 
 #### [Optional] Region Plan
 
-Setting the gateway's region is only required if the Hotspot is not added and asserted to the
-blockchain. For onboarded Hotspots, the region is retrieved via the asserted location stored
-on-chain. The Hotspot will not transfer data unless one of these criteria is met.
+Setting the gateway's region is only required if the Data-Only Hotspot is not added and asserted to
+the Blockchain. For onboarded Data-Only Hotspots, the region is retrieved via the asserted location
+stored on-chain. The Data-Only Hotspot will not transfer data unless one of these criteria is met.
 
 ```toml title="Uncomment this line by removing the #. Set the appropriate region"
 # region = "US915"
 ```
 
 To determine the region plan that should be used, refer to the
-[Helium Region Plans](/iot/lorawan-region-plans) document. The selected region plan must match the
+[Helium Region Plans](/iot/lorawan-region-plans) section. The selected region plan must match the
 region plan in the Semtech Packet Forwarder.
 
 #### [Optional] Define `gateway_key.bin` Location
@@ -141,24 +140,24 @@ region plan in the Semtech Packet Forwarder.
 The default path is `/etc/helium_gateway/gateway_key.bin`. If using a different path, update the key
 location in settings.toml.
 
-The `gateway_key.bin` file stores the information used to identify the Hotspot on the network. The
-key file will allow gateway-rs to securely sign all messages transferred from the Hotspot. Key
-signing allows the Helium Network to confirm that data payloads are delivered from verifiable
-sources. The gateway_key will be generated during the first run of the server if no existing key is
-found.
+The `gateway_key.bin` file stores the information used to identify the Data-Only Hotspot on the
+Network. The key file will allow gateway-rs to securely sign all messages transferred from the
+Data-Only Hotspot. Key signing allows the Helium Network to confirm that data payloads are delivered
+from verifiable sources. The gateway_key will be generated during the first run of the server if no
+existing key is found.
 
 ```toml
 # File based:
 keypair = "/etc/helium_gateway/gateway_key.bin"
 ```
 
-It's advised to backup the gateway_key file, especially if it needs to be recovered after the
+It's advised to backup the `gateway_key.bin` file, especially if it needs to be recovered after the
 onboarding process.
 
 ### First Run
 
-With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the
-gateway_key in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
+With gateway-rs installed on the gateway, initialize the key for the Data-Only Hotspot. If creating
+the gateway_key in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
 
 ```sh title="Generate a swarm_key by running gateway-rs."
 sudo helium_gateway server
@@ -213,24 +212,24 @@ sudo systemctl start gateway-rs.service
 sudo journalctl -fu gateway-rs
 ```
 
-If there are errors in the service edit it by first stopping the service
+If there are errors in the service, edit it by first stopping the service
 (`systemctl stop gateway-rs.service`), then editing it
 (`sudo nano /etc/systemd/system/gateway-rs.service`). After changes are made, rerun the above
 commands to test and monitor.
 
 ## Prepare the Helium Wallet CLI
 
-The Wallet CLI will be used to sign and submit the transaction generated. The Wallet CLI should not
-be installed on the Hotspot.
+The Helium Wallet CLI will be used to sign and submit the transaction generated. The Helium Wallet
+CLI should not be installed on the Data-Only Hotspot.
 
-For details on setting up the Wallet CLI and using an existing account, see the
+For details on setting up the Helium Wallet CLI and using an existing account, see the
 [CLI Wallet](/wallets/cli-wallet) documentation.
 
 ```sh title="Get Helium address for the imported account"
 ./helium-wallet -f <path/to/>wallet.key info
 ```
 
-The `info` command will return the wallet addresses for both the Solana blockchain and the legacy
+The `info` command will return the Wallet addresses for both the Solana blockchain and the legacy
 Helium L1.
 
 ```json
@@ -246,7 +245,7 @@ Helium L1.
 
 ## Generate the `add` Transaction Using Gateway-rs
 
-Connect to the Hotspot using SSH or the interface provided by the hardware manufacturer.
+Connect to the Data-Only Hotspot using SSH or the interface provided by the hardware manufacturer.
 
 Gateway-rs provides tooling to generate a transaction using the gateway_key. Use the Solana address
 for the `<OWNER>` and `<PAYER>` fields.
@@ -255,9 +254,9 @@ for the `<OWNER>` and `<PAYER>` fields.
 helium_gateway add --owner <OWNER> --payer <PAYER>
 ```
 
-The owner and payer accounts can both be the same. To onboard the Hotspot, the payer account will
-need to sign the transaction and pay the DC onboarding fee. The owner will be the recipient of the
-data-only Hotspot.
+The owner and payer accounts can both be the same. To onboard the Data-Only Hotspot, the payer
+account will need to sign the transaction and pay the DC onboarding fee. The owner will be the
+recipient of the Data-Only Hotspot.
 
 The add command will generate the transaction that can be used in the onboarding step.
 
@@ -271,11 +270,11 @@ The add command will generate the transaction that can be used in the onboarding
 }
 ```
 
-## Onboarding With The Command Line Wallet
+## Onboarding With The Command Line Interface Wallet
 
 Onboarding is done using the [Helium CLI Wallet](/wallets/cli-wallet).
 
-The Helium Wallet CLI will not automatically convert HNT to Data Credits. Make sure the paying
+The Helium CLI Wallet will not automatically convert HNT to Data Credits. Make sure the paying
 account has at least 1,000,000 Data Credits available to complete the add transaction. The
 transactions take place on the Solana blockchain, so a small amount of SOL is also required to cover
 Solana fees.
@@ -285,7 +284,8 @@ helium-wallet hotspots add iot <Txn from gateway-rs> --commit
 ```
 
 The CLI will return a Solana transaction hash for the on-chain event. This transaction can be looked
-up using a Solana block explorer.
+up using a Solana block explorer such as [Solana Explorer](https://explorer.solana.com/) or
+[Solscan](https://solscan.io/).
 
 ```json
 {
@@ -296,32 +296,33 @@ up using a Solana block explorer.
 
 ## Asserting Hotspot Location
 
-Asserting the location of the Hotspot can be performed with either the Helium Wallet App or the
-Helium Wallet CLI. Once onboarded to the network, asserting the location of a data-only Hotspot is
-the same experience as any other Hotspot.
+Asserting the location of the Data-Only Hotspot can be performed with either the Helium Wallet App
+or the Helium CLI Wallet. Once onboarded to the IoT Network, asserting the location of a Data-Only
+Hotspot is the same experience as any other IoT Hotspot.
 
 ### Asserting Using the Helium Wallet App
 
-Once the Hotspot has been onboarded, it will be visible in the wallet for the account indicated with
---owner in the previous `helium_gateway add` transaction. Follow the in-app steps to assert the
-location of the Hotspot.
+Once the Data-Only Hotspot has been onboarded, it will be visible in the Wallet for the account
+indicated with `--owner` in the previous `helium_gateway add` transaction. Follow the in-app steps
+to assert the location of the Data-Only Hotspot.
 
-### Asserting Using the Helium Wallet CLI
+### Asserting Using the Helium CLI Wallet
 
-To assert the location of the Hotspot using the Wallet CLI, use the command
+To assert the location of the Data-Only Hotspot using the Helium CLI Wallet, use the command
 `helium-wallet hotspots assert`.
 
 Make sure the paying account has at least 500,000 Data Credits available to complete the assert
 transaction. The transactions take place on the Solana blockchain, so a small amount of SOL is also
 required to cover Solana fees.
 
-Before running the assert command, get the public key from the data-only Hotspot.
+Before running the assert command, get the public key from the Data-Only Hotspot.
 
 ```sh
 helium_gateway key info
 ```
 
-The `key info` command will return the Hotspot's 'animal name' along with the Hotspot's public key.
+The `key info` command will return the Data-Only Hotspot's 'animal name' along with the Hotspot's
+public key.
 
 ```json
 {
@@ -331,14 +332,14 @@ The `key info` command will return the Hotspot's 'animal name' along with the Ho
 }
 ```
 
-Use the "key" value along with the Hotspot's physical latitude and longitude to assert its location
-to the network. A utility like [latlong.net](https://www.latlong.net) is helpful for looking up
-coordinates. Gain is set in dBm and elevation is set in meters.
+Use the "key" value along with the Data-Only Hotspot's physical latitude and longitude to assert its
+location to the IoT Network. A utility like [latlong.net](https://www.latlong.net) is helpful for
+looking up coordinates. Gain is set in dBm and elevation is set in meters.
 
 ```
 helium-wallet hotspots assert iot <Hotspot Public Key> --lat=37.771150 --lon=-122.419200 --gain 1.2 --elevation 7 --commit
 ```
 
 `--elevation` and `--gain` are optional values and can be updated at any time without further fees
-as long as the lat/lon values remain the same. Use the built-in help command,
+as long as the lat/long values remain the same. Use the built-in help command,
 `helium-wallet hotspots assert --help` for more info.

--- a/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
@@ -36,7 +36,7 @@ Gateway-rs.
 ## Installing Gateway-rs
 
 If the gateway is already configured with gateway-rs, skip to
-[Prepare the Helium Wallet CLI](/iot/data-only-hotspots-onboarding/#prepare-the-helium-wallet-cli).
+[Prepare the Helium Wallet CLI](#prepare-the-helium-wallet-cli).
 
 If the gateway does not already have gateway-rs installed, follow these steps to install and
 configure it.  
@@ -140,7 +140,7 @@ region plan in the Semtech Packet Forwarder.
 The default path is `/etc/helium_gateway/gateway_key.bin`. If using a different path, update the key
 location in `settings.toml`.
 
-The `gateway_key.bin` file stores the information used to identify the Hotspot on the Network. The
+The `gateway_key.bin` file stores the information used to identify the Hotspot on the network. The
 key file will allow gateway-rs to securely sign all messages transferred from the Hotspot. Key
 signing allows the Helium Network to confirm that data payloads are delivered from verifiable
 sources. The gateway_key will be generated during the first run of the server if no existing key is
@@ -157,7 +157,7 @@ onboarding process.
 ### First Run
 
 With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the
-`gateway_key` in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
+gateway_key in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
 
 ```sh title="Generate a swarm_key by running gateway-rs."
 sudo helium_gateway server
@@ -340,5 +340,5 @@ helium-wallet hotspots assert iot <Hotspot Public Key> --lat=37.771150 --lon=-12
 ```
 
 `--elevation` and `--gain` are optional values and can be updated at any time without further fees
-as long as the lat/long values remain the same. Use the built-in help command,
+as long as the lat/lon values remain the same. Use the built-in help command,
 `helium-wallet hotspots assert --help` for more info.

--- a/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-onboarding.mdx
@@ -25,7 +25,7 @@ Gateway-rs.
 
 ## Prerequisites
 
-- LoRaWAN&trade; Gateway with Gateway-rs installed.
+- LoRaWAN Gateway with Gateway-rs installed.
 - Helium Wallet CLI with a funded account imported.
 - Token balances to onboard Data-Only Hotspot.
   - 1,500,000 Data Credits (DCs)

--- a/docs/network-iot/hotspots-iot/iot-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/iot-hotspots.mdx
@@ -9,16 +9,13 @@ slug: /iot/hotspots
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
-<LegacyContentBanner />
 
 ## IoT Hotspot Properties
 
 The IoT Hotspot software [gateway-rs](https://github.com/helium/gateway-rs) is in production,
 satisfying the following properties:
 
-- A Hotspot on the Helium Network will Beacon automatically on a pre-determined time interval.
+- A Hotspot on the Helium network will Beacon automatically on a pre-determined time interval.
 - A Hotspot will submit PoC receipts directly to an Off-Chain PoC Oracle.
 - A Hotspot will transmit packets on behalf of IoT devices on the Network to an Off-Chain Data
   Oracle.
@@ -49,7 +46,7 @@ receipts to be off-chain.
 
 The most taxing piece of PoC is not just Challenge creation but Receipt validation and verification.
 By taking these tasks off-chain, PoC event frequency can increase to several times daily. As a
-result, Hotspot Operators can expect more reliable challenges and witness events.
+result, Hotspot operators can expect more reliable challenges and witness events.
 
 ## IoT Proof-of-Coverage Architecture Overview
 
@@ -70,8 +67,8 @@ result, Hotspot Operators can expect more reliable challenges and witness events
 
 ## Code and Development
 
-The bulk of the code that enables Hotspots on actual LoRaWAN gateways is Helium's
-next-generation packet forwarder called [gateway-rs](https://github.com/helium/gateway-rs).
+The bulk of the code that enables Hotspots on actual LoRaWAN gateways is Helium's next-generation
+packet forwarder called [gateway-rs](https://github.com/helium/gateway-rs).
 
 :::info Join The Conversation
 

--- a/docs/network-iot/hotspots-iot/iot-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/iot-hotspots.mdx
@@ -1,8 +1,8 @@
 ---
 id: iot-hotspots
-title: IOT Network Hotspots
-pagination_label: IOT Network Hotspots
-sidebar_label: IOT Network Hotspots
+title: IoT Network Hotspots
+pagination_label: IoT Network Hotspots
+sidebar_label: IoT Network Hotspots
 description: Helium Documentation
 image: https://docs.helium.com/img/link-image.png
 slug: /iot/hotspots
@@ -13,17 +13,17 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <LegacyContentBanner />
 
-## IOT Hotspot Properties
+## IoT Hotspot Properties
 
-The IOT Hotspot software [gateway-rs](https://github.com/helium/gateway-rs) is in production,
+The IoT Hotspot software [gateway-rs](https://github.com/helium/gateway-rs) is in production,
 satisfying the following properties:
 
-- A Hotspot on the Helium network will Beacon automatically on a pre-determined time interval.
+- A Hotspot on the Helium Network will Beacon automatically on a pre-determined time interval.
 - A Hotspot will submit PoC receipts directly to an Off-Chain PoC Oracle.
 - A Hotspot will transmit packets on behalf of IoT devices on the Network to an Off-Chain Data
   Oracle.
 - A Hotspot will no longer depend on libp2p or "gossip", and instead use [gRPC](https://grpc.io/), a
-  new framework to communicate between distributed systems
+  new framework to communicate between distributed systems.
 - A Hotspot will be eligible to earn IOT token rewards.
 - A Hotspot will reconnect every 30 minutes to
   [Packet Router Service](/oracles/data-transfer-oracles#packet-router-service) in order to ensure
@@ -31,10 +31,10 @@ satisfying the following properties:
 
 :::info Naming
 
-All IOT Hotspots are referred to as "Hotspots", discarding the previous distinctions of "Full
+All IoT Hotspots are referred to as "Hotspots", discarding the previous distinctions of "Full
 Hotspot" and "Light Hotspot."
 
-With the switch to `gateway-rs,` all IOT Hotspots are "Light Hotspots", so the prefix is no longer
+With the switch to `gateway-rs,` all IoT Hotspots are "Light Hotspots", so the prefix is no longer
 needed.
 
 :::
@@ -43,15 +43,15 @@ needed.
 
 ## HIP 70 Changes
 
-[HIP-70](https://github.com/helium/HIP/issues/471)has passed. HIP-70 proposes a new architecture
-involving several Oracles, allowing Proof of Coverage ("PoC") generation to be automated and its
+[HIP-70](https://github.com/helium/HIP/issues/471) has passed. HIP-70 proposes a new architecture
+involving several Oracles, allowing Proof -of-Coverage (PoC) generation to be automated and its
 receipts to be off-chain.
 
 The most taxing piece of PoC is not just Challenge creation but Receipt validation and verification.
 By taking these tasks off-chain, PoC event frequency can increase to several times daily. As a
-result, Hotspot operators can expect more reliable challenges and witness events.
+result, Hotspot Operators can expect more reliable challenges and witness events.
 
-## IOT Proof of Coverage Architecture Overview
+## IoT Proof-of-Coverage Architecture Overview
 
 1. A Hotspot broadcasts a Beacon.
 2. Nearby Hotspot(s) witness the Beacon.
@@ -70,13 +70,13 @@ result, Hotspot operators can expect more reliable challenges and witness events
 
 ## Code and Development
 
-The bulk of the code that enables Hotspots on actual LoRaWAN gateways is Helium's next-generation
-packet forwarder called [gateway-rs](https://github.com/helium/gateway-rs).
+The bulk of the code that enables Hotspots on actual LoRaWAN&trade; gateways is Helium's
+next-generation packet forwarder called [gateway-rs](https://github.com/helium/gateway-rs).
 
 :::info Join The Conversation
 
-For real-time development and community support of Data Only Hotspots and IOT Hotspots, please join
+For real-time development and community support of Data-Only Hotspots and IoT Hotspots, please join
 the [#gateway-development](discord://discord.com/channels/404106811252408320/784462269072277576)
-channel on [Helium Discord](https://discord.gg/helium)
+channel on the official [Helium Discord](https://discord.gg/helium)
 
 :::

--- a/docs/network-iot/hotspots-iot/iot-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/iot-hotspots.mdx
@@ -70,7 +70,7 @@ result, Hotspot Operators can expect more reliable challenges and witness events
 
 ## Code and Development
 
-The bulk of the code that enables Hotspots on actual LoRaWAN&trade; gateways is Helium's
+The bulk of the code that enables Hotspots on actual LoRaWAN gateways is Helium's
 next-generation packet forwarder called [gateway-rs](https://github.com/helium/gateway-rs).
 
 :::info Join The Conversation

--- a/docs/network-iot/hotspots-iot/iot-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/iot-hotspots.mdx
@@ -41,7 +41,7 @@ needed.
 ## HIP 70 Changes
 
 [HIP-70](https://github.com/helium/HIP/issues/471) has passed. HIP-70 proposes a new architecture
-involving several Oracles, allowing Proof -of-Coverage (PoC) generation to be automated and its
+involving several Oracles, allowing Proof-of-Coverage (PoC) generation to be automated and its
 receipts to be off-chain.
 
 The most taxing piece of PoC is not just Challenge creation but Receipt validation and verification.

--- a/docs/network-iot/lorawan-frequency-plans.mdx
+++ b/docs/network-iot/lorawan-frequency-plans.mdx
@@ -9,17 +9,14 @@ slug: /iot/lorawan-frequency-plans
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 # Frequencies on the Helium Network
 
-<LegacyContentBanner />
-
-Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm
-the appropriate frequencies for gateway configuration for each country.
+Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
+appropriate frequencies for gateway configuration for each country.
 
 Feel free to refer to
 [our packet forwarder configuration examples](https://github.com/helium/sx1302_hal/tree/helium/hotspot/packet_forwarder).

--- a/docs/network-iot/lorawan-frequency-plans.mdx
+++ b/docs/network-iot/lorawan-frequency-plans.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem'
 
 <LegacyContentBanner />
 
-Helium's LoRaWAN&trade; Network is built upon 8-channel gateways. This page will help you confirm
+Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm
 the appropriate frequencies for gateway configuration for each country.
 
 Feel free to refer to

--- a/docs/network-iot/lorawan-frequency-plans.mdx
+++ b/docs/network-iot/lorawan-frequency-plans.mdx
@@ -18,8 +18,8 @@ import TabItem from '@theme/TabItem'
 
 <LegacyContentBanner />
 
-Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
-appropriate frequencies for gateway configuration for each country.
+Helium's LoRaWAN&trade; Network is built upon 8-channel gateways. This page will help you confirm
+the appropriate frequencies for gateway configuration for each country.
 
 Feel free to refer to
 [our packet forwarder configuration examples](https://github.com/helium/sx1302_hal/tree/helium/hotspot/packet_forwarder).

--- a/docs/network-iot/lorawan-on-helium.mdx
+++ b/docs/network-iot/lorawan-on-helium.mdx
@@ -15,17 +15,17 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <img className="docsheader" src={useBaseUrl('img/lorawan-on-helium/lorawanheader.png')} />
 
-In typical LoRaWAN Networks, a central or regional LNS is managed by a single entity. Helium’s
-design for a decentralized Network, however, means not only do we want gateways (referred to as
-Hotspots) to be independently owned and operated, but we want to enable the independent operation of
-the LNS.
+In typical LoRaWAN&trade; Networks, a central or regional LNS is managed by a single entity.
+Helium’s design for a decentralized Network, however, means not only do we want gateways (referred
+to as Hotspots) to be independently owned and operated, but we want to enable the independent
+operation of the LNS.
 
 Without this, access to the Network would require permission from a single central entity, the LNS
 operator of the Network.
 
-Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN Network. Achieving
-this distinguishes Helium’s LoRaWAN Network from any other: public wireless infrastructure is now
-compatible with privately-run Network Servers.
+Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN&trade; Network.
+Achieving this distinguishes Helium’s LoRaWAN&trade; Network from all other LoRaWA&trade; networks:
+public wireless infrastructure is now compatible with privately-run Network Servers.
 
 The rest of this article will discuss the networking primitives. If you want to go ahead and run a
 Network Server, please check out our article about running a network server.
@@ -45,17 +45,18 @@ Integrity Check (MIC) to disambiguate.
 
 Starting in 2023, Helium will be utilizing an OpenLNS Initiative to allow more choice and increase
 usability. You can read more about the OpenLNS Initiative at the [Helium Foundation
-Blog][foundation-blog] or read more [here](/iot/lorawan-network-servers).
+Blog][foundation-blog] or read more in the [Use Helium LoraWAN](/iot/lorawan-network-servers)
+section.
 
-## Organizationally Unique Identifier
+## Organizationally Unique Identifier (OUI)
 
 Organizationally Unique Identifiers (OUIs) are registered identities on the Helium Blockchain. To
 send and receive packets to an end-device, a network user needs to be serviced an OUI. This can be
-their own OUI or one operated by a third party, such as [Console](/console) operated by Helium
-Foundation.
+their own OUI or one operated by a third party, such as [Helium Console](/console) operated by the
+Helium Foundation.
 
-An OUI has some specificities related to LoRaWAN and packet routing,
-[documented here](/iot/lorawan-on-helium#the-oui), but with respect to the blockchain, what's
+An OUI has some specificities related to LoRaWAN and packet routing, as
+[documented above](/iot/lorawan-on-helium#the-oui), but with respect to the blockchain, what's
 important is that
 [only libp2p addresses registered as endpoints for the OUI](https://github.com/helium/proto/blob/master/src/blockchain_txn_oui_v1.proto#L6)
 may open and close state channels on behalf of an OUI.
@@ -64,8 +65,9 @@ For example, the account `13tyMLKRFYURNBQqLSqNJg9k41maP1A7Bh8QYxR13oWv7EnFooc` p
 OUI on the Helium Blockchain. The address `112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE`
 operates the OUI on behalf of the owner.
 
-OUIs are purchased (see current [fee schedule](/iot/transaction-fees#transaction-fee-schedule)) and
-numbered in incrementing order.
+OUIs are purchased (see current
+[Transaction Fee Schedule](/iot/transaction-fees/#transaction-fee-schedule)) and numbered in
+incrementing order.
 
 :::info
 

--- a/docs/network-iot/lorawan-on-helium.mdx
+++ b/docs/network-iot/lorawan-on-helium.mdx
@@ -9,23 +9,20 @@ slug: /iot/lorawan-on-helium
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
-<LegacyContentBanner />
 
 <img className="docsheader" src={useBaseUrl('img/lorawan-on-helium/lorawanheader.png')} />
 
-In typical LoRaWAN Networks, a central or regional LNS is managed by a single entity.
-Helium’s design for a decentralized Network, however, means not only do we want gateways (referred
-to as Hotspots) to be independently owned and operated, but we want to enable the independent
-operation of the LNS.
+In typical LoRaWAN Networks, a central or regional LNS is managed by a single entity. Helium's
+design for a decentralized Network, however, means not only do we want gateways (referred to as
+Hotspots) to be independently owned and operated, but we want to enable the independent operation of
+the LNS.
 
 Without this, access to the Network would require permission from a single central entity, the LNS
 operator of the Network.
 
-Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN Network.
-Achieving this distinguishes Helium’s LoRaWAN Network from all other LoRaWAN networks:
-public wireless infrastructure is now compatible with privately-run Network Servers.
+Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN Network. Achieving
+this distinguishes Helium's LoRaWAN Network from all other LoRaWAN networks: public wireless
+infrastructure is now compatible with privately-run Network Servers.
 
 The rest of this article will discuss the networking primitives. If you want to go ahead and run a
 Network Server, please check out our article about running a network server.
@@ -48,7 +45,7 @@ usability. You can read more about the OpenLNS Initiative at the [Helium Foundat
 Blog][foundation-blog] or read more in the [Use Helium LoraWAN](/iot/lorawan-network-servers)
 section.
 
-## Organizationally Unique Identifier (OUI)
+## Organizationally Unique Identifier
 
 Organizationally Unique Identifiers (OUIs) are registered identities on the Helium Blockchain. To
 send and receive packets to an end-device, a network user needs to be serviced an OUI. This can be

--- a/docs/network-iot/lorawan-on-helium.mdx
+++ b/docs/network-iot/lorawan-on-helium.mdx
@@ -15,7 +15,7 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <img className="docsheader" src={useBaseUrl('img/lorawan-on-helium/lorawanheader.png')} />
 
-In typical LoRaWAN&trade; Networks, a central or regional LNS is managed by a single entity.
+In typical LoRaWAN Networks, a central or regional LNS is managed by a single entity.
 Helium’s design for a decentralized Network, however, means not only do we want gateways (referred
 to as Hotspots) to be independently owned and operated, but we want to enable the independent
 operation of the LNS.
@@ -23,8 +23,8 @@ operation of the LNS.
 Without this, access to the Network would require permission from a single central entity, the LNS
 operator of the Network.
 
-Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN&trade; Network.
-Achieving this distinguishes Helium’s LoRaWAN&trade; Network from all other LoRaWA&trade; networks:
+Therefore, we want to enable the multi-tenancy of LNSs on the same public LoRaWAN Network.
+Achieving this distinguishes Helium’s LoRaWAN Network from all other LoRaWAN networks:
 public wireless infrastructure is now compatible with privately-run Network Servers.
 
 The rest of this article will discuss the networking primitives. If you want to go ahead and run a

--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -8,14 +8,10 @@ image: https://docs.helium.com/img/link-image.png
 slug: /iot/lorawan-region-plans
 ---
 
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
 # Frequencies by Region on the Helium Network
 
-<LegacyContentBanner />
-
-Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm
-the appropriate frequencies for gateway configuration for each region.
+Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
+appropriate frequencies for gateway configuration for each region.
 
 ## Frequency Plans by Country
 

--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -14,20 +14,24 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <LegacyContentBanner />
 
-Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm the
-appropriate frequencies for gateway configuration for each region.
+Helium's LoRaWAN&trade; Network is built upon 8-channel gateways. This page will help you confirm
+the appropriate frequencies for gateway configuration for each region.
 
 ## Frequency Plans by Country
 
 Where a frequency plan is "Unknown", it often means the local telecommunications or radio authority
 in that country has not yet created
-[Short Range Device (SRD)](https://en.wikipedia.org/wiki/Short-range_device) regulations for either
-the 800 Mhz or 900 Mhz spectrum bands. Helium gateways cannot be operated in countries without valid
-SRD regulations. Contact the LoRa Alliance for further information -
-[LoRa Alliance](https://lora-alliance.org/contact/)
+[Short Range Device (SRD)](https://www.etsi.org/technologies/short-range-devices) regulations for
+either the 800 Mhz or 900 Mhz spectrum bands. Helium gateways cannot be operated in countries
+without valid SRD regulations. Contact the [LoRa Alliance](https://lora-alliance.org/contact/) for
+further information.
 
-Note - Helium does not support EU433 and has no plans to ever support EU433 given it is a legacy
-band. Countries with EU433 should consider regulations to support the 800 or 900 Mhz SRD bands.
+:::Note
+
+Helium does not support EU433 and has no plans to ever support EU433 given it is a legacy band.
+Countries with EU433 should consider regulations to support the 800 or 900 Mhz SRD bands.
+
+:::
 
 #### A <a id="a"></a>
 

--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -14,7 +14,7 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <LegacyContentBanner />
 
-Helium's LoRaWAN&trade; Network is built upon 8-channel gateways. This page will help you confirm
+Helium's LoRaWAN Network is built upon 8-channel gateways. This page will help you confirm
 the appropriate frequencies for gateway configuration for each region.
 
 ## Frequency Plans by Country

--- a/docs/network-iot/lorawan-region-plans.mdx
+++ b/docs/network-iot/lorawan-region-plans.mdx
@@ -22,12 +22,8 @@ either the 800 Mhz or 900 Mhz spectrum bands. Helium gateways cannot be operated
 without valid SRD regulations. Contact the [LoRa Alliance](https://lora-alliance.org/contact/) for
 further information.
 
-:::Note
-
-Helium does not support EU433 and has no plans to ever support EU433 given it is a legacy band.
-Countries with EU433 should consider regulations to support the 800 or 900 Mhz SRD bands.
-
-:::
+Note - Helium does not support EU433 and has no plans to ever support EU433 given it is a legacy
+band. Countries with EU433 should consider regulations to support the 800 or 900 Mhz SRD bands.
 
 #### A <a id="a"></a>
 


### PR DESCRIPTION
Updated LoRaWAN on Helium section.
Devices section I did not update yet. I have to check the last PR I did on devices (I think last one I did was for Netvox?)
Updated IOT Hotspots heading. Subsections not yet.
Updated the Data-Only Hotspots main heading.
Updated Data-Only Onboarding section.

COTX X1 Lite link in Data-Only Hotspots and Data-Only Onboarding removed. Dead link. They didn't pay their webhost.

#Solana Scribes 2024