### PR TITLE
Updated sections in Governance

### DIFF
--- a/docs/governance/committees.mdx
+++ b/docs/governance/committees.mdx
@@ -9,9 +9,6 @@ slug: /governance/committees
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
-<LegacyContentBanner />
 
 Committees are a necessary part of performing key operations, regulating standards, and coming to a
 consensus on changes to the Helium Network.
@@ -25,11 +22,12 @@ rough consensus from a common sense need.
 
 Today, the Helium Community utilizes one Committee, the Manufacturing Compliance Committee ("MCC").
 
-The MCC was established by [HIP-19][hip-19] with the purpose to set basic technical, security, and
+The MCC was established by [HIP 19][hip-19] with the purpose to set basic technical, security, and
 ethical standards & verifies those standards are met by Hotspot Makers joining the Helium Network
-through the [HIP-19][hip-19] process.
+through the [HIP 19][hip-19] process.
 
-You can find more information about the MCC, Ethics for Makers/Manufacturers, and more [here][mcc].
+You can find more information about the MCC, Ethics for Makers/Manufacturers, and more under the
+[Hotspot Makers subsections][mcc].
 
 [hip-19]: https://github.com/helium/HIP/blob/main/0019-third-party-manufacturers.md
 [mcc]: /hotspot-makers/compliance-committee

--- a/docs/governance/hip.mdx
+++ b/docs/governance/hip.mdx
@@ -39,12 +39,12 @@ decentralized wireless network.
 
 ## Proposing a HIP
 
-Anyone can create a HIP by submitting a Pull Request in the HIP GitHub Repository.
+Anyone can create a HIP by submitting a Pull Request in the HIP GitHub repository.
 
 Ideas often are sparked through community discussion in the Official Helium Discord, which is
 managed and owned by the Helium Foundation. The appropriate channel for new HIP ideas is
 #hip-discussion. After an initial discussion to vet an idea, HIP Authors make a copy (“fork”) of the
-HIP Repository and create a new one, titled with a name and '.md' to designate a Markdown file. All
+HIP repository and create a new one, titled with a name and '.md' to designate a Markdown file. All
 instructions are provided in the format from the
 [HIP Template](https://github.com/helium/HIP/blob/main/0000-template.md) within the repository. This
 new file will be the basis of their Helium Improvement Proposal.
@@ -62,7 +62,7 @@ subnetwork that the HIP impacts. After HIP Editing, the HIP is merged into the p
 all documented Helium Improvement Proposals. The Helium Foundation creates the status of the HIP,
 and a new HIP-specific channel in Discord is opened for community discussion.
 
-HIPs are managed entirely from the HIP GitHub Repository, which is public and fully transparent.
+HIPs are managed entirely from the HIP GitHub repository, which is public and fully transparent.
 Read the Steps to Create a HIP to understand how to bring an idea into a proposal.
 
 Discussion on HIPs occurs on both the Official Helium Discord and within the GitHub repository as
@@ -75,7 +75,7 @@ View, create, or comment on a HIP at: www.github.com/helium/hip
 ## HIP Editors
 
 HIP Editors support the governance process by moving HIPs through each stage of their lifecycle.
-They review new HIPs, flag formatting and structural issues, and keep the GitHub Repository current.
+They review new HIPs, flag formatting and structural issues, and keep the GitHub repository current.
 Today, there are currently two HIP Editors on the Helium Foundation team who are supported by
 additional subject matter experts. To contact a HIP editor ask in the #hip-discussion channel on
 Discord: [https://discord.gg/helium][discord]
@@ -96,19 +96,19 @@ Discord: [https://discord.gg/helium][discord]
 
 - Author is ready to draft a HIP.
 - Author seeks out the HIP Template in HIP 7 (also located in the Discussion tab of the HIP
-  Repository).
+  repository).
 - Author drafts a HIP within the template.
 - Author makes changes to the template as needed to craft their argument.
 - During drafting, Author may seek other information and knowledge to craft their proposal.
 - Author may seek feedback or input from collaborators.
 - Author may seek feedback or input from Helium Foundation.
 
-4. **Pull Request Submission:** The Author forks the Helium GitHub Repository, adds the HIP file
+4. **Pull Request Submission:** The Author forks the Helium GitHub repository, adds the HIP file
    with a title (without allocating a number), commits the changes, and submits a pull request. –
    see step-by-step guide to using GitHub [here](/write-a-hip).
 
 - Author navigates to GitHub in the web or desktop application.
-- Author forks the Helium HIP Repository.
+- Author forks the Helium HIP repository.
 - Author creates a new branch to submit changes to.
 - Author inputs their HIP as a new file within the branch.
 - Author submits a branch as a pull request to the helium/hip repository.
@@ -128,7 +128,7 @@ Discord: [https://discord.gg/helium][discord]
 - HIP Editors define the Voting Requirements for the HIP and confirm the voting token.
 - If all Edits are made and accepted, the HIP will be merged.
 - If all Edits are not made and accepted, the HIP will remain in Draft as a PR.
-- Once merged into the main HIP Repository, a HIP Editor creates an issue ticket, adds basic
+- Once merged into the main HIP repository, a HIP Editor creates an issue ticket, adds basic
   information about the HIP, tags, and updates the README file with status.
 
 6. **Discussion and Approval:** The HIP enters the discussion phase, during which comments and

--- a/docs/governance/hip.mdx
+++ b/docs/governance/hip.mdx
@@ -9,9 +9,6 @@ slug: /governance/hip
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-
-<LegacyContentBanner />
 
 ---
 
@@ -21,14 +18,15 @@ Helium Improvement Proposals (HIPs) define modifications to the open-source Heli
 Network itself. Proposals can modify economics and incentives, technical properties, or
 meta-governance, including the governance process or changes to the rules controlling how HIPs are
 managed. Anyone in the Helium ecosystem can introduce a HIP. All HIPs are publicly available in the
-open HIP Repository, managed by the Helium Foundation on behalf of the community.
+open [HIP Repository](https://github.com/helium/HIP), managed by the Helium Foundation on behalf of
+the community.
 
 Users participate in network-wide token holder voting. You must have tokens to vote on Helium
 Improvement Proposals. The Helium Network and subnetworks vote with three tokens: HNT, IOT, and
-MOBILE. These tokens do not inherently provide governance rights and privileges and must be locked,
-in a method called Staking, to create a user's voting power. Voting power is a multiplication of
-tokens staked and the time duration of staking. Staking aligns a user with the long-term success of
-building a decentralized wireless network.
+MOBILE. These tokens do not inherently provide governance rights and privileges and must be locked
+to create a user's voting power. Voting power is a multiplication of tokens locked and the time
+duration of locking. Locking tokens aligns a user with the long-term success of building a
+decentralized wireless network.
 
 - Holders of HNT vote on proposals that concern meta governance, economic, or technical changes to
   the entire protocol. Proposals that exclusively affect a subnetwork do not fall into HNT voting.
@@ -41,14 +39,15 @@ building a decentralized wireless network.
 
 ## Proposing a HIP
 
-Anyone can create a HIP by submitting a Pull Request in the HIP Github Repository.
+Anyone can create a HIP by submitting a Pull Request in the HIP GitHub Repository.
 
 Ideas often are sparked through community discussion in the Official Helium Discord, which is
 managed and owned by the Helium Foundation. The appropriate channel for new HIP ideas is
 #hip-discussion. After an initial discussion to vet an idea, HIP Authors make a copy (“fork”) of the
 HIP Repository and create a new one, titled with a name and '.md' to designate a Markdown file. All
-instructions are provided in the format from the HIP Template within the repository. This new file
-will be the basis of their Helium Improvement Proposal.
+instructions are provided in the format from the
+[HIP Template](https://github.com/helium/HIP/blob/main/0000-template.md) within the repository. This
+new file will be the basis of their Helium Improvement Proposal.
 
 After a HIP Author creates a Pull Request, the HIP is submitted for review by the Helium Foundation.
 It will be reviewed for editing by the community and designated Helium Foundation HIP Editors. The
@@ -63,11 +62,11 @@ subnetwork that the HIP impacts. After HIP Editing, the HIP is merged into the p
 all documented Helium Improvement Proposals. The Helium Foundation creates the status of the HIP,
 and a new HIP-specific channel in Discord is opened for community discussion.
 
-HIPs are managed entirely from the HIP GitHub repository, which is public and fully transparent.
+HIPs are managed entirely from the HIP GitHub Repository, which is public and fully transparent.
 Read the Steps to Create a HIP to understand how to bring an idea into a proposal.
 
 Discussion on HIPs occurs on both the Official Helium Discord and within the GitHub repository as
-comments. All community members are able to participate in the governance process at any stage.
+comments. All community members are welcome to participate in the governance process at any stage.
 
 View, create, or comment on a HIP at: www.github.com/helium/hip
 
@@ -77,8 +76,8 @@ View, create, or comment on a HIP at: www.github.com/helium/hip
 
 HIP Editors support the governance process by moving HIPs through each stage of their lifecycle.
 They review new HIPs, flag formatting and structural issues, and keep the GitHub Repository current.
-Today, there are currently two HIP Editors on the Helium Foundation team who are supported
-byadditional subject matter experts. To contact a HIP editor ask in the #hip-discussion channel on
+Today, there are currently two HIP Editors on the Helium Foundation team who are supported by
+additional subject matter experts. To contact a HIP editor ask in the #hip-discussion channel on
 Discord: [https://discord.gg/helium][discord]
 
 ---
@@ -102,13 +101,13 @@ Discord: [https://discord.gg/helium][discord]
 - Author makes changes to the template as needed to craft their argument.
 - During drafting, Author may seek other information and knowledge to craft their proposal.
 - Author may seek feedback or input from collaborators.
-- Author may seek feedback or input from Helium Foundation
+- Author may seek feedback or input from Helium Foundation.
 
-4. **Pull Request Submission:** The Author forks the Helium GitHub repository, adds the HIP file
+4. **Pull Request Submission:** The Author forks the Helium GitHub Repository, adds the HIP file
    with a title (without allocating a number), commits the changes, and submits a pull request. –
-   see step-by-step guide to using Github [here](/write-a-hip).
+   see step-by-step guide to using GitHub [here](/write-a-hip).
 
-- Author navigates to Github in the web or desktop application.
+- Author navigates to GitHub in the web or desktop application.
 - Author forks the Helium HIP Repository.
 - Author creates a new branch to submit changes to.
 - Author inputs their HIP as a new file within the branch.
@@ -123,10 +122,10 @@ Discord: [https://discord.gg/helium][discord]
   viability.
 - HIP Editor submits edits to Author for revision.
 - HIP Editor requests changes.
-- At the same time, the HIP Editor begins a conversation with the HIP Author on Discord or Github to
+- At the same time, the HIP Editor begins a conversation with the HIP Author on Discord or GitHub to
   make sure they are available for questions and engage the Author if more clarity or revision is
   needed.
-- HIP Editors define the Voting Requirements for the HIP and confirm the voting token. .
+- HIP Editors define the Voting Requirements for the HIP and confirm the voting token.
 - If all Edits are made and accepted, the HIP will be merged.
 - If all Edits are not made and accepted, the HIP will remain in Draft as a PR.
 - Once merged into the main HIP Repository, a HIP Editor creates an issue ticket, adds basic
@@ -138,7 +137,7 @@ Discord: [https://discord.gg/helium][discord]
    are used to achieve approval to move towards proposal voting.
 
 - HIP Editors have finished merging the file into the main Repo and move on to opening discussion.
-- HIP Editors create a new channel in Discord
+- HIP Editors create a new channel in Discord.
 - HIP Editors title the channel, add essential channel information, and begin the discussion.
 - HIP Editors or Community Managers make an announcement letting the community know the HIP is live
   and open for discussion.
@@ -152,7 +151,7 @@ Discord: [https://discord.gg/helium][discord]
   voting in the Realms voting and governance platform.
 - HIP Editors prepare the vote, including proposal descriptions, and announcements to the community,
   and inform the Author.
-- Helium Core Devs make the proposal available for the community to vote on in Realms.
+- Helium Core Devs make the proposal available for the community to vote on in Modular Governance.
 
 Vet an idea in the community by joining the #hip-discussion channel on Discord:
 [https://discord.gg/helium][discord]
@@ -162,10 +161,10 @@ Vet an idea in the community by joining the #hip-discussion channel on Discord:
 ## Implemented and Vetoed Proposals
 
 All HIPs that have passed, been implemented, or vetoed in the Helium Community can be found at
-[Helium HIP repository on GitHub][hip-repo]. Not all HIPs get to the vote stage or pass
+[Helium HIP Repository on GitHub][hip-repo]. Not all HIPs get to the vote stage or pass
 super-majority voting, so you will see different status indicators against HIP numbers as you go
 down this list. Just like bills that become law, HIPs often amend each other. To get a full
-understanding of how HIPs have been implemented and how each impacts another, join the Helium
+understanding of how HIPs have been implemented and how each HIP impacts another, join the Helium
 Discord. Long-time Community Members are a wealth of knowledge and can help folks understand changes
 over time.
 

--- a/docs/home/faq/edit-a-hip.mdx
+++ b/docs/home/faq/edit-a-hip.mdx
@@ -9,10 +9,8 @@ slug: /edit-a-hip
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-import { CreateFork, PullRequest } from './EditAHip'
 
-<LegacyContentBanner />
+import { CreateFork, PullRequest } from './EditAHip'
 
 While HIPs are in discussion, the actual text is included in the
 [Helium HIP Repository on GitHub](https://github.com/helium/hip).
@@ -34,9 +32,9 @@ This page will walk users through the process of:
 
 ### Markdown Formatting
 
-All HIPs in the Helium GitHub repository are written in Markdown an easy-to-read, easy-to-write
-syntax for formatting rich text. Read more about basic writing and formatting syntax
-[here.](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+All HIPs in the Helium GitHub Repository are written in Markdown an easy-to-read, easy-to-write
+syntax for formatting rich text. Read more about basic writing and formatting syntax on
+[GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 Do not let knowledge of Markdown stop you from writing a proposal. Get words on a page, and the
 repository maintainers and other community members will help!
@@ -48,7 +46,7 @@ repository maintainers and other community members will help!
 **Step 1.** Log in to an existing account or create a new account on [GitHub](https://github.com).
 
 **Step 2.** Open the Helium HIP Repository at
-[https://github.com/helium/hip](https://github.com/helium/hip)
+[https://github.com/helium/hip](https://github.com/helium/hip).
 
 **Step 3.** Click the `Fork` button in the upper right-hand corner.
 
@@ -71,11 +69,11 @@ bottom left-hand corner.
 
 ## Edit an Existing HIP
 
-All HIPs in the Helium GitHub repository are written in Markdown an easy-to-read, easy-to-write
-syntax for formatting rich text. Read more about basic writing and formatting syntax
-[here.](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+All HIPs in the Helium GitHub Repository are written in Markdown an easy-to-read, easy-to-write
+syntax for formatting rich text. Read more about basic writing and formatting syntax on
+[GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
-**Step 1.** Begin inside the forked copy at `https://github.com/<githubUsername>/HIP`
+**Step 1.** Begin inside the forked copy at `https://github.com/<githubUsername>/HIP`.
 
 <figure className="screensnippet-wrapper">
   <img
@@ -181,7 +179,7 @@ A Pull Request, or "PR", is quite literally an ask to the repository maintainers
 proposed changes.
 
 **Step 1.** A new banner will be presented with a green `Compare & pull request` button. Click the
-button to start a Pull Request
+button to start a Pull Request.
 
 <PullRequest />
 
@@ -226,7 +224,7 @@ were made.
 
 <br />
 
-**Step 5.** View the newly created Pull Request in the main Helium HIP repository.
+**Step 5.** View the newly created Pull Request in the main Helium HIP Repository.
 
 <figure className="screensnippet-wrapper">
   <img

--- a/docs/home/faq/write-a-hip.mdx
+++ b/docs/home/faq/write-a-hip.mdx
@@ -9,10 +9,8 @@ slug: /write-a-hip
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
-import LegacyContentBanner from '@site/src/theme/LegacyContentBanner'
-import { FileName, Fork, NewHip, TitleDescription } from './WriteAHip'
 
-<LegacyContentBanner />
+import { FileName, Fork, NewHip, TitleDescription } from './WriteAHip'
 
 While HIPs are in discussion the actual text is included in the
 [Helium HIP Repository on GitHub](https://github.com/helium/hip).
@@ -24,7 +22,7 @@ proposal.
 
 This page will walk users through the process of:
 
-- Creating a personal copy, or "fork", of the Helium HIP repository.
+- Creating a personal copy, or "fork", of the Helium HIP Repository.
 - Copying the HIP template.
 - Writing a new proposal using the in-browser text editor.
 - Submitting the proposal for review.
@@ -35,9 +33,9 @@ This page will walk users through the process of:
 
 ### Markdown Formatting
 
-All HIPs in the Helium GitHub repository are written in Markdown an easy-to-read, easy-to-write
-syntax for formatting plain text. Read more about basic writing and formatting syntax
-[here.](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+All HIPs in the Helium GitHub Repository are written in Markdown an easy-to-read, easy-to-write
+syntax for formatting plain text. Read more about basic writing and formatting syntax on
+[GitHub](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
 
 Do not let knowledge of Markdown stop you from writing a proposal. Get words on a page, and the
 repository maintainers and other community members will help!
@@ -49,7 +47,7 @@ repository maintainers and other community members will help!
 **Step 1.** Log in to an existing account or create a new account on [GitHub](https://github.com).
 
 **Step 2.** Open the Helium HIP Repository at
-[https://github.com/helium/hip](https://github.com/helium/hip)
+[https://github.com/helium/hip](https://github.com/helium/hip).
 
 **Step 3.** Click the `Fork` button in the upper right-hand corner.
 
@@ -168,7 +166,7 @@ A Pull Request, or "PR", is quite literally an ask to the repository maintainers
 proposed changes.
 
 **Step 1.** A new banner will be presented with a green `Compare & pull request` button. Click the
-button to start a Pull Request
+button to start a Pull Request.
 
 <figure className="screensnippet-wrapper">
   <img
@@ -209,7 +207,7 @@ is about.
 
 <br />
 
-**Step 5.** View the newly created Pull Request in the main Helium HIP repository.
+**Step 5.** View the newly created Pull Request in the main Helium HIP Repository.
 
 <figure className="screensnippet-wrapper">
   <img


### PR DESCRIPTION
Updated committees.mdx
Updated hip.mdx
Updated edit-a-hip.mdx
Updated write-a-hip.mdx
Why is Edit-A-Hip and Write-A-Hip under faq in GitHub, but on the website it falls under heading Helium Improvement Proposals? For me it does not make sense to place it under faq. Not easy to find in GitHub to edit.

#Solana Scribes 2024.