### PR TITLE
Fixes some formatter issues with the display of `$`

### DIFF
--- a/docs/architecture/hotspot-makers/become-a-maker/funding-a-maker-account.mdx
+++ b/docs/architecture/hotspot-makers/become-a-maker/funding-a-maker-account.mdx
@@ -69,7 +69,7 @@ Wallet][helium-wallet] using the inbuilt browser and a swap aggregator such as [
 ## Funding Maker Wallets with Data Credits
 
 Funding a wallet with Data Credits requires HNT, as Data Credits can only be obtained using HNT. The
-exchange rate for DC is $1 worth of HNT = 100,000 DC.
+exchange rate for DC is \$1 worth of HNT = 100,000 DC.
 
 - If HNT is $2 then 0.5 HNT = 100,000 DC
 - If HNT is $10 then 0.1 HNT = 100,000 DC

--- a/docs/architecture/hotspot-makers/hotspot-makers.mdx
+++ b/docs/architecture/hotspot-makers/hotspot-makers.mdx
@@ -319,11 +319,12 @@ the network by these makers. Existing stock already manufactured in sales channe
 already manufactured can be onboarded onto the network.
 
 Helium Foundation still requests that these makers fulfill their obligations to their customers to
-fund the $40+$10 Onboarding and Location assertion fees but cannot enforce this requirement. Owners
-of un-onboarded Hotspots can pay the onboarding and location assertion fees from their own wallets
-if maker wallets are out of DC funds by using the [Helium Wallet App.](/wallets/helium-wallet-app)
-to onboard. Do not use the maker apps or the "Repair Onboarding" option in the Helium Wallet app
-unless the maker has enough DC in their wallet balance for the onboarding and assert transactions.
+fund the \$40+\$10 Onboarding and Location assertion fees but cannot enforce this requirement.
+Owners of un-onboarded Hotspots can pay the onboarding and location assertion fees from their own
+wallets if maker wallets are out of DC funds by using the
+[Helium Wallet App.](/wallets/helium-wallet-app) to onboard. Do not use the maker apps or the
+"Repair Onboarding" option in the Helium Wallet app unless the maker has enough DC in their wallet
+balance for the onboarding and assert transactions.
 
 ## Aiteks
 

--- a/docs/architecture/hotspot-makers/mobile-cbrs/5g-hardware-specification.mdx
+++ b/docs/architecture/hotspot-makers/mobile-cbrs/5g-hardware-specification.mdx
@@ -159,7 +159,7 @@ it does not require a re-audit or new HIP19 application.
 :::
 
 Indoor and Outdoor Hotspots with the same hardware layout arriving together will be audited together
-(additional $500 fee). An example of this would be the same Hotspot model with the same hardware,
+(additional \$500 fee). An example of this would be the same Hotspot model with the same hardware,
 but one has an exterior case making it an outdoor unit.
 
 Different Hotspot models or indoor and outdoor Hotspots arriving at the same time with different

--- a/docs/architecture/solana/introduction.mdx
+++ b/docs/architecture/solana/introduction.mdx
@@ -30,14 +30,14 @@ migration window.
 
 1. The Helium blockchain officially halted.
 2. A snapshot was taken of Helium chain state.
-3. Existing $HNT and $MOBILE were mapped to Solana. Hotspots were minted as NFTs.
+3. Existing \$HNT and \$MOBILE were mapped to Solana. Hotspots were minted as NFTs.
 4. During the Migration, PoC and Data Transfer continued to function through the off-chain Oracle,
    rewards were claimable after the transition phase (estimated 24-48 hours) was complete.
 5. Users and Exchanges can access their assets using the same private key on Solana (Solana and
    Helium blockchain use the same [ed25519 encryption](https://en.wikipedia.org/wiki/EdDSA)
    algorithm.)
-6. Programmatic Treasury was activated in 2023 Q2, users will be able to convert $MOBILE and $IOT
-   into $HNT on chain at that time.
+6. Programmatic Treasury was activated in 2023 Q2, users will be able to convert \$MOBILE and \$IOT
+   into \$HNT on chain at that time.
 
 ---
 

--- a/docs/archive/console/quickstart.mdx
+++ b/docs/archive/console/quickstart.mdx
@@ -24,8 +24,8 @@ This Console quickstart guide will cover how to:
 
 :::info
 
-The cost per packet is $0.00001 USD \(24 byte packets\) which is equivalent to 1 Data Credit \(DC\).
-For more information please go [here](/tokens/data-credit).
+The cost per packet is \$0.00001 USD \(24 byte packets\) which is equivalent to 1 Data Credit
+\(DC\). For more information please go [here](/tokens/data-credit).
 
 :::
 

--- a/docs/archive/run-a-network-server/run-a-network-server.mdx
+++ b/docs/archive/run-a-network-server/run-a-network-server.mdx
@@ -42,9 +42,6 @@ Before pursuing this configuration though, it is worth considering.
   accounts start with free 250 Data Credits (DC). To go beyond 10 devices check out Console Hosting
   Providers [here](/iot/find-a-lns-provider).
 
-- The initial costs to host your own Console is U.S. $900 or 90 million DC (OUI costs 10 million DC,
-  and 80 million DC for the smallest address slab).
-
 :::info
 
 For a video tutorial on setting up your own instance of Console, check out our Tips and Tricks video

--- a/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
+++ b/docs/network-iot/hotspots-iot/data-only-hotspots.mdx
@@ -94,8 +94,8 @@ location, two criteria must be met:
 
 The network fees are as follows:
 
-- **Add Data-Only Hotspot**: 50,000 Data Credits (USD $0.50)
-- **Assert Location**: 50,000 Data Credits (USD $0.50)
+- **Add Data-Only Hotspot**: 50,000 Data Credits (USD \$0.50)
+- **Assert Location**: 50,000 Data Credits (USD \$0.50)
 
 These fees are paid using [Data Credits](/tokens/data-credit).
 

--- a/docs/network-iot/run-an-lns/buy-an-oui.mdx
+++ b/docs/network-iot/run-an-lns/buy-an-oui.mdx
@@ -12,27 +12,27 @@ Each LoRaWAN Network Server (LNS) on the Helium Network is managed using an Orga
 Identifier (OUI). This registers the LNS with the network and manages the
 [devAddrs](#devaddr-explained), [Data Credits](/tokens/data-credit), and routes for device traffic.
 
-Currently, the purchasing of OUIs and devAddrs must be done by contacting the Helium Foundation. 
-In the future, these registrations will be self-service.
+Currently, the purchasing of OUIs and devAddrs must be done by contacting the Helium Foundation. In
+the future, these registrations will be self-service.
 
-As an alternate to purchasing a devAddr slab, it is also an option to obtain a NetID from the LoRa 
-Alliance and use it in a roaming configuration. An OUI and data credits are required in either 
+As an alternate to purchasing a devAddr slab, it is also an option to obtain a NetID from the LoRa
+Alliance and use it in a roaming configuration. An OUI and data credits are required in either
 scenario.
 
 ## Pricing
 
-The minimum cost to deploy an LNS to the Helium Network is $235 USD. This cost is divided into three
-parts.
+The minimum cost to deploy an LNS to the Helium Network is \$235 USD. This cost is divided into
+three parts.
 
-The cost of an OUI is US$100. This is a one-time fee.
+The cost of an OUI is US\$100. This is a one-time fee.
 
-DevAddrs are issued in blocks of 8 and cost US$12.50 per devAddr for a total of $100. DevAddrs are
+DevAddrs are issued in blocks of 8 and cost US\$12.50 per devAddr for a total of \$100. DevAddrs are
 also purchased as a one-time fee. DevAddrs are only required if a NetID is not already obtained from
 the LoRa Alliance.
 
-A minimum of 3,500,000 Data Credits ($35 USD) must be held in the escrow account associated with the
-OUI. DC are consumed in proportion to the network traffic transferred[^1]. If the DC balance drops
-below 3.5M, device traffic to the routes associated with the OUI will halt.
+A minimum of 3,500,000 Data Credits (\$35 USD) must be held in the escrow account associated with
+the OUI. DC are consumed in proportion to the network traffic transferred[^1]. If the DC balance
+drops below 3.5M, device traffic to the routes associated with the OUI will halt.
 
 | Item                | Fee               |
 | ------------------- | ----------------- |
@@ -66,8 +66,8 @@ In doing so, a Helium wallet will be generated with key pairs in the native Sola
 The OUI configuration process currently leverages public keys in a format from the legacy Helium L1
 blockchain. To convert a Solana public key into the legacy format, use the conversion tool below.
 
-To use the tool, simply paste your Helium wallet public key in the Solana format into the top
-"Enter Helium or Solana Wallet Address" field and copy the result from the "Helium Address" field.
+To use the tool, simply paste your Helium wallet public key in the Solana format into the top "Enter
+Helium or Solana Wallet Address" field and copy the result from the "Helium Address" field.
 
 **This value will be the Helium wallet public key in the legacy format required for purchasing an
 OUI**.
@@ -169,10 +169,10 @@ helium-config-service-cli env info --keypair <key file name>.bin
 }
 ```
 
-The `.bin` files should be kept safe and never shared. 
+The `.bin` files should be kept safe and never shared.
 
-**The public keys of the owner and delegate key pairs are required for purchasing an
-OUI and are the only part that should be shared.**
+**The public keys of the owner and delegate key pairs are required for purchasing an OUI and are the
+only part that should be shared.**
 
 ## Purchasing OUI and devAddr Slab
 

--- a/docs/network-iot/run-an-lns/fund-an-oui.mdx
+++ b/docs/network-iot/run-an-lns/fund-an-oui.mdx
@@ -80,10 +80,10 @@ https://api.spherepay.co/v1/solanaDepinSession/dcAmount/<Escrow Account>
 
 ## Minimum Balance
 
-The Helium Packet Router enforces a minimum balance of 3,500,000 Data Credits ($35). This minimum
+The Helium Packet Router enforces a minimum balance of 3,500,000 Data Credits (\$35). This minimum
 balance is required to ensure that all Hotspots are compensated for their work on the network in the
 case that the LNS transfers data more quickly than can be deducted from the OUI's balance. Token
-balances cannot become negative, so this $35 buffer keeps network payments balanced.
+balances cannot become negative, so this \$35 buffer keeps network payments balanced.
 
 If the DC balance of an OUI falls below the minimum balance, the OUI will be unable to receive data
 until the balance is increased. The

--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -109,11 +109,11 @@ In addition to network data transfer, DCs are also utilized for certain network-
 
 In much the same design as the Helium IoT Network, the Helium Mobile Network leverages DCs as the
 sole mechanism of billing and fee management. However, as a separate protocol, different pricing
-mechanics apply. While the Helium IoT Network charges data at a rate of $0.00001 per 24-byte
+mechanics apply. While the Helium IoT Network charges data at a rate of \$0.00001 per 24-byte
 message, the Helium Mobile Network charges data at a rate of **$0.50 per 1 gigabyte** (50,000 DC).
 
 On cellular networks, it is customary that network operators bill for bulk data rather than for
-individual packets. By setting the data cost to $0.50 per gigabyte, the Helium Mobile network
+individual packets. By setting the data cost to \$0.50 per gigabyte, the Helium Mobile network
 positions itself competitively in the marketplace while preserving valuable rewards for the Mobile
 Hotspot operator.
 

--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -122,11 +122,11 @@ Hotspot operator.
 Fees related to onboarding and location assert were defined through community governance through
 [HIP-89](https://github.com/helium/HIP/blob/main/0089-mobile-network-onboard-fees.md).
 
-| Action                                                     | Fee   |
-| ---------------------------------------------------------- | ----- |
-| WiFi Indoor Onboard                                        | $20   |
-| WiFi Outdoor Onboard                                       | $30   |
-| [(Converted Network Onboarding)](/mobile/data-only-mobile) | $2.00 |
+| Action                                                   | Fee   |
+| -------------------------------------------------------- | ----- |
+| WiFi Indoor Onboard                                      | $20   |
+| WiFi Outdoor Onboard                                     | $30   |
+| [Converted Network Onboarding](/mobile/data-only-mobile) | $2.00 |
 
 ## Acquiring Data Credits
 

--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -34,8 +34,8 @@ HNT serves the needs of the two primary parties in the Helium Ecosystem:
    [MOBILE][mobile] while deploying and maintaining network coverage. These network tokens are
    redeemable for HNT.
 2. **Enterprises and Developers use the Helium Network** to connect devices and build IoT
-   applications. [Data Credits][datacredit], which are a $USD-pegged utility token derived from HNT,
-   are used to pay transaction fees for wireless data transmissions on the Network.
+   applications. [Data Credits][datacredit], which are a \$USD-pegged utility token derived from
+   HNT, are used to pay transaction fees for wireless data transmissions on the Network.
 
 ## HNT Token Economic Concepts
 

--- a/docs/tokens/sol-token.mdx
+++ b/docs/tokens/sol-token.mdx
@@ -15,7 +15,7 @@ scalable, and low-cost blockchain.
 
 Interacting with the Solana blockchain requires a small fee (average transaction fee is 0.000014
 SOL) paid in SOL tokens, which is massively cheaper than the original Helium blockchain transaction
-fee of $0.35 in DC.
+fee of \$0.35 in DC.
 
 All interactions with the Solana blockchain require fees, including sending tokens, staking tokens,
 making payments, swapping tokens, minting NFTs, claiming rewards from your Hotspots, and all

--- a/docs/wallets/transaction-safety.mdx
+++ b/docs/wallets/transaction-safety.mdx
@@ -93,7 +93,7 @@ A Solana transaction is made up of
 3. Signers - A set of Wallets that must agree to this transaction for it to be valid
 
 Accounts are generally tied to particular wallets - this means that **only** that wallet can make
-changes to the Account. For example, if you hold $HNT, only your wallet can send those tokens. This
+changes to the Account. For example, if you hold \$HNT, only your wallet can send those tokens. This
 is why it is important to **never give out your seed phrase** and **never sign a transaction you
 don't trust**.
 
@@ -300,10 +300,10 @@ You should see a preview like this:
 Not every transaction you approve will be executed. In a smoke screen attack, the attacker creates
 multiple transactions, the sum of which is a positive outcome.
 
-In this attack, you may see that you sent all of your $HNT to the attacker. But you may also see
-another transaction that's sending you $1,000,000 $USDC. Or some "free" airdrop. You figure that its
-worth losing the HNT for the USDC. The site could also be convincing you that this is a legitimate
-swap of some sort.
+In this attack, you may see that you sent all of your \$HNT to the attacker. But you may also see
+another transaction that's sending you \$1,000,000 \$USDC. Or some "free" airdrop. You figure that
+its worth losing the HNT for the USDC. The site could also be convincing you that this is a
+legitimate swap of some sort.
 
 The transaction may look something like this:
 
@@ -335,7 +335,7 @@ You should see a preview like this:
   </div>
 </figure>
 
-This looks appealing. After all, the simulation is telling you you'll get $1,000,000 and all you
+This looks appealing. After all, the simulation is telling you you'll get \$1,000,000 and all you
 have to do is send 0.01 SOL! As always, if it seems too good to be true, it is. If you approve a
 transaction like this, the attacker will only send the transactions where you give them funds.
 
@@ -346,7 +346,7 @@ moment?
 
 Some attacks compromise your wallet, and then lay in wait until more funds are transferred into the
 wallet. Imagine you signed a suspicious transaction to mint an NFT, but then you got the NFT.
-Everything is good, right? Wrong. Later on, you transfer $50,000 USDC into this wallet, and it
+Everything is good, right? Wrong. Later on, you transfer \$50,000 USDC into this wallet, and it
 immediately disappears. This actually happened to someone. How can this happen?
 
 Solana token accounts have an ability called `delegation`. Think of delegation as a way to give
@@ -431,8 +431,8 @@ always, be careful about what you sign.
 
 Attack sites will try to make the transaction preview look like it is giving you what you expect.
 
-For example, an attacker may claim to be giving out free $JUP. When you see the transaction preview,
-it says you are receiving $JUP. But is it actually $JUP?
+For example, an attacker may claim to be giving out free \$JUP. When you see the transaction
+preview, it says you are receiving \$JUP. But is it actually \$JUP?
 
 On Solana, token names and symbols **are not unique**. Anybody can create a token that is a
 duplicate of another token. If you are unsure, verify the public key of the token you are receiving.


### PR DESCRIPTION
Tex formatter was grabbing `$` as LaTeX blocks. Escaping with `\` fixes these instances.

**Before:**
<kbd><img width="736" alt="image" src="https://github.com/user-attachments/assets/ebd37e12-5ad3-4715-83af-adee104775e2" /></kbd>


**After:**
<kbd><img width="750" alt="image" src="https://github.com/user-attachments/assets/0a1aa45a-6b75-4ba5-a388-52a04e89b121" /></kbd>