### PR TITLE
HNT distribution mechanics to subnetworks as observed from recent data

### DIFF
--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -101,6 +101,30 @@ Emissions do not add to the total outstanding, they do not violate max supply.
 
 Review the [complete Net Emissions discussion in the HIP][hip-20] for more information.
 
+### Allocation of HNT to Subnetworks
+
+The Helium Network, in its ongoing commitment to decentralization and network growth, employs a dynamic mechanism for distributing HNT among its subnetworks, namely IoT (Internet of Things) and Mobile. This allocation process is governed by the principles outlined in HIP-80, which introduces a simplified DAO Utility Score to ensure an equitable distribution based on network contribution and utility.
+
+### Simplified DAO Utility Score
+
+HIP-80 redefines the DAO Utility Score, moving away from the previous complex model to a more straightforward formula.
+The DAO Utility Score is equal to V multiplied by D. Here, `V` represents the veHNT delegated to a subDAO, acknowledging economic investment, while `D` highlights the Data Credits (DC) burned by the subDAO, reflecting its utility to the network. This new formula aims to balance investment and utility, ensuring a fair distribution of HNT to support network growth and infrastructure.
+
+#### Recent Allocation Insights from the graph
+
+Analysis of recent data highlights the practical application of these principles:
+
+- **February 26, 2024:** A total of 41,872.87 HNT was minted, with 7,109.14 allocated to the IoT treasury and 21,783.14 to the Mobile treasury. This distribution reflects the Mobile network's significant contribution to data transfer and its strategic importance to the Helium ecosystem's expansion.
+- **Cumulative Totals:** The ongoing support for both IoT and Mobile networks is evident in their cumulative HNT allocations, ensuring resources are available for infrastructure maintenance and growth. This balanced approach promotes stability and innovation within the Helium ecosystem.
+
+#### Strategic Importance
+
+The allocation of HNT to subnetworks is not static but evolves with the network's needs and contributions. The Mobile treasury's substantial share of daily HNT mint underscores its growing importance and potential to enhance the Helium ecosystem. Simultaneously, the foundational support for the IoT network acknowledges its pivotal role in the network's inception and ongoing infrastructure.
+
+### Conclusion
+
+The allocation of HNT between the IoT and Mobile treasuries, guided by the principles of HIP-80, showcases the Helium Network's commitment to fostering an equitable, dynamic, and growing ecosystem. This strategy not only recognizes past contributions but also invests in future potential, ensuring the Helium Network remains at the forefront of decentralized wireless communication technology.
+
 [bme]: https://multicoin.capital/2018/02/13/new-models-utility-tokens/
 [datacredit]: /tokens/data-credit
 [explorer-stats]: https://explorer.helium.com/stats


### PR DESCRIPTION
Incorporating detailed information about the allocation of Helium Network Tokens (HNT) to subnetworks, as observed from recent data and explained through HIP-80, into the HNT token page, can provide readers with a deeper understanding of the HNT distribution mechanics. 

The addition of this section provides readers with a clear understanding of how HNT is allocated to subnetworks, emphasizing the balance between rewarding existing infrastructure and incentivizing future growth.

 It aligns with the overall narrative of the HNT token page by detailing the economic mechanisms that underpin the Helium Network's operation.

This explanation follows the section on "HNT Token Economic Concepts" to align with the flow of information related to the economic underpinnings of the Helium Network.