### PR TITLE
Move to `text-wrap: pretty`

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -831,7 +831,7 @@ html[data-theme='dark'] .badge--secondary:hover {
 .screensnippet-wrapper figcaption {
   background: white;
   color: rgb(64, 68, 79);
-  text-wrap: balance; /*:soon:*/
+  text-wrap: pretty;
   font-size: smaller;
   font-weight: 500;
   padding: 0.25rem 1rem;


### PR DESCRIPTION
`text-wrap: pretty` is more appropriate and results in a better display of captions. sees broader support in upcoming browser releases