### PR TITLE
new ref for burn/mint and confirmed added to total supply

### DIFF
--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -94,15 +94,16 @@ produced via Net Emissions do not add to the total outstanding, they do not viol
 However, to ensure that the deflationary pressure is still present, the Net Emission is capped at 1%
 of the epoch emission.
 
-For instance, in February 2024, the Net Emissions cap is 1,643.83561643 HNT per epoch, and the
+For instance, in October 2024, the Net Emissions cap is 1,643.83561643 HNT per epoch, and the
 up-to-date value can be verified
-[on chain](https://explorer.solana.com/address/BQ3MCuTT5zVBhNfQ4SjMh3NPVhFy73MPV8rjfq5d1zie/anchor-account).
+[on chain at](https://solscan.io/account/BQ3MCuTT5zVBhNfQ4SjMh3NPVhFy73MPV8rjfq5d1zie#data). Move
+decimal point 8 positions left to measure in HNT.
 
 If less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned will be
-re-minted and distributed into the subnetwork's Treasury for that epoch. However, if more than
+re-minted and added to the day's usual scheduled emissions for that days epoch. However, if more than
 1,643.83561643 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643
 will be permanently burned and removed from the max supply, while 1,643.83561643 being re-minted and
-distributed to the subnetwork.
+distributed, and added to scheduled emissions.
 
 Review the [complete Net Emissions discussion in the HIP][hip-20] for more information. Note that in
 HIP-20, the cap was 34.24 HNT because the epoch was every 30 minutes at the time HIP-20 was written.

--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -100,10 +100,10 @@ up-to-date value can be verified
 decimal point 8 positions left to measure in HNT.
 
 If less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned will be
-re-minted and added to the day's usual scheduled emissions for that days epoch. However, if more than
-1,643.83561643 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643
-will be permanently burned and removed from the max supply, while 1,643.83561643 being re-minted and
-distributed, and added to scheduled emissions.
+re-minted and added to the day's usual scheduled emissions for that day's epoch. However, if more
+than 1,643.83561643 HNT is burned for DC within a single epoch, any HNT burn for DC over
+1,643.83561643 will be permanently burned and removed from the max supply, while 1,643.83561643 will
+be re-minted and distributed in scheduled emissions.
 
 Review the [complete Net Emissions discussion in the HIP][hip-20] for more information. Note that in
 HIP-20, the cap was 34.24 HNT because the epoch was every 30 minutes at the time HIP-20 was written.


### PR DESCRIPTION

Correct link to B&M reference 
Confirmed that B&M adds to total of HNT minted not direct to subnetworks