### PR TITLE
New Cert Filename Update for Unifi

### DIFF
--- a/docs/network-mobile/data-only-guides/data-only-ubiquiti.mdx
+++ b/docs/network-mobile/data-only-guides/data-only-ubiquiti.mdx
@@ -108,7 +108,7 @@ Configure RADIUS properties:
 <br />
 
 1. Under **Radius Settings**, check the **TLS** box.
-   1. Press **Upload** next to **Client Certificate**, choose the path to `client.pem`.
+   1. Press **Upload** next to **Client Certificate**, choose the path to `cert.pem`.
    2. Press **Upload** next to **Private Key**, choose the path to `key.pem`.
       Keep Private Key Password empty.
    3. Press **Upload** next to **CA Certificate**, choose the path to `ca.pem`.


### PR DESCRIPTION
@jthiller sorry for the confusion. This is the correct client cert filename to match the radsec-proxy readme.