### PR TITLE
Update iot-coverage-mapping-quickstart.mdx with a T-beam v1.2 compatible Mapper

### DIFF
--- a/docs/network-iot/coverage-mapping/iot-coverage-mapping-quickstart.mdx
+++ b/docs/network-iot/coverage-mapping/iot-coverage-mapping-quickstart.mdx
@@ -71,6 +71,7 @@ Network.
   - [TTGO T-Beam (hekopath)](https://github.com/hekopath/ttgo-rev1-helium)
   - [TTGO T-Beam (tmiklas)](https://github.com/tmiklas/tbeam-helium-mapper)
   - [TTGO T-Beam (Max_Plastix)](https://github.com/Max-Plastix/tbeam-helium-mapper)
+  - [TTGO T-Beam v1.2 with SX1262 and AXP2101](https://github.com/designer2k2/tbeam-lorawan-mapper)
 - RAKwireless Helium Mapper Kit
   - [Product page](https://store.rakwireless.com/products/helium-mapper-kit?variant=41259355701446)
   - [RAK Helium Mapper Kit tutorial](https://news.rakwireless.com/make-a-helium-mapper-with-the-wisblock/)


### PR DESCRIPTION
This expands the T-Beam section with a v1.2 compatible code.

It works with the SX1262 and AXP2101 found on this modules.  

The code is tested on hardware and by github CI.

All details can be found here: https://github.com/designer2k2/tbeam-lorawan-mapper