### PR TITLE
Changed subDAOs to Subnetworks

### DIFF
--- a/docs/architecture/oracles/mobile-proof-of-coverage-oracles.mdx
+++ b/docs/architecture/oracles/mobile-proof-of-coverage-oracles.mdx
@@ -13,7 +13,7 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <LegacyContentBanner />
 
-As the MOBILE Subnetwork is still in its infancy, its
+As the MOBILE subnetwork is still in its infancy, its
 [PoC model is relatively straightforward](/mobile/proof-of-coverage) and based on the following
 factors:
 

--- a/docs/architecture/oracles/mobile-proof-of-coverage-oracles.mdx
+++ b/docs/architecture/oracles/mobile-proof-of-coverage-oracles.mdx
@@ -13,7 +13,7 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 
 <LegacyContentBanner />
 
-As the MOBILE subDAO is still in its infancy, its
+As the MOBILE Subnetwork is still in its infancy, its
 [PoC model is relatively straightforward](/mobile/proof-of-coverage) and based on the following
 factors:
 

--- a/docs/architecture/oracles/oracles.mdx
+++ b/docs/architecture/oracles/oracles.mdx
@@ -16,13 +16,13 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 <img className="docsheader" src={useBaseUrl('img/blockchain/oracle.png')} />
 
 The migration of the Helium L1 to the Solana L1 brings several changes to the setup of the Network
-and its associated Subnetworks infrastructure. Chief among these changes is moving a lot of data that
+and its associated subnetworks infrastructure. Chief among these changes is moving a lot of data that
 has previously been "on-chain" (namely PoC data) "off-chain".
 
 As such, this migration introduces several Oracles which serve as bridges between the external world
 and the blockchain. These infrastructure changes allow the Helium Network to effectively introduce
-new Networks as Decentralized Network Protocol (DNP) Subnetworks, and more easily scale existing DNP
-Subnetworks (e.g., IOT) by removing existing bottlenecks.
+new Networks as Decentralized Network Protocol (DNP) subnetworks, and more easily scale existing DNP
+subnetworks (e.g., IOT) by removing existing bottlenecks.
 
 With the deprecation of the Helium L1, changes to the API and
 [ETL](https://github.com/helium/blockchain-etl) include:

--- a/docs/architecture/oracles/oracles.mdx
+++ b/docs/architecture/oracles/oracles.mdx
@@ -16,13 +16,13 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 <img className="docsheader" src={useBaseUrl('img/blockchain/oracle.png')} />
 
 The migration of the Helium L1 to the Solana L1 brings several changes to the setup of the Network
-and its associated subDAOs infrastructure. Chief among these changes is moving a lot of data that
+and its associated Subnetworks infrastructure. Chief among these changes is moving a lot of data that
 has previously been "on-chain" (namely PoC data) "off-chain".
 
 As such, this migration introduces several Oracles which serve as bridges between the external world
 and the blockchain. These infrastructure changes allow the Helium Network to effectively introduce
-new Networks as Decentralized Network Protocol (DNP) subDAOs, and more easily scale existing DNP
-subDAOs (e.g., IOT) by removing existing bottlenecks.
+new Networks as Decentralized Network Protocol (DNP) Subnetworks, and more easily scale existing DNP
+Subnetworks (e.g., IOT) by removing existing bottlenecks.
 
 With the deprecation of the Helium L1, changes to the API and
 [ETL](https://github.com/helium/blockchain-etl) include:

--- a/docs/architecture/oracles/oracles.mdx
+++ b/docs/architecture/oracles/oracles.mdx
@@ -16,8 +16,8 @@ import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
 <img className="docsheader" src={useBaseUrl('img/blockchain/oracle.png')} />
 
 The migration of the Helium L1 to the Solana L1 brings several changes to the setup of the Network
-and its associated subnetworks infrastructure. Chief among these changes is moving a lot of data that
-has previously been "on-chain" (namely PoC data) "off-chain".
+and its associated subnetworks infrastructure. Chief among these changes is moving a lot of data
+that has previously been "on-chain" (namely PoC data) "off-chain".
 
 As such, this migration introduces several Oracles which serve as bridges between the external world
 and the blockchain. These infrastructure changes allow the Helium Network to effectively introduce

--- a/docs/architecture/oracles/rewards-oracles.mdx
+++ b/docs/architecture/oracles/rewards-oracles.mdx
@@ -47,14 +47,14 @@ Receipts, and the veHNT backing the MOBILE Network and emits rewards to each Hot
 ## HNT Rewards Oracle
 
 As defined in [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md), the HNT Rewards
-Oracle will issue HNT Reward emissions to each subDAOs treasury using each subDAOs Utility Score to
-determine which percentage of the total rewards each subDAO is due.
+Oracle will issue HNT Reward emissions to each Subnetworks treasury using each Subnetworks Utility Score to
+determine which percentage of the total rewards each Subnetwork is due.
 
-The following comprise the subDAO Utility Score:
+The following comprise the Subnetwork Utility Score:
 
-- subDAO's DCs burned in USD
-- subDAO's active device count and device activation fee
-- veHNT backing each subDAO
+- Subnetwork's DCs burned in USD
+- Subnetwork's active device count and device activation fee
+- veHNT backing each Subnetwork
 
 DC burned, active device count, and veHNT staked are submitted to the chain through the proxy of
 [Switchboard](https://switchboard.xyz/) to facilitate this process and keep a record.
@@ -121,9 +121,9 @@ flowchart LR
 
 ```
 
-## SubDAO to HNT Conversion
+## Subnetwork to HNT Conversion
 
-Each subDAO is responsible for defining its Treasury Reserve Decentralized Network Token (DNT)
+Each Subnetwork is responsible for defining its Treasury Reserve Decentralized Network Token (DNT)
 Market Making Curve.
 
 The curves for

--- a/docs/architecture/oracles/rewards-oracles.mdx
+++ b/docs/architecture/oracles/rewards-oracles.mdx
@@ -47,8 +47,8 @@ Receipts, and the veHNT backing the MOBILE Network and emits rewards to each Hot
 ## HNT Rewards Oracle
 
 As defined in [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md), the HNT Rewards
-Oracle will issue HNT Reward emissions to each subnetworks treasury using each subnetworks Utility Score to
-determine which percentage of the total rewards each subnetwork is due.
+Oracle will issue HNT Reward emissions to each subnetworks treasury using each subnetworks Utility
+Score to determine which percentage of the total rewards each subnetwork is due.
 
 The following comprise the subnetwork Utility Score:
 

--- a/docs/architecture/oracles/rewards-oracles.mdx
+++ b/docs/architecture/oracles/rewards-oracles.mdx
@@ -47,14 +47,14 @@ Receipts, and the veHNT backing the MOBILE Network and emits rewards to each Hot
 ## HNT Rewards Oracle
 
 As defined in [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md), the HNT Rewards
-Oracle will issue HNT Reward emissions to each Subnetworks treasury using each Subnetworks Utility Score to
-determine which percentage of the total rewards each Subnetwork is due.
+Oracle will issue HNT Reward emissions to each subnetworks treasury using each subnetworks Utility Score to
+determine which percentage of the total rewards each subnetwork is due.
 
-The following comprise the Subnetwork Utility Score:
+The following comprise the subnetwork Utility Score:
 
-- Subnetwork's DCs burned in USD
-- Subnetwork's active device count and device activation fee
-- veHNT backing each Subnetwork
+- subnetwork's DCs burned in USD
+- subnetwork's active device count and device activation fee
+- veHNT backing each subnetwork
 
 DC burned, active device count, and veHNT staked are submitted to the chain through the proxy of
 [Switchboard](https://switchboard.xyz/) to facilitate this process and keep a record.
@@ -123,7 +123,7 @@ flowchart LR
 
 ## Subnetwork to HNT Conversion
 
-Each Subnetwork is responsible for defining its Treasury Reserve Decentralized Network Token (DNT)
+Each subnetwork is responsible for defining its Treasury Reserve Decentralized Network Token (DNT)
 Market Making Curve.
 
 The curves for

--- a/docs/architecture/solana/introduction.mdx
+++ b/docs/architecture/solana/introduction.mdx
@@ -91,7 +91,7 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### helium_sub_daos
 
 - Program ID: `hdaoVTCqhfHHo75XdAMxBKdUqvq1i5bF23sisBqVgGR`
-- Manages the DAO/SubDAO structure proposed in HIP-51, including the minting of tokens to subDAOs,
+- Manages the DAO/Subnetwork structure proposed in HIP-51, including the minting of tokens to Subnetworks,
   HST holders, and the `lazy_distributor` for PoC earnings.
 
 #### lazy_distributor
@@ -109,7 +109,7 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### treasury_management
 
 - Program ID: `treaf4wWBBty3fHdyBpo35Mz84M8k3heKXmjmi9vFt5`
-- Manages the treasury of each subDAO as proposed in HIP-51, allowing DNT tokens to be swapped for
+- Manages the treasury of each Subnetwork as proposed in HIP-51, allowing DNT tokens to be swapped for
   HNT according to a formula.
 
 #### voter_stake_registry

--- a/docs/architecture/solana/introduction.mdx
+++ b/docs/architecture/solana/introduction.mdx
@@ -91,7 +91,7 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### helium_sub_daos
 
 - Program ID: `hdaoVTCqhfHHo75XdAMxBKdUqvq1i5bF23sisBqVgGR`
-- Manages the DAO/Subnetwork structure proposed in HIP-51, including the minting of tokens to Subnetworks,
+- Manages the DAO/subnetwork structure proposed in HIP-51, including the minting of tokens to subnetworks,
   HST holders, and the `lazy_distributor` for PoC earnings.
 
 #### lazy_distributor
@@ -109,7 +109,7 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### treasury_management
 
 - Program ID: `treaf4wWBBty3fHdyBpo35Mz84M8k3heKXmjmi9vFt5`
-- Manages the treasury of each Subnetwork as proposed in HIP-51, allowing DNT tokens to be swapped for
+- Manages the treasury of each subnetwork as proposed in HIP-51, allowing DNT tokens to be swapped for
   HNT according to a formula.
 
 #### voter_stake_registry

--- a/docs/architecture/solana/introduction.mdx
+++ b/docs/architecture/solana/introduction.mdx
@@ -91,8 +91,8 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### helium_sub_daos
 
 - Program ID: `hdaoVTCqhfHHo75XdAMxBKdUqvq1i5bF23sisBqVgGR`
-- Manages the DAO/subnetwork structure proposed in HIP-51, including the minting of tokens to subnetworks,
-  HST holders, and the `lazy_distributor` for PoC earnings.
+- Manages the DAO/subnetwork structure proposed in HIP-51, including the minting of tokens to
+  subnetworks, HST holders, and the `lazy_distributor` for PoC earnings.
 
 #### lazy_distributor
 
@@ -109,8 +109,8 @@ published March 20, 2023. The audit report is available from sec3 on their
 #### treasury_management
 
 - Program ID: `treaf4wWBBty3fHdyBpo35Mz84M8k3heKXmjmi9vFt5`
-- Manages the treasury of each subnetwork as proposed in HIP-51, allowing DNT tokens to be swapped for
-  HNT according to a formula.
+- Manages the treasury of each subnetwork as proposed in HIP-51, allowing DNT tokens to be swapped
+  for HNT according to a formula.
 
 #### voter_stake_registry
 

--- a/docs/architecture/solana/migration/governance.mdx
+++ b/docs/architecture/solana/migration/governance.mdx
@@ -27,8 +27,8 @@ wallet, and vote.
 ## Governance Changes
 
 The major change with Solana governance is that more of the Helium Network can be governed by the
-Helium DAO and its subDAOS. Everything from Program (smart contract) changes to approving Makers can
-now be controlled by the Helium DAO and its subDAOs.
+Helium DAO and its Subnetworks. Everything from Program (smart contract) changes to approving Makers can
+now be controlled by the Helium DAO and its Subnetworks.
 
 [helium-vote]: https://helium.vote
 [realms]: https://app.realms.today

--- a/docs/architecture/solana/migration/governance.mdx
+++ b/docs/architecture/solana/migration/governance.mdx
@@ -27,8 +27,8 @@ wallet, and vote.
 ## Governance Changes
 
 The major change with Solana governance is that more of the Helium Network can be governed by the
-Helium DAO and its Subnetworks. Everything from Program (smart contract) changes to approving Makers can
-now be controlled by the Helium DAO and its Subnetworks.
+Helium Network and its subnetworks. Everything from Program (smart contract) changes to approving Makers can
+now be controlled by the Helium DAO and its subnetworks.
 
 [helium-vote]: https://helium.vote
 [realms]: https://app.realms.today

--- a/docs/architecture/solana/migration/governance.mdx
+++ b/docs/architecture/solana/migration/governance.mdx
@@ -27,8 +27,8 @@ wallet, and vote.
 ## Governance Changes
 
 The major change with Solana governance is that more of the Helium Network can be governed by the
-Helium Network and its subnetworks. Everything from Program (smart contract) changes to approving Makers can
-now be controlled by the Helium DAO and its subnetworks.
+Helium Network and its subnetworks. Everything from Program (smart contract) changes to approving
+Makers can now be controlled by the Helium DAO and its subnetworks.
 
 [helium-vote]: https://helium.vote
 [realms]: https://app.realms.today

--- a/docs/architecture/solana/migration/hotspot-operator.mdx
+++ b/docs/architecture/solana/migration/hotspot-operator.mdx
@@ -67,8 +67,8 @@ available.
 
 ## IOT Pre-mine
 
-As described in [HIP-52: IOT subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the
-launch of the IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and
+As described in [HIP-52: IOT subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md)
+the launch of the IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and
 Hotspots on the existing IoT network.
 
 The IOT Pre-mine will reward Hotspots contributing and earning on the Network within the 30 days

--- a/docs/architecture/solana/migration/hotspot-operator.mdx
+++ b/docs/architecture/solana/migration/hotspot-operator.mdx
@@ -36,7 +36,7 @@ screen and will not accept transaction requests.
 
 ## Reward Distribution and Claiming
 
-All LoRaWAN Hotspots will be rewarded in the new IOT Subnetwork token instead of HNT.
+All LoRaWAN Hotspots will be rewarded in the new IOT subnetwork token instead of HNT.
 
 Rewards will accumulate to each Hotspot, not directly to a Wallet, and must be "claimed" before they
 will be in the owning Wallet.
@@ -67,7 +67,7 @@ available.
 
 ## IOT Pre-mine
 
-As described in [HIP-52: IOT Subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the
+As described in [HIP-52: IOT subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the
 launch of the IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and
 Hotspots on the existing IoT network.
 

--- a/docs/architecture/solana/migration/hotspot-operator.mdx
+++ b/docs/architecture/solana/migration/hotspot-operator.mdx
@@ -36,7 +36,7 @@ screen and will not accept transaction requests.
 
 ## Reward Distribution and Claiming
 
-All LoRaWAN Hotspots will be rewarded in the new IOT subDAO token instead of HNT.
+All LoRaWAN Hotspots will be rewarded in the new IOT Subnetwork token instead of HNT.
 
 Rewards will accumulate to each Hotspot, not directly to a Wallet, and must be "claimed" before they
 will be in the owning Wallet.
@@ -67,7 +67,7 @@ available.
 
 ## IOT Pre-mine
 
-As described in [HIP-52: IOT subDAO](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the
+As described in [HIP-52: IOT Subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the
 launch of the IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and
 Hotspots on the existing IoT network.
 

--- a/docs/architecture/solana/migration/hotspot-operator.mdx
+++ b/docs/architecture/solana/migration/hotspot-operator.mdx
@@ -67,9 +67,9 @@ available.
 
 ## IOT Pre-mine
 
-As described in [HIP-52: IOT subnetwork](https://github.com/helium/HIP/blob/main/0052-iot-dao.md)
-the launch of the IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and
-Hotspots on the existing IoT network.
+As described in [HIP-52](https://github.com/helium/HIP/blob/main/0052-iot-dao.md) the launch of the
+IoT subnetwork will include a pre-mine of 5 billion IOT tokens to Validators and Hotspots on the
+existing IoT network.
 
 The IOT Pre-mine will reward Hotspots contributing and earning on the Network within the 30 days
 preceding the Solana Migration Snapshot.

--- a/docs/architecture/solana/migration/hotspot-owner.mdx
+++ b/docs/architecture/solana/migration/hotspot-owner.mdx
@@ -50,7 +50,7 @@ of your Hotspots.
 
 ### Hotspots Will Earn IOT
 
-Hotspot Owners will start earning IOT as the blockchain migration will launch the IOT Subnetwork. To
+Hotspot Owners will start earning IOT as the blockchain migration will launch the IOT subnetwork. To
 view IOT earned by your Hotspot, use the Helium Wallet app. 5G Hotspot Owners will continue earning
 MOBILE and will additionally begin to earn IOT.
 

--- a/docs/architecture/solana/migration/hotspot-owner.mdx
+++ b/docs/architecture/solana/migration/hotspot-owner.mdx
@@ -50,7 +50,7 @@ of your Hotspots.
 
 ### Hotspots Will Earn IOT
 
-Hotspot Owners will start earning IOT as the blockchain migration will launch the IOT subDAO. To
+Hotspot Owners will start earning IOT as the blockchain migration will launch the IOT Subnetwork. To
 view IOT earned by your Hotspot, use the Helium Wallet app. 5G Hotspot Owners will continue earning
 MOBILE and will additionally begin to earn IOT.
 

--- a/docs/architecture/solana/migration/validator-operator.mdx
+++ b/docs/architecture/solana/migration/validator-operator.mdx
@@ -97,9 +97,9 @@ lock-up time.
 
 **Step 6: Monitor and adjust**
 
-Monitor your subnetwork earnings and adjust your delegations as desired. Remember that as more veHNT is
-delegated to a particular subnetwork, individual holder earnings will be reduced due to the sharing of
-the 6% subnetwork token emissions.
+Monitor your subnetwork earnings and adjust your delegations as desired. Remember that as more veHNT
+is delegated to a particular subnetwork, individual holder earnings will be reduced due to the
+sharing of the 6% subnetwork token emissions.
 
 :::important Important notes:
 
@@ -116,8 +116,8 @@ the 6% subnetwork token emissions.
 - veHNT gives holders voting rights to determine the future of the Helium Network.
 - Validators who remain staked receive a 3x veHNT bonus for staked HNT, and their HNT remains locked
   up for the six-month lock-up period as defined in HIP 51.
-- Stakers will no longer receive a reward in HNT tokens. subnetwork delegation rewards IOT and/or MOBILE
-  which are convertible to HNT.
+- Stakers will no longer receive a reward in HNT tokens. subnetwork delegation rewards IOT and/or
+  MOBILE which are convertible to HNT.
 - HNT can be released back to the veHNT owner's Wallet after the minimum six-month lock-up period
   after selecting the staking cooldown.
 
@@ -136,14 +136,14 @@ convert to veHNT, these holders can optionally delegate to specific subnetworks.
 
 Currently, the IOT and MOBILE subnetwork have a 6% token emission pool for veHNT stakers.
 
-After the implementation of HIP-51, HIP-52, and HIP-53, all the subnetworks combined will receive the
-non-HST emissions of HNT. This is 68% of emitted HNT and will increase to 69% in the following
+After the implementation of HIP-51, HIP-52, and HIP-53, all the subnetworks combined will receive
+the non-HST emissions of HNT. This is 68% of emitted HNT and will increase to 69% in the following
 yearly emissions change in August 2023. This emissions curve changes annually, so the subnetworks
 eventually receive 85% of all future HNT emissions.
 
 Previously Validator stakers had a Validator performance-based randomized chance at 6% of the daily
-distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to subnetworks based
-on how much HNT for how long they are willing to lock up that HNT.
+distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to subnetworks
+based on how much HNT for how long they are willing to lock up that HNT.
 
 ### What Happens to my HNT Previously Staked in a Pool?
 
@@ -190,8 +190,8 @@ cooldown option has been initiated. After selecting cooldown, they will get thei
 validator back in 183 days (6 months) after the date of the cooldown selection.
 
 Validators will no longer receive any reward in HNT from the transition date. Stakes will need to be
-delegated to either the IOT or MOBILE subnetwork to get a reward in IOT or MOBILE tokens. A stake can
-also be split among subnetworks.
+delegated to either the IOT or MOBILE subnetwork to get a reward in IOT or MOBILE tokens. A stake
+can also be split among subnetworks.
 
 ### What if I want my HNT back?
 
@@ -205,8 +205,8 @@ After selecting cooldown, they will get their 10,000 HNT per validator back in 1
 after the date of the cooldown selection. This is like the 250,000 block cooldown period validators
 previously had.
 
-veHNT can be delegated to subnetworks to earn a linearly decreasing reward in IOT or MOBILE tokens while
-in cooldown.
+veHNT can be delegated to subnetworks to earn a linearly decreasing reward in IOT or MOBILE tokens
+while in cooldown.
 
 ### "Top-up" of veHNT Positions
 
@@ -235,8 +235,8 @@ created in the Landrush period.
 Splitting as an action transfers some of the veHNT from one position to another new or existing
 position.
 
-veHNT owners may want to frequently vary their split of subnetwork delegations and lock-up periods to
-suit their situations and the variance of the HNT per subnetwork emitted based on the DAO Utility
+veHNT owners may want to frequently vary their split of subnetwork delegations and lock-up periods
+to suit their situations and the variance of the HNT per subnetwork emitted based on the DAO Utility
 Scores.
 
 ### Can I Increase My Staking Lock-up Period At Any Time?

--- a/docs/architecture/solana/migration/validator-operator.mdx
+++ b/docs/architecture/solana/migration/validator-operator.mdx
@@ -22,13 +22,13 @@ changes you can expect and the steps necessary to continue earning a return for 
 1. Access to your validator's Wallet, either through the Helium Wallet App or a Ledger hardware
    wallet.
 1. Familiarized yourself with the new [veHNT](/governance/vehnt) governance model and the concept
-   staking to Subnetworks (IOT and MOBILE).
+   staking to subnetworks (IOT and MOBILE).
 
 :::tip VeHNT, a New Way to Stake:
 
 After the transition, veHNT will replace staked HNT and will be represented by a non-transferable
 Solana NFT held in your Wallet. veHNT grants holders voting rights to influence the future of the
-Helium Network and the ability to earn IOT and/or MOBILE through Subnetwork delegation.
+Helium Network and the ability to earn IOT and/or MOBILE through subnetwork delegation.
 
 :::
 
@@ -76,17 +76,17 @@ cooldown will automatically convert to veHNT with a six-month staking release da
 HIP-70. Each validator will receive 375,000 veHNT as a veHNT position for six months with rolling
 lock-up, called "constant lock-up."
 
-**Step 4: Delegation to Subnetworks** Decide which Subnetwork or combination of Subnetworks
+**Step 4: Delegation to subnetworks** Decide which subnetwork or combination of subnetworks
 ([IOT](/tokens/iot-token) and [MOBILE](/tokens/mobile-token)) you want to delegate your veHNT to.
-You can have multiple positions of veHNT delegated to different Subnetworks or for different lock-up
+You can have multiple positions of veHNT delegated to different subnetworks or for different lock-up
 periods. Each position of veHNT can delegate all or nothing of the veHNT.
 
 Delegation of veHNT can be managed within the [Helium Wallet App](/wallets/helium-wallet-app) using
 Realms.
 
 - [HNT DAO on Realms](https://app.realms.today/dao/HNT)
-- [IOT Subnetwork on Realms](https://app.realms.today/dao/IOT)
-- [MOBILE Subnetwork on Realms](https://app.realms.today/dao/MOBILE)
+- [IOT subnetwork on Realms](https://app.realms.today/dao/IOT)
+- [MOBILE subnetwork on Realms](https://app.realms.today/dao/MOBILE)
 
 **Step 5: Managing lock-up periods**
 
@@ -97,9 +97,9 @@ lock-up time.
 
 **Step 6: Monitor and adjust**
 
-Monitor your Subnetwork earnings and adjust your delegations as desired. Remember that as more veHNT is
-delegated to a particular Subnetwork, individual holder earnings will be reduced due to the sharing of
-the 6% Subnetwork token emissions.
+Monitor your subnetwork earnings and adjust your delegations as desired. Remember that as more veHNT is
+delegated to a particular subnetwork, individual holder earnings will be reduced due to the sharing of
+the 6% subnetwork token emissions.
 
 :::important Important notes:
 
@@ -116,7 +116,7 @@ the 6% Subnetwork token emissions.
 - veHNT gives holders voting rights to determine the future of the Helium Network.
 - Validators who remain staked receive a 3x veHNT bonus for staked HNT, and their HNT remains locked
   up for the six-month lock-up period as defined in HIP 51.
-- Stakers will no longer receive a reward in HNT tokens. Subnetwork delegation rewards IOT and/or MOBILE
+- Stakers will no longer receive a reward in HNT tokens. subnetwork delegation rewards IOT and/or MOBILE
   which are convertible to HNT.
 - HNT can be released back to the veHNT owner's Wallet after the minimum six-month lock-up period
   after selecting the staking cooldown.
@@ -132,17 +132,17 @@ began to beacon independently. As a result, the PoC Challenger rewards pool retu
 
 After HIP-70 and the L1 transition are implemented, the existing Validators will no longer produce
 blocks for the Helium Network and will no longer receive HNT rewards. As their staked HNT will
-convert to veHNT, these holders can optionally delegate to specific Subnetworks.
+convert to veHNT, these holders can optionally delegate to specific subnetworks.
 
-Currently, the IOT and MOBILE Subnetwork have a 6% token emission pool for veHNT stakers.
+Currently, the IOT and MOBILE subnetwork have a 6% token emission pool for veHNT stakers.
 
-After the implementation of HIP-51, HIP-52, and HIP-53, all the Subnetworks combined will receive the
+After the implementation of HIP-51, HIP-52, and HIP-53, all the subnetworks combined will receive the
 non-HST emissions of HNT. This is 68% of emitted HNT and will increase to 69% in the following
-yearly emissions change in August 2023. This emissions curve changes annually, so the Subnetworks
+yearly emissions change in August 2023. This emissions curve changes annually, so the subnetworks
 eventually receive 85% of all future HNT emissions.
 
 Previously Validator stakers had a Validator performance-based randomized chance at 6% of the daily
-distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to Subnetworks based
+distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to subnetworks based
 on how much HNT for how long they are willing to lock up that HNT.
 
 ### What Happens to my HNT Previously Staked in a Pool?
@@ -190,8 +190,8 @@ cooldown option has been initiated. After selecting cooldown, they will get thei
 validator back in 183 days (6 months) after the date of the cooldown selection.
 
 Validators will no longer receive any reward in HNT from the transition date. Stakes will need to be
-delegated to either the IOT or MOBILE Subnetwork to get a reward in IOT or MOBILE tokens. A stake can
-also be split among Subnetworks.
+delegated to either the IOT or MOBILE subnetwork to get a reward in IOT or MOBILE tokens. A stake can
+also be split among subnetworks.
 
 ### What if I want my HNT back?
 
@@ -205,7 +205,7 @@ After selecting cooldown, they will get their 10,000 HNT per validator back in 1
 after the date of the cooldown selection. This is like the 250,000 block cooldown period validators
 previously had.
 
-veHNT can be delegated to Subnetworks to earn a linearly decreasing reward in IOT or MOBILE tokens while
+veHNT can be delegated to subnetworks to earn a linearly decreasing reward in IOT or MOBILE tokens while
 in cooldown.
 
 ### "Top-up" of veHNT Positions
@@ -222,9 +222,9 @@ It is highly recommended that previous validator owners and large HNT stakers sp
 position received after the transition into several smaller positions immediately upon lock-up and,
 when applicable, within ten days after the Solana transition, before 23:59:59 UTC on April 28.
 
-This is because the Subnetwork delegation of veHNT is a 0 or 100% all-or-nothing action.
+This is because the subnetwork delegation of veHNT is a 0 or 100% all-or-nothing action.
 
-- Splitting veHNT across multiple Subnetworks requires multiple positions.
+- Splitting veHNT across multiple subnetworks requires multiple positions.
 - Splitting veHNT over different lock-up periods requires multiple positions.
 - Splitting veHNT with some in constant lock-up and some in cooldown requires multiple positions.
 
@@ -235,8 +235,8 @@ created in the Landrush period.
 Splitting as an action transfers some of the veHNT from one position to another new or existing
 position.
 
-veHNT owners may want to frequently vary their split of Subnetwork delegations and lock-up periods to
-suit their situations and the variance of the HNT per Subnetwork emitted based on the DAO Utility
+veHNT owners may want to frequently vary their split of subnetwork delegations and lock-up periods to
+suit their situations and the variance of the HNT per subnetwork emitted based on the DAO Utility
 Scores.
 
 ### Can I Increase My Staking Lock-up Period At Any Time?

--- a/docs/architecture/solana/migration/validator-operator.mdx
+++ b/docs/architecture/solana/migration/validator-operator.mdx
@@ -22,13 +22,13 @@ changes you can expect and the steps necessary to continue earning a return for 
 1. Access to your validator's Wallet, either through the Helium Wallet App or a Ledger hardware
    wallet.
 1. Familiarized yourself with the new [veHNT](/governance/vehnt) governance model and the concept
-   staking to subDAOs (IOT and MOBILE).
+   staking to Subnetworks (IOT and MOBILE).
 
 :::tip VeHNT, a New Way to Stake:
 
 After the transition, veHNT will replace staked HNT and will be represented by a non-transferable
 Solana NFT held in your Wallet. veHNT grants holders voting rights to influence the future of the
-Helium Network and the ability to earn IOT and/or MOBILE through subDAO delegation.
+Helium Network and the ability to earn IOT and/or MOBILE through Subnetwork delegation.
 
 :::
 
@@ -76,17 +76,17 @@ cooldown will automatically convert to veHNT with a six-month staking release da
 HIP-70. Each validator will receive 375,000 veHNT as a veHNT position for six months with rolling
 lock-up, called "constant lock-up."
 
-**Step 4: Delegation to subDAOs** Decide which subDAO or combination of subDAOs
+**Step 4: Delegation to Subnetworks** Decide which Subnetwork or combination of Subnetworks
 ([IOT](/tokens/iot-token) and [MOBILE](/tokens/mobile-token)) you want to delegate your veHNT to.
-You can have multiple positions of veHNT delegated to different subDAOs or for different lock-up
+You can have multiple positions of veHNT delegated to different Subnetworks or for different lock-up
 periods. Each position of veHNT can delegate all or nothing of the veHNT.
 
 Delegation of veHNT can be managed within the [Helium Wallet App](/wallets/helium-wallet-app) using
 Realms.
 
 - [HNT DAO on Realms](https://app.realms.today/dao/HNT)
-- [IOT subDAO on Realms](https://app.realms.today/dao/IOT)
-- [MOBILE subDAO on Realms](https://app.realms.today/dao/MOBILE)
+- [IOT Subnetwork on Realms](https://app.realms.today/dao/IOT)
+- [MOBILE Subnetwork on Realms](https://app.realms.today/dao/MOBILE)
 
 **Step 5: Managing lock-up periods**
 
@@ -97,9 +97,9 @@ lock-up time.
 
 **Step 6: Monitor and adjust**
 
-Monitor your subDAO earnings and adjust your delegations as desired. Remember that as more veHNT is
-delegated to a particular subDAO, individual holder earnings will be reduced due to the sharing of
-the 6% subDAO token emissions.
+Monitor your Subnetwork earnings and adjust your delegations as desired. Remember that as more veHNT is
+delegated to a particular Subnetwork, individual holder earnings will be reduced due to the sharing of
+the 6% Subnetwork token emissions.
 
 :::important Important notes:
 
@@ -116,7 +116,7 @@ the 6% subDAO token emissions.
 - veHNT gives holders voting rights to determine the future of the Helium Network.
 - Validators who remain staked receive a 3x veHNT bonus for staked HNT, and their HNT remains locked
   up for the six-month lock-up period as defined in HIP 51.
-- Stakers will no longer receive a reward in HNT tokens. SubDAO delegation rewards IOT and/or MOBILE
+- Stakers will no longer receive a reward in HNT tokens. Subnetwork delegation rewards IOT and/or MOBILE
   which are convertible to HNT.
 - HNT can be released back to the veHNT owner's Wallet after the minimum six-month lock-up period
   after selecting the staking cooldown.
@@ -132,17 +132,17 @@ began to beacon independently. As a result, the PoC Challenger rewards pool retu
 
 After HIP-70 and the L1 transition are implemented, the existing Validators will no longer produce
 blocks for the Helium Network and will no longer receive HNT rewards. As their staked HNT will
-convert to veHNT, these holders can optionally delegate to specific subDAOs.
+convert to veHNT, these holders can optionally delegate to specific Subnetworks.
 
-Currently, the IOT and MOBILE subDAO have a 6% token emission pool for veHNT stakers.
+Currently, the IOT and MOBILE Subnetwork have a 6% token emission pool for veHNT stakers.
 
-After the implementation of HIP-51, HIP-52, and HIP-53, all the subDAOs combined will receive the
+After the implementation of HIP-51, HIP-52, and HIP-53, all the Subnetworks combined will receive the
 non-HST emissions of HNT. This is 68% of emitted HNT and will increase to 69% in the following
-yearly emissions change in August 2023. This emissions curve changes annually, so the subDAOs
+yearly emissions change in August 2023. This emissions curve changes annually, so the Subnetworks
 eventually receive 85% of all future HNT emissions.
 
 Previously Validator stakers had a Validator performance-based randomized chance at 6% of the daily
-distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to subDAOs based
+distribution of HNT. Now they have a share of 6% of the 68% of the HNT distributed to Subnetworks based
 on how much HNT for how long they are willing to lock up that HNT.
 
 ### What Happens to my HNT Previously Staked in a Pool?
@@ -190,8 +190,8 @@ cooldown option has been initiated. After selecting cooldown, they will get thei
 validator back in 183 days (6 months) after the date of the cooldown selection.
 
 Validators will no longer receive any reward in HNT from the transition date. Stakes will need to be
-delegated to either the IOT or MOBILE subDAO to get a reward in IOT or MOBILE tokens. A stake can
-also be split among subDAOs.
+delegated to either the IOT or MOBILE Subnetwork to get a reward in IOT or MOBILE tokens. A stake can
+also be split among Subnetworks.
 
 ### What if I want my HNT back?
 
@@ -205,7 +205,7 @@ After selecting cooldown, they will get their 10,000 HNT per validator back in 1
 after the date of the cooldown selection. This is like the 250,000 block cooldown period validators
 previously had.
 
-veHNT can be delegated to subDAOs to earn a linearly decreasing reward in IOT or MOBILE tokens while
+veHNT can be delegated to Subnetworks to earn a linearly decreasing reward in IOT or MOBILE tokens while
 in cooldown.
 
 ### "Top-up" of veHNT Positions
@@ -222,9 +222,9 @@ It is highly recommended that previous validator owners and large HNT stakers sp
 position received after the transition into several smaller positions immediately upon lock-up and,
 when applicable, within ten days after the Solana transition, before 23:59:59 UTC on April 28.
 
-This is because the subDAO delegation of veHNT is a 0 or 100% all-or-nothing action.
+This is because the Subnetwork delegation of veHNT is a 0 or 100% all-or-nothing action.
 
-- Splitting veHNT across multiple subDAOs requires multiple positions.
+- Splitting veHNT across multiple Subnetworks requires multiple positions.
 - Splitting veHNT over different lock-up periods requires multiple positions.
 - Splitting veHNT with some in constant lock-up and some in cooldown requires multiple positions.
 
@@ -235,8 +235,8 @@ created in the Landrush period.
 Splitting as an action transfers some of the veHNT from one position to another new or existing
 position.
 
-veHNT owners may want to frequently vary their split of subDAO delegations and lock-up periods to
-suit their situations and the variance of the HNT per subDAO emitted based on the DAO Utility
+veHNT owners may want to frequently vary their split of Subnetwork delegations and lock-up periods to
+suit their situations and the variance of the HNT per Subnetwork emitted based on the DAO Utility
 Scores.
 
 ### Can I Increase My Staking Lock-up Period At Any Time?

--- a/docs/architecture/solana/primer.mdx
+++ b/docs/architecture/solana/primer.mdx
@@ -31,7 +31,7 @@ for this account, we can see that this is a `DaoV0` on the devnet `helium-sub-da
 
 ![Dao in Explorer](/img/solana/dao-in-explorer.png)
 
-Scrolling up we can see that it is, in fact, owned by the Helium Subnetwork's program:
+Scrolling up we can see that it is, in fact, owned by the Helium subnetwork's program:
 
 ![Program Owner](/img/solana/program-owner.png)
 
@@ -81,9 +81,9 @@ const daoAddr = daoKey(new PublicKey("...hnt mint..."))[0];
 :::note Helium PDAs and Mints
 
 You'll notice that if you trace the graph of Helium PDAs, they always lead back to the address of
-either the HNT token mint, or the Subnetwork token mint.
+either the HNT token mint, or the subnetwork token mint.
 
-This design is intentional. Rather than making DAOs, Subnetworks, etc global, we opted to make them
+This design is intentional. Rather than making DAOs, subnetworks, etc global, we opted to make them
 dependent on the specific mints being used. This allows us to set up testing scenarios in which we
 use a testing token alongside the real tokens. This design also allows for easier reuse of our
 contracts throughout the Solana community.

--- a/docs/architecture/solana/primer.mdx
+++ b/docs/architecture/solana/primer.mdx
@@ -31,7 +31,7 @@ for this account, we can see that this is a `DaoV0` on the devnet `helium-sub-da
 
 ![Dao in Explorer](/img/solana/dao-in-explorer.png)
 
-Scrolling up we can see that it is, in fact, owned by the Helium subDAO's program:
+Scrolling up we can see that it is, in fact, owned by the Helium Subnetwork's program:
 
 ![Program Owner](/img/solana/program-owner.png)
 
@@ -81,9 +81,9 @@ const daoAddr = daoKey(new PublicKey("...hnt mint..."))[0];
 :::note Helium PDAs and Mints
 
 You'll notice that if you trace the graph of Helium PDAs, they always lead back to the address of
-either the HNT token mint, or the subDAO token mint.
+either the HNT token mint, or the Subnetwork token mint.
 
-This design is intentional. Rather than making DAOs, subDAOs, etc global, we opted to make them
+This design is intentional. Rather than making DAOs, Subnetworks, etc global, we opted to make them
 dependent on the specific mints being used. This allows us to set up testing scenarios in which we
 use a testing token alongside the real tokens. This design also allows for easier reuse of our
 contracts throughout the Solana community.

--- a/docs/architecture/solana/rewardable-entities.mdx
+++ b/docs/architecture/solana/rewardable-entities.mdx
@@ -181,7 +181,7 @@ Hotspot, or both. If the Hotspot wants to earn both MOBILE and IOT rewards, it m
 IOT network AND the MOBILE network. It must also assert location on both subnetworks.
 
 Similarly, makers are approved for specific subnetworks. A maker that creates IOT Hotspots cannot
-necessarily onboard MOBILE Hotspots. Each network Subnetwork must approve makers to issue rewardable
+necessarily onboard MOBILE Hotspots. Each network subnetwork must approve makers to issue rewardable
 entities.
 
 The following test shows the full flow of onboarding a Hotspot using the onboarding server.

--- a/docs/architecture/solana/rewardable-entities.mdx
+++ b/docs/architecture/solana/rewardable-entities.mdx
@@ -181,7 +181,7 @@ Hotspot, or both. If the Hotspot wants to earn both MOBILE and IOT rewards, it m
 IOT network AND the MOBILE network. It must also assert location on both subnetworks.
 
 Similarly, makers are approved for specific subnetworks. A maker that creates IOT Hotspots cannot
-necessarily onboard MOBILE Hotspots. Each network subDAO must approve makers to issue rewardable
+necessarily onboard MOBILE Hotspots. Each network Subnetwork must approve makers to issue rewardable
 entities.
 
 The following test shows the full flow of onboarding a Hotspot using the onboarding server.

--- a/docs/archive/blockchain/mining.mdx
+++ b/docs/archive/blockchain/mining.mdx
@@ -24,8 +24,8 @@ reward basics.
 
 The Helium Network rewards Hotspots for providing wireless coverage and verifying the Helium
 Network. Helium has migrated to Solana. All LoRaWAN
-Hotspots now mine IOT, while HNT is emitted into the Subnetwork Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the amount of existing IOT tokens and the amount of HNT in the 
-Subnetwork Treasury at the time.
+Hotspots now mine IOT, while HNT is emitted into the subnetwork Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the amount of existing IOT tokens and the amount of HNT in the 
+subnetwork Treasury at the time.
 
 Every epoch, the current consensus group mines approximately 30 blocks on the blockchain. In each
 block, Hotspots perform various types of work and are awarded according to the following

--- a/docs/archive/blockchain/mining.mdx
+++ b/docs/archive/blockchain/mining.mdx
@@ -23,9 +23,10 @@ reward basics.
 ## How Do Hotspots Earn Helium Tokens?
 
 The Helium Network rewards Hotspots for providing wireless coverage and verifying the Helium
-Network. Helium has migrated to Solana. All LoRaWAN
-Hotspots now mine IOT, while HNT is emitted into the subnetwork Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the amount of existing IOT tokens and the amount of HNT in the 
-subnetwork Treasury at the time.
+Network. Helium has migrated to Solana. All LoRaWAN Hotspots now mine IOT, while HNT is emitted into
+the subnetwork Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is
+calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the
+amount of existing IOT tokens and the amount of HNT in the subnetwork Treasury at the time.
 
 Every epoch, the current consensus group mines approximately 30 blocks on the blockchain. In each
 block, Hotspots perform various types of work and are awarded according to the following

--- a/docs/archive/blockchain/mining.mdx
+++ b/docs/archive/blockchain/mining.mdx
@@ -24,8 +24,8 @@ reward basics.
 
 The Helium Network rewards Hotspots for providing wireless coverage and verifying the Helium
 Network. Helium has migrated to Solana. All LoRaWAN
-Hotspots now mine IOT, while HNT is emitted into the subDAO Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the amount of existing IOT tokens and the amount of HNT in the 
-subDAO Treasury at the time.
+Hotspots now mine IOT, while HNT is emitted into the Subnetwork Treasury. IOT Holders can redeem their IOT for HNT. The redemption ratio is calculated every day anew (in technical terms: at the end of each "epoch") as the ratio between the amount of existing IOT tokens and the amount of HNT in the 
+Subnetwork Treasury at the time.
 
 Every epoch, the current consensus group mines approximately 30 blocks on the blockchain. In each
 block, Hotspots perform various types of work and are awarded according to the following

--- a/docs/governance/governance-faq.mdx
+++ b/docs/governance/governance-faq.mdx
@@ -22,16 +22,16 @@ period in exchange for voting rights and voting power in the HeliumDAO as define
 [HIP-51](https://github.com/helium/HIP/issues/336).
 
 Additionally, this provides other benefits, such as earning MOBILE or IOT tokens, if the holder
-delegates their veHNT to those Subnetworks, respectively. After the lock-up period ends, the same amount
+delegates their veHNT to those subnetworks, respectively. After the lock-up period ends, the same amount
 of HNT is released back to the owner's wallet and is now transferable, if needed.
 
-## What Are The Benefits of Staking HNT after the Subnetworks launch?
+## What Are The Benefits of Staking HNT after the subnetworks launch?
 
 Now the Solana migration has been completed, stakers can use their staked veHNT to vote on proposals
 in the HeliumDAO and help the DAO make collective decisions, influencing the future of the Network.
 
-Stakers will additionally be able to delegate veHNT to a Subnetwork for token rewards. Delegating veHNT
-to a Subnetwork will count towards the DAO Utility Score, the `V` value referenced in
+Stakers will additionally be able to delegate veHNT to a subnetwork for token rewards. Delegating veHNT
+to a subnetwork will count towards the DAO Utility Score, the `V` value referenced in
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model).
 
 ## Where Does My HNT Go if I Stake veHNT?
@@ -54,30 +54,30 @@ with shorter-term interests in the governance of the Network.
 
 ## What is Voting Power?
 
-Voting power is the weight of your vote towards decisions made by the DAO or Subnetwork. The more veHNT
+Voting power is the weight of your vote towards decisions made by the DAO or subnetwork. The more veHNT
 you have, the more weight your vote has.
 
 You can only increase your voting power by staking more HNT or extending an existing veHNT lock-up
 period for longer.
 
-## How to Choose a Subnetwork to Stake?
+## How to Choose a subnetwork to Stake?
 
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
-defines that all Subnetworks return a maximum of 6% of their earnings to their veHNT delegators and is
-designed to be an equal maximum reward level across all Subnetworks so that no Subnetwork can buy their way
+defines that all subnetworks return a maximum of 6% of their earnings to their veHNT delegators and is
+designed to be an equal maximum reward level across all subnetworks so that no subnetwork can buy their way
 to a higher DAO Utility score.
 
-Returns can be lower than 6% in Subnetwork tokens if the Subnetwork votes to provide a lower token return in
+Returns can be lower than 6% in subnetwork tokens if the subnetwork votes to provide a lower token return in
 return for other benefits or similar.
 
-As more veHNT is delegated to a Subnetwork, the DAO Utility Score improves, among other factors defined
-in HIP-51, which drives greater earnings of HNT for the Subnetwork.
+As more veHNT is delegated to a subnetwork, the DAO Utility Score improves, among other factors defined
+in HIP-51, which drives greater earnings of HNT for the subnetwork.
 
-As more veHNT holders delegate to a particular Subnetwork, individual holder earnings will reduce the
-amount of net Subnetwork token earnings as delegators share the 6% Subnetwork token emissions.
+As more veHNT holders delegate to a particular subnetwork, individual holder earnings will reduce the
+amount of net subnetwork token earnings as delegators share the 6% subnetwork token emissions.
 
-The more veHNT delegated to a Subnetwork the more the Subnetwork Utility score increases and the more HNT
-the Subnetwork gets at each epoch improving the HNT/Subnetwork Token ratio. But the more veHNT delegated,
+The more veHNT delegated to a subnetwork the more the subnetwork Utility score increases and the more HNT
+the subnetwork gets at each epoch improving the HNT/subnetwork Token ratio. But the more veHNT delegated,
 the more veHNT holders the 6% will have to be shared between.
 
 ## How Will Staking Work By Using veHNT?
@@ -87,14 +87,14 @@ your unstaking date at the time of lock-up or decide to keep it on a rolling loc
 "constant lock-up" before initiating the start or the veHNT decay process. The HNT staked is
 exchanged for veHNT, which provides two benefits:
 
-- Voting in the Helium DAO on new Subnetwork proposals and Participating in the Governance.
-- Receiving an income if the veHNT is delegated to a Subnetwork.
+- Voting in the Helium DAO on new subnetwork proposals and Participating in the Governance.
+- Receiving an income if the veHNT is delegated to a subnetwork.
 
-Anyone can delegate veHNT to a Subnetwork, it's one component of a Subnetwork's Utility Score. Delegating
-veHNT to a Subnetwork allows the holder to earn Subnetwork token rewards proportionally based on the Subnetworks
+Anyone can delegate veHNT to a subnetwork, it's one component of a subnetwork's Utility Score. Delegating
+veHNT to a subnetwork allows the holder to earn subnetwork token rewards proportionally based on the subnetworks
 rules.
 
-> For example: If I delegate some veHNT to MOBILE Subnetwork, I proportionally earn MOBILE rewards
+> For example: If I delegate some veHNT to MOBILE subnetwork, I proportionally earn MOBILE rewards
 > allocated to veHNT stakers.
 
 The Helium Network encourages your long-term participation in voting and governance. Those who stake
@@ -109,9 +109,9 @@ from 0.0684462 to 100.
 A combination of an amount of HNT locked up for a specified duration and the assigned veHNT is
 called a "Position". It is possible to own multiple Positions in your wallet. Actions taken on a
 Position - like e.g. on the lock-up duration, delegating the veHNT, voting with the veHNT - are all
-or nothing options. If a Position owner would like to receive rewards from two Subnetworks, then the
+or nothing options. If a Position owner would like to receive rewards from two subnetworks, then the
 HNT-veHNT Position would need to be split into two Positions - by transferring some HNT to a second
-position within the same wallet. Then each position could delegate to a different Subnetwork. Similarly,
+position within the same wallet. Then each position could delegate to a different subnetwork. Similarly,
 wishing to extend the lock-up duration on parts of a Position requires a similar split by transfer.
 
 ## How Can I Obtain veHNT?
@@ -143,12 +143,12 @@ For example:
 **No.** HNT staked to veHNT will not earn more HNT, it will only return what they staked at the end
 of their selected lock-up period.
 
-However, when you stake HNT into veHNT, you can delegate your veHNT into one or more Subnetworks (such
-as IOT or MOBILE), and the Subnetworks allocate up to 6% of their token emissions to the veHNT owners
-delegating to that Subnetwork.
+However, when you stake HNT into veHNT, you can delegate your veHNT into one or more subnetworks (such
+as IOT or MOBILE), and the subnetworks allocate up to 6% of their token emissions to the veHNT owners
+delegating to that subnetwork.
 
-> For example: When you delegate your veHNT to the IOT Subnetwork, you receive IOT every epoch that is
-> claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT Subnetwork
+> For example: When you delegate your veHNT to the IOT subnetwork, you receive IOT every epoch that is
+> claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT subnetwork
 > treasury for HNT, or you may hold your IOT tokens, or stake them into veIOT.
 
 ## How much veHNT will I get for each lock-up period?
@@ -175,9 +175,9 @@ migration.
 |      10       |      20.8      |     |      45       |      93.7      |
 |      11       |      22.9      |     |      48       |     100.0      |
 
-## Do I Have to Delegate My veHNT to a Subnetwork?
+## Do I Have to Delegate My veHNT to a subnetwork?
 
-No. You can hold your veHNT as is or delegate to a Subnetwork at any time.
+No. You can hold your veHNT as is or delegate to a subnetwork at any time.
 
 :::note
 
@@ -195,7 +195,7 @@ The veHNT decay countdown starts when initiated from the Wallet app/Realms, eith
 veHNT quantity decay is granulated per second even though the Epoch period is 24 hours.
 
 It is the current delegated veHNT value at the start of an Epoch that is used for calculating the
-Subnetwork utility score during the Epoch.
+subnetwork utility score during the Epoch.
 
 A 48-month lock-in period has approximately 1461 linear steps between 100 veHNT and 0 veHNT.
 
@@ -243,12 +243,12 @@ veHNT and veDNTs have no price in the larger crypto markets.
 
 The DAO Utility score is described in [HIP-51](https://github.com/helium/HIP/issues/336)
 
-Every epoch, a fixed amount of HNT is allocated to all Subnetworks. Each Subnetwork receives a share of this
-fixed amount. The sizes of the shares are determined by the Utility Scores of each Subnetwork of Helium.
+Every epoch, a fixed amount of HNT is allocated to all subnetworks. Each subnetwork receives a share of this
+fixed amount. The sizes of the shares are determined by the Utility Scores of each subnetwork of Helium.
 
-The higher the Utility Score of a Subnetwork is in relation to the Utility Scores of all other Subnetworks
-combined, the higher its share of the total HNT allocated to all Subnetworks. As the DAO Utility Scores
-are calculated each epoch anew, the share of HNT a Subnetwork receives may change from epoch to epoch.
+The higher the Utility Score of a subnetwork is in relation to the Utility Scores of all other subnetworks
+combined, the higher its share of the total HNT allocated to all subnetworks. As the DAO Utility Scores
+are calculated each epoch anew, the share of HNT a subnetwork receives may change from epoch to epoch.
 
 Delegating veHNT to IOT or MOBILE increases the `V` value in the
 [HIP-51 DAO Utility Score](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
@@ -256,26 +256,26 @@ calculation.
 
 The two other ways the DAO Utility score can be increased are:
 
-1. Increasing the amount of data usage on the Subnetwork, i.e., the Data Credits burned. This increases
+1. Increasing the amount of data usage on the subnetwork, i.e., the Data Credits burned. This increases
    the `D` value in the Utility Score.
-2. Increasing the Data Credits used to onboard the number of Hotspots for that Subnetwork. This
+2. Increasing the Data Credits used to onboard the number of Hotspots for that subnetwork. This
    increases the `A` value in the Utility Score.
 
-## Will My Subnetwork Earnings Remain The Same Over The Time Period Lock-Up?
+## Will My subnetwork Earnings Remain The Same Over The Time Period Lock-Up?
 
 No, they are calculated and paid to the lock-up position per epoch - daily. They may increase when:
 
-- More veHNT is delegated in the Subnetwork you delegated to - your treasury gets more HNT.
-- More Hotspot onboarding fees are burned in the Subnetwork you delegated to.
-- More data is transferred and burned in the Subnetwork you delegated to.
+- More veHNT is delegated in the subnetwork you delegated to - your treasury gets more HNT.
+- More Hotspot onboarding fees are burned in the subnetwork you delegated to.
+- More data is transferred and burned in the subnetwork you delegated to.
 
 They may decrease when:
 
-- More veHNT is delegated in the Subnetwork you delegated to - your share is reduced
-- More veHNT is delegated to other Subnetworks - other treasuries get more HNT.
+- More veHNT is delegated in the subnetwork you delegated to - your share is reduced
+- More veHNT is delegated to other subnetworks - other treasuries get more HNT.
 - Your delegated veHNT decays over time after you entered the cooldown.
-- More Hotspots are online in other Subnetworks with a non-zero onboarding fee.
-- More data is transferred and burned in other Subnetworks.
+- More Hotspots are online in other subnetworks with a non-zero onboarding fee.
+- More data is transferred and burned in other subnetworks.
 
-Thus it can be observed that delegating more or all of your veHNT to a specific Subnetwork has the
-opportunity to both increase or decrease your Subnetwork earnings from delegation.
+Thus it can be observed that delegating more or all of your veHNT to a specific subnetwork has the
+opportunity to both increase or decrease your subnetwork earnings from delegation.

--- a/docs/governance/governance-faq.mdx
+++ b/docs/governance/governance-faq.mdx
@@ -264,7 +264,7 @@ The two other ways the DAO Utility score can be increased are:
 2. Increasing the Data Credits used to onboard the number of Hotspots for that subnetwork. This
    increases the `A` value in the Utility Score.
 
-## Will My subnetwork Earnings Remain The Same Over The Time Period Lock-Up?
+## Will My Subnetwork Earnings Remain The Same Over The Time Period Lock-Up?
 
 No, they are calculated and paid to the lock-up position per epoch - daily. They may increase when:
 

--- a/docs/governance/governance-faq.mdx
+++ b/docs/governance/governance-faq.mdx
@@ -22,16 +22,16 @@ period in exchange for voting rights and voting power in the HeliumDAO as define
 [HIP-51](https://github.com/helium/HIP/issues/336).
 
 Additionally, this provides other benefits, such as earning MOBILE or IOT tokens, if the holder
-delegates their veHNT to those subnetworks, respectively. After the lock-up period ends, the same amount
-of HNT is released back to the owner's wallet and is now transferable, if needed.
+delegates their veHNT to those subnetworks, respectively. After the lock-up period ends, the same
+amount of HNT is released back to the owner's wallet and is now transferable, if needed.
 
 ## What Are The Benefits of Staking HNT after the subnetworks launch?
 
 Now the Solana migration has been completed, stakers can use their staked veHNT to vote on proposals
 in the HeliumDAO and help the DAO make collective decisions, influencing the future of the Network.
 
-Stakers will additionally be able to delegate veHNT to a subnetwork for token rewards. Delegating veHNT
-to a subnetwork will count towards the DAO Utility Score, the `V` value referenced in
+Stakers will additionally be able to delegate veHNT to a subnetwork for token rewards. Delegating
+veHNT to a subnetwork will count towards the DAO Utility Score, the `V` value referenced in
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model).
 
 ## Where Does My HNT Go if I Stake veHNT?
@@ -54,8 +54,8 @@ with shorter-term interests in the governance of the Network.
 
 ## What is Voting Power?
 
-Voting power is the weight of your vote towards decisions made by the DAO or subnetwork. The more veHNT
-you have, the more weight your vote has.
+Voting power is the weight of your vote towards decisions made by the DAO or subnetwork. The more
+veHNT you have, the more weight your vote has.
 
 You can only increase your voting power by staking more HNT or extending an existing veHNT lock-up
 period for longer.
@@ -63,22 +63,22 @@ period for longer.
 ## How to Choose a subnetwork to Stake?
 
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
-defines that all subnetworks return a maximum of 6% of their earnings to their veHNT delegators and is
-designed to be an equal maximum reward level across all subnetworks so that no subnetwork can buy their way
-to a higher DAO Utility score.
+defines that all subnetworks return a maximum of 6% of their earnings to their veHNT delegators and
+is designed to be an equal maximum reward level across all subnetworks so that no subnetwork can buy
+their way to a higher DAO Utility score.
 
-Returns can be lower than 6% in subnetwork tokens if the subnetwork votes to provide a lower token return in
-return for other benefits or similar.
+Returns can be lower than 6% in subnetwork tokens if the subnetwork votes to provide a lower token
+return in return for other benefits or similar.
 
-As more veHNT is delegated to a subnetwork, the DAO Utility Score improves, among other factors defined
-in HIP-51, which drives greater earnings of HNT for the subnetwork.
+As more veHNT is delegated to a subnetwork, the DAO Utility Score improves, among other factors
+defined in HIP-51, which drives greater earnings of HNT for the subnetwork.
 
-As more veHNT holders delegate to a particular subnetwork, individual holder earnings will reduce the
-amount of net subnetwork token earnings as delegators share the 6% subnetwork token emissions.
+As more veHNT holders delegate to a particular subnetwork, individual holder earnings will reduce
+the amount of net subnetwork token earnings as delegators share the 6% subnetwork token emissions.
 
-The more veHNT delegated to a subnetwork the more the subnetwork Utility score increases and the more HNT
-the subnetwork gets at each epoch improving the HNT/subnetwork Token ratio. But the more veHNT delegated,
-the more veHNT holders the 6% will have to be shared between.
+The more veHNT delegated to a subnetwork the more the subnetwork Utility score increases and the
+more HNT the subnetwork gets at each epoch improving the HNT/subnetwork Token ratio. But the more
+veHNT delegated, the more veHNT holders the 6% will have to be shared between.
 
 ## How Will Staking Work By Using veHNT?
 
@@ -90,9 +90,9 @@ exchanged for veHNT, which provides two benefits:
 - Voting in the Helium DAO on new subnetwork proposals and Participating in the Governance.
 - Receiving an income if the veHNT is delegated to a subnetwork.
 
-Anyone can delegate veHNT to a subnetwork, it's one component of a subnetwork's Utility Score. Delegating
-veHNT to a subnetwork allows the holder to earn subnetwork token rewards proportionally based on the subnetworks
-rules.
+Anyone can delegate veHNT to a subnetwork, it's one component of a subnetwork's Utility Score.
+Delegating veHNT to a subnetwork allows the holder to earn subnetwork token rewards proportionally
+based on the subnetworks rules.
 
 > For example: If I delegate some veHNT to MOBILE subnetwork, I proportionally earn MOBILE rewards
 > allocated to veHNT stakers.
@@ -111,8 +111,9 @@ called a "Position". It is possible to own multiple Positions in your wallet. Ac
 Position - like e.g. on the lock-up duration, delegating the veHNT, voting with the veHNT - are all
 or nothing options. If a Position owner would like to receive rewards from two subnetworks, then the
 HNT-veHNT Position would need to be split into two Positions - by transferring some HNT to a second
-position within the same wallet. Then each position could delegate to a different subnetwork. Similarly,
-wishing to extend the lock-up duration on parts of a Position requires a similar split by transfer.
+position within the same wallet. Then each position could delegate to a different subnetwork.
+Similarly, wishing to extend the lock-up duration on parts of a Position requires a similar split by
+transfer.
 
 ## How Can I Obtain veHNT?
 
@@ -143,13 +144,13 @@ For example:
 **No.** HNT staked to veHNT will not earn more HNT, it will only return what they staked at the end
 of their selected lock-up period.
 
-However, when you stake HNT into veHNT, you can delegate your veHNT into one or more subnetworks (such
-as IOT or MOBILE), and the subnetworks allocate up to 6% of their token emissions to the veHNT owners
-delegating to that subnetwork.
+However, when you stake HNT into veHNT, you can delegate your veHNT into one or more subnetworks
+(such as IOT or MOBILE), and the subnetworks allocate up to 6% of their token emissions to the veHNT
+owners delegating to that subnetwork.
 
-> For example: When you delegate your veHNT to the IOT subnetwork, you receive IOT every epoch that is
-> claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT subnetwork
-> treasury for HNT, or you may hold your IOT tokens, or stake them into veIOT.
+> For example: When you delegate your veHNT to the IOT subnetwork, you receive IOT every epoch that
+> is claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT
+> subnetwork treasury for HNT, or you may hold your IOT tokens, or stake them into veIOT.
 
 ## How much veHNT will I get for each lock-up period?
 
@@ -243,12 +244,14 @@ veHNT and veDNTs have no price in the larger crypto markets.
 
 The DAO Utility score is described in [HIP-51](https://github.com/helium/HIP/issues/336)
 
-Every epoch, a fixed amount of HNT is allocated to all subnetworks. Each subnetwork receives a share of this
-fixed amount. The sizes of the shares are determined by the Utility Scores of each subnetwork of Helium.
+Every epoch, a fixed amount of HNT is allocated to all subnetworks. Each subnetwork receives a share
+of this fixed amount. The sizes of the shares are determined by the Utility Scores of each
+subnetwork of Helium.
 
-The higher the Utility Score of a subnetwork is in relation to the Utility Scores of all other subnetworks
-combined, the higher its share of the total HNT allocated to all subnetworks. As the DAO Utility Scores
-are calculated each epoch anew, the share of HNT a subnetwork receives may change from epoch to epoch.
+The higher the Utility Score of a subnetwork is in relation to the Utility Scores of all other
+subnetworks combined, the higher its share of the total HNT allocated to all subnetworks. As the DAO
+Utility Scores are calculated each epoch anew, the share of HNT a subnetwork receives may change
+from epoch to epoch.
 
 Delegating veHNT to IOT or MOBILE increases the `V` value in the
 [HIP-51 DAO Utility Score](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
@@ -256,8 +259,8 @@ calculation.
 
 The two other ways the DAO Utility score can be increased are:
 
-1. Increasing the amount of data usage on the subnetwork, i.e., the Data Credits burned. This increases
-   the `D` value in the Utility Score.
+1. Increasing the amount of data usage on the subnetwork, i.e., the Data Credits burned. This
+   increases the `D` value in the Utility Score.
 2. Increasing the Data Credits used to onboard the number of Hotspots for that subnetwork. This
    increases the `A` value in the Utility Score.
 

--- a/docs/governance/governance-faq.mdx
+++ b/docs/governance/governance-faq.mdx
@@ -22,16 +22,16 @@ period in exchange for voting rights and voting power in the HeliumDAO as define
 [HIP-51](https://github.com/helium/HIP/issues/336).
 
 Additionally, this provides other benefits, such as earning MOBILE or IOT tokens, if the holder
-delegates their veHNT to those subDAOs, respectively. After the lock-up period ends, the same amount
+delegates their veHNT to those Subnetworks, respectively. After the lock-up period ends, the same amount
 of HNT is released back to the owner's wallet and is now transferable, if needed.
 
-## What Are The Benefits of Staking HNT after the subDAOs launch?
+## What Are The Benefits of Staking HNT after the Subnetworks launch?
 
 Now the Solana migration has been completed, stakers can use their staked veHNT to vote on proposals
 in the HeliumDAO and help the DAO make collective decisions, influencing the future of the Network.
 
-Stakers will additionally be able to delegate veHNT to a subDAO for token rewards. Delegating veHNT
-to a subDAO will count towards the DAO Utility Score, the `V` value referenced in
+Stakers will additionally be able to delegate veHNT to a Subnetwork for token rewards. Delegating veHNT
+to a Subnetwork will count towards the DAO Utility Score, the `V` value referenced in
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model).
 
 ## Where Does My HNT Go if I Stake veHNT?
@@ -54,30 +54,30 @@ with shorter-term interests in the governance of the Network.
 
 ## What is Voting Power?
 
-Voting power is the weight of your vote towards decisions made by the DAO or subDAO. The more veHNT
+Voting power is the weight of your vote towards decisions made by the DAO or Subnetwork. The more veHNT
 you have, the more weight your vote has.
 
 You can only increase your voting power by staking more HNT or extending an existing veHNT lock-up
 period for longer.
 
-## How to Choose a subDAO to Stake?
+## How to Choose a Subnetwork to Stake?
 
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
-defines that all subDAOs return a maximum of 6% of their earnings to their veHNT delegators and is
-designed to be an equal maximum reward level across all subDAOs so that no subDAO can buy their way
+defines that all Subnetworks return a maximum of 6% of their earnings to their veHNT delegators and is
+designed to be an equal maximum reward level across all Subnetworks so that no Subnetwork can buy their way
 to a higher DAO Utility score.
 
-Returns can be lower than 6% in subDAO tokens if the subDAO votes to provide a lower token return in
+Returns can be lower than 6% in Subnetwork tokens if the Subnetwork votes to provide a lower token return in
 return for other benefits or similar.
 
-As more veHNT is delegated to a subDAO, the DAO Utility Score improves, among other factors defined
-in HIP-51, which drives greater earnings of HNT for the subDAO.
+As more veHNT is delegated to a Subnetwork, the DAO Utility Score improves, among other factors defined
+in HIP-51, which drives greater earnings of HNT for the Subnetwork.
 
-As more veHNT holders delegate to a particular subDAO, individual holder earnings will reduce the
-amount of net subDAO token earnings as delegators share the 6% subDAO token emissions.
+As more veHNT holders delegate to a particular Subnetwork, individual holder earnings will reduce the
+amount of net Subnetwork token earnings as delegators share the 6% Subnetwork token emissions.
 
-The more veHNT delegated to a subDAO the more the subDAO Utility score increases and the more HNT
-the subDAO gets at each epoch improving the HNT/subDAO Token ratio. But the more veHNT delegated,
+The more veHNT delegated to a Subnetwork the more the Subnetwork Utility score increases and the more HNT
+the Subnetwork gets at each epoch improving the HNT/Subnetwork Token ratio. But the more veHNT delegated,
 the more veHNT holders the 6% will have to be shared between.
 
 ## How Will Staking Work By Using veHNT?
@@ -87,14 +87,14 @@ your unstaking date at the time of lock-up or decide to keep it on a rolling loc
 "constant lock-up" before initiating the start or the veHNT decay process. The HNT staked is
 exchanged for veHNT, which provides two benefits:
 
-- Voting in the Helium DAO on new subDAO proposals and Participating in the Governance.
-- Receiving an income if the veHNT is delegated to a subDAO.
+- Voting in the Helium DAO on new Subnetwork proposals and Participating in the Governance.
+- Receiving an income if the veHNT is delegated to a Subnetwork.
 
-Anyone can delegate veHNT to a subDAO, it's one component of a subDAO's Utility Score. Delegating
-veHNT to a subDAO allows the holder to earn subDAO token rewards proportionally based on the subDAOs
+Anyone can delegate veHNT to a Subnetwork, it's one component of a Subnetwork's Utility Score. Delegating
+veHNT to a Subnetwork allows the holder to earn Subnetwork token rewards proportionally based on the Subnetworks
 rules.
 
-> For example: If I delegate some veHNT to MOBILE subDAO, I proportionally earn MOBILE rewards
+> For example: If I delegate some veHNT to MOBILE Subnetwork, I proportionally earn MOBILE rewards
 > allocated to veHNT stakers.
 
 The Helium Network encourages your long-term participation in voting and governance. Those who stake
@@ -109,9 +109,9 @@ from 0.0684462 to 100.
 A combination of an amount of HNT locked up for a specified duration and the assigned veHNT is
 called a "Position". It is possible to own multiple Positions in your wallet. Actions taken on a
 Position - like e.g. on the lock-up duration, delegating the veHNT, voting with the veHNT - are all
-or nothing options. If a Position owner would like to receive rewards from two SubDAOs, then the
+or nothing options. If a Position owner would like to receive rewards from two Subnetworks, then the
 HNT-veHNT Position would need to be split into two Positions - by transferring some HNT to a second
-position within the same wallet. Then each position could delegate to a different subDAO. Similarly,
+position within the same wallet. Then each position could delegate to a different Subnetwork. Similarly,
 wishing to extend the lock-up duration on parts of a Position requires a similar split by transfer.
 
 ## How Can I Obtain veHNT?
@@ -143,12 +143,12 @@ For example:
 **No.** HNT staked to veHNT will not earn more HNT, it will only return what they staked at the end
 of their selected lock-up period.
 
-However, when you stake HNT into veHNT, you can delegate your veHNT into one or more subDAOs (such
-as IOT or MOBILE), and the subDAOs allocate up to 6% of their token emissions to the veHNT owners
-delegating to that subDAO.
+However, when you stake HNT into veHNT, you can delegate your veHNT into one or more Subnetworks (such
+as IOT or MOBILE), and the Subnetworks allocate up to 6% of their token emissions to the veHNT owners
+delegating to that Subnetwork.
 
-> For example: When you delegate your veHNT to the IOT subDAO, you receive IOT every epoch that is
-> claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT subDAO
+> For example: When you delegate your veHNT to the IOT Subnetwork, you receive IOT every epoch that is
+> claimable in your Helium Wallet. If you choose, this IOT can then be burned at the IOT Subnetwork
 > treasury for HNT, or you may hold your IOT tokens, or stake them into veIOT.
 
 ## How much veHNT will I get for each lock-up period?
@@ -175,9 +175,9 @@ migration.
 |      10       |      20.8      |     |      45       |      93.7      |
 |      11       |      22.9      |     |      48       |     100.0      |
 
-## Do I Have to Delegate My veHNT to a subDAO?
+## Do I Have to Delegate My veHNT to a Subnetwork?
 
-No. You can hold your veHNT as is or delegate to a subDAO at any time.
+No. You can hold your veHNT as is or delegate to a Subnetwork at any time.
 
 :::note
 
@@ -195,7 +195,7 @@ The veHNT decay countdown starts when initiated from the Wallet app/Realms, eith
 veHNT quantity decay is granulated per second even though the Epoch period is 24 hours.
 
 It is the current delegated veHNT value at the start of an Epoch that is used for calculating the
-subDAO utility score during the Epoch.
+Subnetwork utility score during the Epoch.
 
 A 48-month lock-in period has approximately 1461 linear steps between 100 veHNT and 0 veHNT.
 
@@ -243,12 +243,12 @@ veHNT and veDNTs have no price in the larger crypto markets.
 
 The DAO Utility score is described in [HIP-51](https://github.com/helium/HIP/issues/336)
 
-Every epoch, a fixed amount of HNT is allocated to all subDAOs. Each subDAO receives a share of this
-fixed amount. The sizes of the shares are determined by the Utility Scores of each subDAO of Helium.
+Every epoch, a fixed amount of HNT is allocated to all Subnetworks. Each Subnetwork receives a share of this
+fixed amount. The sizes of the shares are determined by the Utility Scores of each Subnetwork of Helium.
 
-The higher the Utility Score of a subDAO is in relation to the Utility Scores of all other subDAOs
-combined, the higher its share of the total HNT allocated to all subDAOs. As the DAO Utility Scores
-are calculated each epoch anew, the share of HNT a subDAO receives may change from epoch to epoch.
+The higher the Utility Score of a Subnetwork is in relation to the Utility Scores of all other Subnetworks
+combined, the higher its share of the total HNT allocated to all Subnetworks. As the DAO Utility Scores
+are calculated each epoch anew, the share of HNT a Subnetwork receives may change from epoch to epoch.
 
 Delegating veHNT to IOT or MOBILE increases the `V` value in the
 [HIP-51 DAO Utility Score](https://github.com/helium/HIP/blob/main/0051-helium-dao.md#omni-protocol-poc-incentive-model)
@@ -256,26 +256,26 @@ calculation.
 
 The two other ways the DAO Utility score can be increased are:
 
-1. Increasing the amount of data usage on the subDAO, i.e., the Data Credits burned. This increases
+1. Increasing the amount of data usage on the Subnetwork, i.e., the Data Credits burned. This increases
    the `D` value in the Utility Score.
-2. Increasing the Data Credits used to onboard the number of Hotspots for that subDAO. This
+2. Increasing the Data Credits used to onboard the number of Hotspots for that Subnetwork. This
    increases the `A` value in the Utility Score.
 
-## Will My subDAO Earnings Remain The Same Over The Time Period Lock-Up?
+## Will My Subnetwork Earnings Remain The Same Over The Time Period Lock-Up?
 
 No, they are calculated and paid to the lock-up position per epoch - daily. They may increase when:
 
-- More veHNT is delegated in the subDAO you delegated to - your treasury gets more HNT.
-- More Hotspot onboarding fees are burned in the subDAO you delegated to.
-- More data is transferred and burned in the subDAO you delegated to.
+- More veHNT is delegated in the Subnetwork you delegated to - your treasury gets more HNT.
+- More Hotspot onboarding fees are burned in the Subnetwork you delegated to.
+- More data is transferred and burned in the Subnetwork you delegated to.
 
 They may decrease when:
 
-- More veHNT is delegated in the subDAO you delegated to - your share is reduced
-- More veHNT is delegated to other subDAOs - other treasuries get more HNT.
+- More veHNT is delegated in the Subnetwork you delegated to - your share is reduced
+- More veHNT is delegated to other Subnetworks - other treasuries get more HNT.
 - Your delegated veHNT decays over time after you entered the cooldown.
-- More Hotspots are online in other subDAOs with a non-zero onboarding fee.
-- More data is transferred and burned in other subDAOs.
+- More Hotspots are online in other Subnetworks with a non-zero onboarding fee.
+- More data is transferred and burned in other Subnetworks.
 
-Thus it can be observed that delegating more or all of your veHNT to a specific subDAO has the
-opportunity to both increase or decrease your subDAO earnings from delegation.
+Thus it can be observed that delegating more or all of your veHNT to a specific Subnetwork has the
+opportunity to both increase or decrease your Subnetwork earnings from delegation.

--- a/docs/governance/hip.mdx
+++ b/docs/governance/hip.mdx
@@ -24,20 +24,20 @@ managed. Anyone in the Helium ecosystem can introduce a HIP. All HIPs are public
 open HIP Repository, managed by the Helium Foundation on behalf of the community.
 
 Users participate in network-wide token holder voting. You must have tokens to vote on Helium
-Improvement Proposals. The Helium Network and subNetworks vote with three tokens: HNT, IOT, and
+Improvement Proposals. The Helium Network and subnetworks vote with three tokens: HNT, IOT, and
 MOBILE. These tokens do not inherently provide governance rights and privileges and must be locked,
 in a method called Staking, to create a user's voting power. Voting power is a multiplication of
 tokens staked and the time duration of staking. Staking aligns a user with the long-term success of
 building a decentralized wireless network.
 
 - Holders of HNT vote on proposals that concern meta governance, economic, or technical changes to
-  the entire protocol. Proposals that exclusively affect a subNetwork do not fall into HNT voting.
+  the entire protocol. Proposals that exclusively affect a subnetwork do not fall into HNT voting.
 
-- Holders of IOT tokens vote on proposals concerning the IoT (LoRaWAN) subNetwork. These proposals
-  include economic, technical, or governance changes to the IoT subNetwork.
+- Holders of IOT tokens vote on proposals concerning the IoT (LoRaWAN) subnetwork. These proposals
+  include economic, technical, or governance changes to the IoT subnetwork.
 
-- Holders of MOBILE tokens vote on proposals concerning the Mobile (5G) subNetwork. These proposals
-  include economic, technical, or governance changes to the Mobile subNetwork.
+- Holders of MOBILE tokens vote on proposals concerning the Mobile (5G) subnetwork. These proposals
+  include economic, technical, or governance changes to the Mobile subnetwork.
 
 ## Proposing a HIP
 
@@ -59,7 +59,7 @@ the fundamental familiarity of the Helium Network.
 During the HIP Editing Process, a HIP Editor defines the scope of the HIP and determines the Voting
 Requirements for the community. Voting Requirements comprise which token should be used to cast a
 vote and which subnetwork this Proposal affects. Token holders are eligible to vote based on the
-subNetwork that the HIP impacts. After HIP Editing, the HIP is merged into the public repository of
+subnetwork that the HIP impacts. After HIP Editing, the HIP is merged into the public repository of
 all documented Helium Improvement Proposals. The Helium Foundation creates the status of the HIP,
 and a new HIP-specific channel in Discord is opened for community discussion.
 

--- a/docs/governance/phase-3.mdx
+++ b/docs/governance/phase-3.mdx
@@ -27,13 +27,13 @@ tokens and casting votes on proposed changes and decisions.
 ### Where can I see what was voted on?
 
 You can view past and current proposals on Realms by navigating to either the Helium Network or
-subNetworks at:
+subnetworks at:
 
 <!-- TODO: three column button for realms links -->
 
 - Helium (HNT): [realms.heliumvote.com/dao/hnt](https://www.realms.heliumvote.com/dao/hnt)
-- IoT subNetwork (IOT): [realms.heliumvote.com/dao/iot](https://www.realms.heliumvote.com/dao/iot)
-- Mobile subNetwork (MOBILE):
+- IoT subnetwork (IOT): [realms.heliumvote.com/dao/iot](https://www.realms.heliumvote.com/dao/iot)
+- Mobile subnetwork (MOBILE):
   [realms.heliumvote.com/dao/mobile](https://www.realms.heliumvote.com/dao/mobile)
 
 You’ll also always find the in progress and final statuses in the Helium HIP Repository at:
@@ -60,7 +60,7 @@ You can view the Helium governance contracts on Solana here:
 
 <!-- TODO: make headings purple -->
 
-#### Contract for delegation of tokens to subNetworks for rewards
+#### Contract for delegation of tokens to subnetworks for rewards
 
 ```
 hdaoVTCqhfHHo75XdAMxBKdUqvq1i5bF23sisBqVgGR
@@ -83,7 +83,7 @@ hvsrNC3NKbcryqDs2DocYHZ9yPKEVzdSjQG6RVtK1s8
 Any token holder is eligible to vote. Token holders may go through different steps to vote depending
 on their level of onboarding and familiarity with the Solana Blockchain.
 
-Users need to have one of the Helium Network or subNetwork Tokens: HNT, IOT, or MOBILE. After this,
+Users need to have one of the Helium Network or subnetwork Tokens: HNT, IOT, or MOBILE. After this,
 they need to be familiar with the Solana Network and have a Solana-compatible wallet. A wallet
 allows users to interact with applications that utilize the Blockchain as a backend for data
 storage. A wallet is straightforward to use and generally is a mobile application or browser plugin
@@ -99,7 +99,7 @@ Once a user is onboarded with a wallet, Helium tokens, and some SOL for transact
 using and interacting with Realms, the Helium Network’s tool for voting. When a user is ready to use
 Realms, they will need to lock or stake their tokens for voting power, creating a vote escrowed
 position with their tokens. This vote escrowed position gives them the ability to cast votes on any
-active proposals for the Helium Network or subNetwork they let you quickly.
+active proposals for the Helium Network or subnetwork they let you quickly.
 
 **A detailed step-by-step description of moving from onboarding to voting is outlined below. All
 steps that may require the signing of a transaction are noted as such:**
@@ -109,7 +109,7 @@ steps that may require the signing of a transaction are noted as such:**
    functions you need.
 2. Acquire tokens by providing coverage for the network or through a liquidity provider in the
    Solana Ecosystem. The tokens you have depend on the network you are providing coverage for or the
-   Network or subNetworks you wish to participate in the governance of (HNT, IOT, or MOBILE).
+   Network or subnetworks you wish to participate in the governance of (HNT, IOT, or MOBILE).
    _Requires signing a transaction_
 3. Acquire SOL to perform transactions on the Solana Blockchain. _Requires signing a transaction_
 4. Navigate to Realms at the addresses above.

--- a/docs/governance/realms.mdx
+++ b/docs/governance/realms.mdx
@@ -23,7 +23,7 @@ is facilitated through the website [Realms][realms].
 
 Like many other Solana Ecosystem projects, Helium uses Realms to organize and manage governance,
 vote escrowed tokens, delegation, and more. Using the links below, you can cast your vote for the
-subDAO of which you seek to impact and contribute to.
+Subnetwork of which you seek to impact and contribute to.
 
 Ensure that you have a Solana-ready wallet that is funded with some SOL and one of the network
 tokes: HNT, IOT, or MOBILE.
@@ -33,7 +33,7 @@ tokes: HNT, IOT, or MOBILE.
 ### Signing Into Realms
 
 Use your account that holds your veHNT positions to sign in to Realms. The same account can be used
-for all platforms, but it must have veTokens for the specific DAO or subDAO hosting the vote.
+for all platforms, but it must have veTokens for the specific DAO or Subnetwork hosting the vote.
 
 The links for the Realms governance portals are:
 

--- a/docs/governance/realms.mdx
+++ b/docs/governance/realms.mdx
@@ -23,7 +23,7 @@ is facilitated through the website [Realms][realms].
 
 Like many other Solana Ecosystem projects, Helium uses Realms to organize and manage governance,
 vote escrowed tokens, delegation, and more. Using the links below, you can cast your vote for the
-Subnetwork of which you seek to impact and contribute to.
+subnetwork of which you seek to impact and contribute to.
 
 Ensure that you have a Solana-ready wallet that is funded with some SOL and one of the network
 tokes: HNT, IOT, or MOBILE.
@@ -33,7 +33,7 @@ tokes: HNT, IOT, or MOBILE.
 ### Signing Into Realms
 
 Use your account that holds your veHNT positions to sign in to Realms. The same account can be used
-for all platforms, but it must have veTokens for the specific DAO or Subnetwork hosting the vote.
+for all platforms, but it must have veTokens for the specific DAO or subnetwork hosting the vote.
 
 The links for the Realms governance portals are:
 

--- a/docs/governance/vehnt.mdx
+++ b/docs/governance/vehnt.mdx
@@ -13,9 +13,9 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <img className="docsheader" src={useBaseUrl('/img/blockchain/veHNT.png')} />
 
 In the Helium Ecosystem, HNT holders can receive veHNT positions by locking their HNT on-chain for a
-specified period in exchange for voting power and Subnetwork delegation reward in the Helium DAO. After
-the lock-up period ends and the locked position is closed, the amount of HNT is released to the
-owner's Wallet and is once again transferable.
+specified period in exchange for voting power and Subnetwork delegation reward in the Helium DAO.
+After the lock-up period ends and the locked position is closed, the amount of HNT is released to
+the owner's Wallet and is once again transferable.
 
 veHNT, or voting-escrowed HNT, is a position introduced as part of
 [HIP-51](https://github.com/helium/HIP/blob/main/0051-helium-dao.md). veHNT was designed to empower
@@ -35,16 +35,17 @@ longer lock-up periods resulting in a higher veHNT multiplier.
 
 ## Subnetworks
 
-The Helium Network serves as the overarching system that enables a multitude of subnetworks
-to exist via the HNT token.
+The Helium Network serves as the overarching system that enables a multitude of subnetworks to exist
+via the HNT token.
 
 Those who delegate their veHNT position to a subnetwork are eligible to receive a portion of that
 Network's token emissions.
 
-Each subnetwork governs a specific area of the Network. The distribution of HNT tokens available to the
-subnetwork is determined by the amount of veHNT delegated to each subnetwork. HNT is minted in proportion to
-the veHNT staked to each subnetwork. Initially, two subnetworks are introduced: IOT and MOBILE. Voting on
-matters specific to the IoT and Mobile networks will require veIOT and veMOBILE respectively.
+Each subnetwork governs a specific area of the Network. The distribution of HNT tokens available to
+the subnetwork is determined by the amount of veHNT delegated to each subnetwork. HNT is minted in
+proportion to the veHNT staked to each subnetwork. Initially, two subnetworks are introduced: IOT
+and MOBILE. Voting on matters specific to the IoT and Mobile networks will require veIOT and
+veMOBILE respectively.
 
 ### IOT Subnetwork
 
@@ -76,9 +77,9 @@ on the [Helium Wallet App](/wallets/helium-wallet-app):
 ### Impacts on Subnetwork Rewards
 
 Subnetwork rewards are calculated and paid to the lock-up position each 24-hour reward period, at
-approximately 00:30 UTC. Currently, the IOT and MOBILE subnetwork each have a 6% token emission pool for
-veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subnetwork at the
-end of each epoch.
+approximately 00:30 UTC. Currently, the IOT and MOBILE subnetwork each have a 6% token emission pool
+for veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subnetwork
+at the end of each epoch.
 
 **Subnetwork rewards may increase when:**
 

--- a/docs/governance/vehnt.mdx
+++ b/docs/governance/vehnt.mdx
@@ -13,7 +13,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 <img className="docsheader" src={useBaseUrl('/img/blockchain/veHNT.png')} />
 
 In the Helium Ecosystem, HNT holders can receive veHNT positions by locking their HNT on-chain for a
-specified period in exchange for voting power and subDAO delegation reward in the Helium DAO. After
+specified period in exchange for voting power and Subnetwork delegation reward in the Helium DAO. After
 the lock-up period ends and the locked position is closed, the amount of HNT is released to the
 owner's Wallet and is once again transferable.
 
@@ -33,63 +33,63 @@ align stakeholders' interests with the Network's long-term success.
 The amount of veHNT received when locking HNT depends on the lock-up period chosen by the user, with
 longer lock-up periods resulting in a higher veHNT multiplier.
 
-## SubDAOs
+## Subnetworks
 
-The Helium Network serves as the overarching system that enables a multitude of Networks (subDAOs)
+The Helium Network serves as the overarching system that enables a multitude of Subnetworks
 to exist via the HNT token.
 
-Those who delegate their veHNT position to a subDAO are eligible to receive a portion of that
+Those who delegate their veHNT position to a Subnetwork are eligible to receive a portion of that
 Network's token emissions.
 
-Each subDAO governs a specific area of the Network. The distribution of HNT tokens available to the
-subDAO is determined by the amount of veHNT delegated to each subDAO. HNT is minted in proportion to
-the veHNT staked to each subDAO. Initially, two subDAOs are introduced: IOT and MOBILE. Voting on
+Each Subnetwork governs a specific area of the Network. The distribution of HNT tokens available to the
+Subnetwork is determined by the amount of veHNT delegated to each Subnetwork. HNT is minted in proportion to
+the veHNT staked to each Subnetwork. Initially, two Subnetworks are introduced: IOT and MOBILE. Voting on
 matters specific to the IoT and Mobile networks will require veIOT and veMOBILE respectively.
 
-### IOT subDAO
+### IOT Subnetwork
 
-The IOT subDAO focuses on the original vision of the Helium Network, supporting the growth and
-development of IoT devices and applications. Delegating veHNT to the IOT subDAO will help fund
+The IOT Subnetwork focuses on the original vision of the Helium Network, supporting the growth and
+development of IoT devices and applications. Delegating veHNT to the IOT Subnetwork will help fund
 projects and initiatives that further the IoT Ecosystem on the Helium Network.
 
-### MOBILE subDAO
+### MOBILE Subnetwork
 
-The MOBILE subDAO is dedicated to the growth and expansion of the Helium Network in the cellular
-communications sector of the Network. Delegating veHNT to the MOBILE subDAO will help finance
+The MOBILE Subnetwork is dedicated to the growth and expansion of the Helium Network in the cellular
+communications sector of the Network. Delegating veHNT to the MOBILE Subnetwork will help finance
 projects and initiatives aimed at integrating Helium technology into mobile devices and Networks.
 
 ## Delegating veHNT
 
 To earn rewards from the token emissions, veHNT holders must delegate their position to one or more
-subDAOs. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
+Subnetworks. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
 resulting in a higher veHNT multiplier. Users can also change their delegations at any time to
-optimize their rewards from the subDAOs. For the accrued rewards to be sent to a veHNT holder's
+optimize their rewards from the Subnetworks. For the accrued rewards to be sent to a veHNT holder's
 wallet, they need to be claimed manually.
 
 veTokens can be managed through [Realms](/governance/staking-with-helium-vote) using the in-app browser
 on the [Helium Wallet App](/wallets/helium-wallet-app):
 
 - [HNT DAO on Realms](https://app.realms.today/dao/HNT)
-- [IOT subDAO on Realms](https://app.realms.today/dao/IOT)
-- [MOBILE subDAO on Realms](https://app.realms.today/dao/MOBILE)
+- [IOT Subnetwork on Realms](https://app.realms.today/dao/IOT)
+- [MOBILE Subnetwork on Realms](https://app.realms.today/dao/MOBILE)
 
-### Impacts on subDAO Rewards
+### Impacts on Subnetwork Rewards
 
-SubDAO rewards are calculated and paid to the lock-up position each 24-hour reward period, at
-approximately 00:30 UTC. Currently, the IOT and MOBILE subDAO each have a 6% token emission pool for
-veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subDAO at the
+Subnetwork rewards are calculated and paid to the lock-up position each 24-hour reward period, at
+approximately 00:30 UTC. Currently, the IOT and MOBILE Subnetwork each have a 6% token emission pool for
+veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that Subnetwork at the
 end of each epoch.
 
-**subDAO rewards may increase when:**
+**Subnetwork rewards may increase when:**
 
-- More veHNT is delegated in the subDAO you delegated to - your treasury gets more HNT.
-- More Hotspot onboarding fees are burned in the subDAO you delegated to.
-- More Network Data is transferred within the subDAO you delegated to.
+- More veHNT is delegated in the Subnetwork you delegated to - your treasury gets more HNT.
+- More Hotspot onboarding fees are burned in the Subnetwork you delegated to.
+- More Network Data is transferred within the Subnetwork you delegated to.
 
-**subDAO rewards may decrease when:**
+**Subnetwork rewards may decrease when:**
 
-- More veHNT is delegated in the subDAO you delegated to - your share is reduced.
-- More veHNT is delegated to other subDAOs - other treasuries get more HNT.
+- More veHNT is delegated in the Subnetwork you delegated to - your share is reduced.
+- More veHNT is delegated to other Subnetworks - other treasuries get more HNT.
 - Your delegated veHNT decays over time after you enter cooldown (cliff mode)
-- More Hotspots are online in other subDAOs that have a non-zero onboarding fee.
-- More Network Data is transferred within other subDAOs.
+- More Hotspots are online in other Subnetworks that have a non-zero onboarding fee.
+- More Network Data is transferred within other Subnetworks.

--- a/docs/governance/vehnt.mdx
+++ b/docs/governance/vehnt.mdx
@@ -35,61 +35,61 @@ longer lock-up periods resulting in a higher veHNT multiplier.
 
 ## Subnetworks
 
-The Helium Network serves as the overarching system that enables a multitude of Subnetworks
+The Helium Network serves as the overarching system that enables a multitude of subnetworks
 to exist via the HNT token.
 
-Those who delegate their veHNT position to a Subnetwork are eligible to receive a portion of that
+Those who delegate their veHNT position to a subnetwork are eligible to receive a portion of that
 Network's token emissions.
 
-Each Subnetwork governs a specific area of the Network. The distribution of HNT tokens available to the
-Subnetwork is determined by the amount of veHNT delegated to each Subnetwork. HNT is minted in proportion to
-the veHNT staked to each Subnetwork. Initially, two Subnetworks are introduced: IOT and MOBILE. Voting on
+Each subnetwork governs a specific area of the Network. The distribution of HNT tokens available to the
+subnetwork is determined by the amount of veHNT delegated to each subnetwork. HNT is minted in proportion to
+the veHNT staked to each subnetwork. Initially, two subnetworks are introduced: IOT and MOBILE. Voting on
 matters specific to the IoT and Mobile networks will require veIOT and veMOBILE respectively.
 
 ### IOT Subnetwork
 
-The IOT Subnetwork focuses on the original vision of the Helium Network, supporting the growth and
-development of IoT devices and applications. Delegating veHNT to the IOT Subnetwork will help fund
+The IOT subnetwork focuses on the original vision of the Helium Network, supporting the growth and
+development of IoT devices and applications. Delegating veHNT to the IOT subnetwork will help fund
 projects and initiatives that further the IoT Ecosystem on the Helium Network.
 
 ### MOBILE Subnetwork
 
-The MOBILE Subnetwork is dedicated to the growth and expansion of the Helium Network in the cellular
-communications sector of the Network. Delegating veHNT to the MOBILE Subnetwork will help finance
+The MOBILE subnetwork is dedicated to the growth and expansion of the Helium Network in the cellular
+communications sector of the Network. Delegating veHNT to the MOBILE subnetwork will help finance
 projects and initiatives aimed at integrating Helium technology into mobile devices and Networks.
 
 ## Delegating veHNT
 
 To earn rewards from the token emissions, veHNT holders must delegate their position to one or more
-Subnetworks. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
+subnetworks. The lock-up period can range from 1 day to 48 months, with the longer lock-up periods
 resulting in a higher veHNT multiplier. Users can also change their delegations at any time to
-optimize their rewards from the Subnetworks. For the accrued rewards to be sent to a veHNT holder's
+optimize their rewards from the subnetworks. For the accrued rewards to be sent to a veHNT holder's
 wallet, they need to be claimed manually.
 
 veTokens can be managed through [Realms](/governance/staking-with-helium-vote) using the in-app browser
 on the [Helium Wallet App](/wallets/helium-wallet-app):
 
 - [HNT DAO on Realms](https://app.realms.today/dao/HNT)
-- [IOT Subnetwork on Realms](https://app.realms.today/dao/IOT)
-- [MOBILE Subnetwork on Realms](https://app.realms.today/dao/MOBILE)
+- [IOT subnetwork on Realms](https://app.realms.today/dao/IOT)
+- [MOBILE subnetwork on Realms](https://app.realms.today/dao/MOBILE)
 
 ### Impacts on Subnetwork Rewards
 
 Subnetwork rewards are calculated and paid to the lock-up position each 24-hour reward period, at
-approximately 00:30 UTC. Currently, the IOT and MOBILE Subnetwork each have a 6% token emission pool for
-veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that Subnetwork at the
+approximately 00:30 UTC. Currently, the IOT and MOBILE subnetwork each have a 6% token emission pool for
+veHNT stakers. This 6% is shared proportionately amongst all veHNT delegated to that subnetwork at the
 end of each epoch.
 
 **Subnetwork rewards may increase when:**
 
-- More veHNT is delegated in the Subnetwork you delegated to - your treasury gets more HNT.
-- More Hotspot onboarding fees are burned in the Subnetwork you delegated to.
-- More Network Data is transferred within the Subnetwork you delegated to.
+- More veHNT is delegated in the subnetwork you delegated to - your treasury gets more HNT.
+- More Hotspot onboarding fees are burned in the subnetwork you delegated to.
+- More Network Data is transferred within the subnetwork you delegated to.
 
 **Subnetwork rewards may decrease when:**
 
-- More veHNT is delegated in the Subnetwork you delegated to - your share is reduced.
-- More veHNT is delegated to other Subnetworks - other treasuries get more HNT.
+- More veHNT is delegated in the subnetwork you delegated to - your share is reduced.
+- More veHNT is delegated to other subnetworks - other treasuries get more HNT.
 - Your delegated veHNT decays over time after you enter cooldown (cliff mode)
-- More Hotspots are online in other Subnetworks that have a non-zero onboarding fee.
-- More Network Data is transferred within other Subnetworks.
+- More Hotspots are online in other subnetworks that have a non-zero onboarding fee.
+- More Network Data is transferred within other subnetworks.

--- a/docs/governance/voting.mdx
+++ b/docs/governance/voting.mdx
@@ -34,7 +34,7 @@ governance. Storing voting data on a Blockchain ensures transparency and immutab
 process.
 
 Today, the Helium Network utilizes the Helium Vote tool for on-chain voting. Since the passage of
-HIP 51- 53, the Helium Network established the distinction between Networks and subNetworks,
+HIP 51- 53, the Helium Network established the distinction between Networks and subnetworks,
 currently represented by a token for each. HIP 51 - 53 also established the Vote Escrowed Model of
 token Staking for Voting Power.
 
@@ -64,28 +64,28 @@ retain the tokens' economic value and utility, while the veToken assumes the vot
 Helium veTokens are non-transferable, ‘soulbound,’ and have zero intrinsic economic value. They are
 represented by an NFT in your Helium Wallet App.
 
-Visit Helium Vote, the Helium Network, and subNetworks at:
+Visit Realms, the Helium Network, and subnetworks at:
 
-- Helium (HNT): [https://heliumvote.com/hnt](https://heliumvote.com/hnt)
-- IoT subNetwork (IOT): [https://heliumvote.com/iot](https://heliumvote.com/iot)
-- Mobile subNetwork (MOBILE): [https://heliumvote.com/mobile](https://heliumvote.com/mobile)
+- Helium (HNT): [realms.heliumvote.com/dao/hnt][realms-helium]
+- IoT subnetwork (IOT): [realms.heliumvote.com/dao/iot][realms-iot]
+- Mobile subnetwork (MOBILE): [realms.heliumvote.com/dao/mobile][realms-mobile]
 
 ## Staking
 
 To vote in the Helium Network for changes to either the Network at large, the IoT (LoRaWAN)
-subNetwork, or the Mobile (5G) subNetwork, a participant must stake tokens: HNT, IOT, or MOBILE
+subnetwork, or the Mobile (5G) subnetwork, a participant must stake tokens: HNT, IOT, or MOBILE
 tokens.
 
 Staking is a process of locking up a token amount (as little as one token) for a specific period of
 time in an on-chain program on the Solana Blockchain. This program defines the parameters for
-lockup. In the Helium Network and subNetworks, users can stake tokens for up to 4 years. Staking
+lockup. In the Helium Network and subnetworks, users can stake tokens for up to 4 years. Staking
 allows users to make a commitment to the future, creating long-term alignment to increase the value
 of the Network.
 
 :::note How to stake tokens
 
-For a full walkthrough on how to stake your tokens to the Helium Network or one of its subNetworks,
-see the [Helium Vote Staking](/governance/faq) guide.
+For a full walkthrough on how to stake your tokens to the Helium Network or one of its subnetworks,
+see the [Realms Staking][voting-power] guide.
 
 :::
 
@@ -100,11 +100,11 @@ see the [Helium Vote Staking](/governance/faq) guide.
 
 ## Voting Power
 
-Specific network tokens will give you Voting Power in the designated Network or subNetworks. Voting
+Specific network tokens will give you Voting Power in the designated Network or subnetworks. Voting
 Power is your token amount multiplied by the duration of a lock-up period. Voting Power creates a
 weight of your vote against others. This Voting Power enables those with strong incentive alignment
 with the network to have greater influence over governance decisions. The function of staking and
-Voting Power applies to any new subNetworks in the future, as per the community-passed and approved
+Voting Power applies to any new subnetworks in the future, as per the community-passed and approved
 HIP 51.
 
 ---
@@ -157,6 +157,6 @@ voting occurs within seven days.
 
 A quorum of tokens represented must be met to certify the proposal as a valid outcome. The quorum is
 100,000,000 tokens represented at the time of the vote in the vote results. This quorum is equal
-across the Network and all subNetworks. If a proposal does not reach this quorum, the proposal will
+across the Network and all subnetworks. If a proposal does not reach this quorum, the proposal will
 automatically fail. Even if the proposal received a 66% super majority of Voting Power, the proposal
 did not reach quorum and therefore is invalidated.

--- a/docs/network-mobile/5g-on-helium.mdx
+++ b/docs/network-mobile/5g-on-helium.mdx
@@ -95,10 +95,10 @@ be reallocated to Grants and Operations.
 ### Grants and Operations
 
 The Helium Foundation will distribute grants to teams making core contributions to the development
-of the MOBILE Subnetwork. Grants will be distributed based on defined deliverables and milestones.
+of the MOBILE subnetwork. Grants will be distributed based on defined deliverables and milestones.
 
 The Nova Labs team will be the first grant recipient for work-in-progress and ongoing development
-for the MOBILE Subnetwork. This is spread across three deliverables with 5B MOBILE per milestone for a
+for the MOBILE subnetwork. This is spread across three deliverables with 5B MOBILE per milestone for a
 total grant of 15B MOBILE:
 
 - Milestone 1: Ability for 5G Hotspots to earn MOBILE (Started in August 2022)
@@ -112,7 +112,7 @@ other community contributions.
 
 ### Growth Activities Related to the MOBILE Subnetwork
 
-Reserved for marketing and educational campaigns around the MOBILE Subnetwork.
+Reserved for marketing and educational campaigns around the MOBILE subnetwork.
 
 ---
 
@@ -121,9 +121,9 @@ Reserved for marketing and educational campaigns around the MOBILE Subnetwork.
 HIP-53 defined a max supply of 250B (billion) MOBILE with issuance halvenings every two years
 aligned with the HNT issuance halvenings. The first MOBILE halving will occur on August 1, 2023, to
 align with HNT halving and will continue on a 2-year cycle afterward. Creating a "stub period" as
-defined by [HIP-53: Mobile Subnetwork](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md),
+defined by [HIP-53: Mobile subnetwork](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md),
 which will begin when standard emissions of MOBILE tokens begin (and MOBILE can be redeemed by HNT
-in the Subnetwork's treasury).
+in the subnetwork's treasury).
 
 [HIP-75](https://github.com/helium/HIP/blob/main/0075-mobile-poc-initiate-programmatic-minting-and-updated-emissions-curve.md#economic-changes-to-emissions-curve)
 further modified the emission schedule and started the programatic minting of MOBILE on Feb
@@ -147,7 +147,7 @@ Full emissions schedule of HIP53 and HIP75 can be downloaded
 
 The date for the treasury implementation is April 18, 2023 and dependent on core developers
 implementing the HNT token treasury and redemption transactions on the Solana Blockchain as defined
-for all new Subnetworks in Phase 2 of
+for all new subnetworks in Phase 2 of
 [HIP-51: Helium DAO](https://github.com/helium/HIP/blob/main/0051-helium-dao.md).
 
 ---

--- a/docs/network-mobile/5g-on-helium.mdx
+++ b/docs/network-mobile/5g-on-helium.mdx
@@ -95,10 +95,10 @@ be reallocated to Grants and Operations.
 ### Grants and Operations
 
 The Helium Foundation will distribute grants to teams making core contributions to the development
-of the MOBILE subDAO. Grants will be distributed based on defined deliverables and milestones.
+of the MOBILE Subnetwork. Grants will be distributed based on defined deliverables and milestones.
 
 The Nova Labs team will be the first grant recipient for work-in-progress and ongoing development
-for the MOBILE subDAO. This is spread across three deliverables with 5B MOBILE per milestone for a
+for the MOBILE Subnetwork. This is spread across three deliverables with 5B MOBILE per milestone for a
 total grant of 15B MOBILE:
 
 - Milestone 1: Ability for 5G Hotspots to earn MOBILE (Started in August 2022)
@@ -110,9 +110,9 @@ total grant of 15B MOBILE:
 The remaining 15B MOBILE is reserved for other work pertaining to Oracles and Mappers development or
 other community contributions.
 
-### Growth Activities Related to the MOBILE subDAO
+### Growth Activities Related to the MOBILE Subnetwork
 
-Reserved for marketing and educational campaigns around the MOBILE subDAO.
+Reserved for marketing and educational campaigns around the MOBILE Subnetwork.
 
 ---
 
@@ -121,9 +121,9 @@ Reserved for marketing and educational campaigns around the MOBILE subDAO.
 HIP-53 defined a max supply of 250B (billion) MOBILE with issuance halvenings every two years
 aligned with the HNT issuance halvenings. The first MOBILE halving will occur on August 1, 2023, to
 align with HNT halving and will continue on a 2-year cycle afterward. Creating a "stub period" as
-defined by [HIP-53: Mobile subDAO](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md),
+defined by [HIP-53: Mobile Subnetwork](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md),
 which will begin when standard emissions of MOBILE tokens begin (and MOBILE can be redeemed by HNT
-in the subDAO's treasury).
+in the Subnetwork's treasury).
 
 [HIP-75](https://github.com/helium/HIP/blob/main/0075-mobile-poc-initiate-programmatic-minting-and-updated-emissions-curve.md#economic-changes-to-emissions-curve)
 further modified the emission schedule and started the programatic minting of MOBILE on Feb
@@ -147,7 +147,7 @@ Full emissions schedule of HIP53 and HIP75 can be downloaded
 
 The date for the treasury implementation is April 18, 2023 and dependent on core developers
 implementing the HNT token treasury and redemption transactions on the Solana Blockchain as defined
-for all new subDAOs in Phase 2 of
+for all new Subnetworks in Phase 2 of
 [HIP-51: Helium DAO](https://github.com/helium/HIP/blob/main/0051-helium-dao.md).
 
 ---

--- a/docs/network-mobile/5g-on-helium.mdx
+++ b/docs/network-mobile/5g-on-helium.mdx
@@ -98,8 +98,8 @@ The Helium Foundation will distribute grants to teams making core contributions 
 of the MOBILE subnetwork. Grants will be distributed based on defined deliverables and milestones.
 
 The Nova Labs team will be the first grant recipient for work-in-progress and ongoing development
-for the MOBILE subnetwork. This is spread across three deliverables with 5B MOBILE per milestone for a
-total grant of 15B MOBILE:
+for the MOBILE subnetwork. This is spread across three deliverables with 5B MOBILE per milestone for
+a total grant of 15B MOBILE:
 
 - Milestone 1: Ability for 5G Hotspots to earn MOBILE (Started in August 2022)
 - Milestone 2: Development and release of programmatic treasury (by October 2022)

--- a/docs/network-mobile/mobile-service-providers.mdx
+++ b/docs/network-mobile/mobile-service-providers.mdx
@@ -28,12 +28,12 @@ token emissions.
 [HIP-53](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md) put forth a detailed overview
 of this economic model to pave the way for Service Providers’ success in the Helium ecosystem.
 
-It established the MOBILE subnetwork, which handles all MOBILE Rewards emissions, mining Rewards, and
-programmatic treasury operations.
+It established the MOBILE subnetwork, which handles all MOBILE Rewards emissions, mining Rewards,
+and programmatic treasury operations.
 
-Nova Labs has emerged as the first Service Provider on the MOBILE subnetwork. Its Helium Mobile service
-is an innovative mobile carrier model that leverages people-built coverage and crypto-economics to
-reduce costs and increase benefits for subscribers.
+Nova Labs has emerged as the first Service Provider on the MOBILE subnetwork. Its Helium Mobile
+service is an innovative mobile carrier model that leverages people-built coverage and
+crypto-economics to reduce costs and increase benefits for subscribers.
 
 ## Operating A Major Carrier
 

--- a/docs/network-mobile/mobile-service-providers.mdx
+++ b/docs/network-mobile/mobile-service-providers.mdx
@@ -28,10 +28,10 @@ token emissions.
 [HIP-53](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md) put forth a detailed overview
 of this economic model to pave the way for Service Providers’ success in the Helium ecosystem.
 
-It established the MOBILE subDAO, which handles all MOBILE Rewards emissions, mining Rewards, and
+It established the MOBILE Subnetwork, which handles all MOBILE Rewards emissions, mining Rewards, and
 programmatic treasury operations.
 
-Nova Labs has emerged as the first Service Provider on the MOBILE subDAO. Its Helium Mobile service
+Nova Labs has emerged as the first Service Provider on the MOBILE Subnetwork. Its Helium Mobile service
 is an innovative mobile carrier model that leverages people-built coverage and crypto-economics to
 reduce costs and increase benefits for subscribers.
 

--- a/docs/network-mobile/mobile-service-providers.mdx
+++ b/docs/network-mobile/mobile-service-providers.mdx
@@ -28,10 +28,10 @@ token emissions.
 [HIP-53](https://github.com/helium/HIP/blob/main/0053-mobile-dao.md) put forth a detailed overview
 of this economic model to pave the way for Service Providers’ success in the Helium ecosystem.
 
-It established the MOBILE Subnetwork, which handles all MOBILE Rewards emissions, mining Rewards, and
+It established the MOBILE subnetwork, which handles all MOBILE Rewards emissions, mining Rewards, and
 programmatic treasury operations.
 
-Nova Labs has emerged as the first Service Provider on the MOBILE Subnetwork. Its Helium Mobile service
+Nova Labs has emerged as the first Service Provider on the MOBILE subnetwork. Its Helium Mobile service
 is an innovative mobile carrier model that leverages people-built coverage and crypto-economics to
 reduce costs and increase benefits for subscribers.
 

--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -91,7 +91,7 @@ that to the number of HNT to mint that epoch. The current value for Net Emission
 For example, if less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned
 will be re-minted and distributed into the subDAOs Treasury for that epoch. However, if more than 1,643
 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643 will be permanently
-burned and removed from the max supply, while 1,643.83561643 being re-minted and distributed to the subDAOs.
+burned and removed from the max supply, while 1,643.83561643 being re-minted and distributed to the Subnetworks.
 
 The Net Emissions cap can be verified on chain [here](https://explorer.solana.com/address/BQ3MCuTT5zVBhNfQ4SjMh3NPVhFy73MPV8rjfq5d1zie/anchor-account)
 

--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -89,7 +89,7 @@ Net Emissions enable the Network to monitor the number of HNT burned for DC in a
 that to the number of HNT to mint that epoch. The current value for Net Emissions is 1,643.83561643 HNT.
 
 For example, if less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned
-will be re-minted and distributed into the subDAOs Treasury for that epoch. However, if more than 1,643
+will be re-minted and distributed into the subnetworks Treasury for that epoch. However, if more than 1,643 
 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643 will be permanently
 burned and removed from the max supply, while 1,643.83561643 being re-minted and distributed to the Subnetworks.
 

--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -20,8 +20,8 @@ The original Helium blockchain produced the first HNT on July 29th, 2019, on blo
 pre-mine of HNT before the launch of the Network. The Helium network migrated to the Solana
 Blockchain on April 18, 2023.
 
-The mint address for HNT is [`hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux`][hnt-mint-addr] on
-the Solana blockchain.
+The mint address for HNT is [`hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux`][hnt-mint-addr] on the
+Solana blockchain.
 
 Navigate to [https://explorer.helium.com/stats][explorer-stats] for up-to-date information on
 Network tokens.
@@ -86,14 +86,17 @@ of HNT to respond to network usage trends.
 Net Emissions give the protocol enough HNT for rewards in perpetuity.
 
 Net Emissions enable the Network to monitor the number of HNT burned for DC in a given epoch and add
-that to the number of HNT to mint that epoch. The current value for Net Emissions is 1,643.83561643 HNT.
+that to the number of HNT to mint that epoch. The current value for Net Emissions is 1,643.83561643
+HNT.
 
-For example, if less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned
-will be re-minted and distributed into the subnetworks Treasury for that epoch. However, if more than 1,643 
-HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643 will be permanently
-burned and removed from the max supply, while 1,643.83561643 being re-minted and distributed to the Subnetworks.
+For example, if less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount
+burned will be re-minted and distributed into the subnetworks Treasury for that epoch. However, if
+more than 1,643 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643
+will be permanently burned and removed from the max supply, while 1,643.83561643 being re-minted and
+distributed to the Subnetworks.
 
-The Net Emissions cap can be verified on chain [here](https://explorer.solana.com/address/BQ3MCuTT5zVBhNfQ4SjMh3NPVhFy73MPV8rjfq5d1zie/anchor-account)
+The Net Emissions cap can be verified on chain
+[here](https://explorer.solana.com/address/BQ3MCuTT5zVBhNfQ4SjMh3NPVhFy73MPV8rjfq5d1zie/anchor-account)
 
 A cap on the number of HNT minted via Net Emissions per epoch ensures the desired deflationary
 effect of Burn and Mint and the resulting reduction of supply. Because HNT produced via Net


### PR DESCRIPTION
## Changes 

Changed all occurences of `subDAO` or `subDAOs` to `Subnetworks` or `Subnetwork` in all necessery places(except for code examples). 

## Reasoning
Based on the discussion in https://github.com/helium/docs/pull/1769 and discord channel the Subnetwork is the term that should be used because they aren't actually DAOs.

## Outcome
This change should result in more consistency and ease of use for the docs after standarization, I've also added rule of using `Subnetworks`  instead of `subDAOs` to the style guide PR - https://github.com/helium/docs/pull/1799