### PR TITLE
Update hnt-token.mdx

### DIFF
--- a/docs/tokens/hnt-token.mdx
+++ b/docs/tokens/hnt-token.mdx
@@ -92,7 +92,7 @@ Net Emissions give the protocol enough HNT for rewards in perpetuity by monitori
 burned for DC in a given epoch and adding that to the number of HNT to mint that epoch. Because HNT
 produced via Net Emissions do not add to the total outstanding, they do not violate max supply.
 However, to ensure that the deflationary pressure is still present, the Net Emission is capped at 1%
-of the epoch emission.
+of the epoch emissions at the time when HIP 20 was approved.
 
 For instance, in October 2024, the Net Emissions cap is 1,643.83561643 HNT per epoch, and the
 up-to-date value can be verified


### PR DESCRIPTION
Clarifies that the net emissions cap in HIP-20 was set at 1% of the epoch emissions *back then* and isn't adjusted with each halving.

Note: The paragraph "If less than 1,643.83561643 HNT is burned for DC within an epoch, the full amount burned will be re-minted and added to the day's usual scheduled emissions for that day's epoch. However, if more than 1,643.83561643 HNT is burned for DC within a single epoch, any HNT burn for DC over 1,643.83561643 will be permanently burned and removed from the max supply, while 1,643.83561643 will be re-minted and distributed in scheduled emissions." isn't correct any more, now that we have the smoothing mechanism implemented. Flagging this, but have no capacity atm to update it myself.