### PR TITLE
fixed the Helium installation guide link to the right one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Documentation for the Helium network.
 
 - [Yarn](https://yarnpkg.com/getting-started/install) version >= 1.5
 
-## Installation
+## Helium Documentation Installation Guide
 
-- [Installation Guide](https://docs.helium.com/home/faqdocs-installation/)
+- [Installation Guide](https://docs.helium.com/faq/docs-installation/)
 
 ## Contributing
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -209,6 +209,11 @@
   status = 301
   force = true
 [[redirects]]
+  from = "/home/faqdocs-installation"
+  to = "/faq/docs-installation"
+  status = 301
+  force = true
+[[redirects]]
   from = "/governance/staking-with-realms"
   to = "/governance/staking-with-helium-vote"
   status = 301


### PR DESCRIPTION
Closes https://github.com/helium/docs/issues/1821

The current link is broken and hence needs to be replaced by the right link.