### PR TITLE
remove router key reference from widget placeholder

### DIFF
--- a/src/theme/EscrowOUIWidget.tsx
+++ b/src/theme/EscrowOUIWidget.tsx
@@ -36,7 +36,7 @@ export const EscrowOUIWidget = () => {
       <input
         type="text"
         name="wallet"
-        placeholder="Enter Payer or Router Key"
+        placeholder="Enter OUI Payer Key"
         value={wallet}
         onChange={(e) => setWallet(e.target.value)}
       />


### PR DESCRIPTION
remove router key reference from oui funding widget placeholder, correct key to use here is the oui payers key.