### PR TITLE
Add Cambium cnMaestro Conversion Guide

### DIFF
--- a/docs/network-mobile/data-only-guides/data-only-cambium-cnmaestro.mdx
+++ b/docs/network-mobile/data-only-guides/data-only-cambium-cnmaestro.mdx
@@ -1,0 +1,206 @@
+---
+id: data-only-Cambium-cnMaestro
+title: Cambium cnMaestro Conversion Guide
+pagination_label: Cambium cnMaestro Conversion Guide
+sidebar_label: Cambium cnMaestro Conversion Guide
+description: Helium Network Conversion Documentation
+image: https://docs.helium.com/img/link-image.png
+slug: /mobile/data-only-Cambium-cnMaestro
+source: https://github.com/novalabsxyz/radsec-proxy
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+# Cambium cnMaestro Conversion Guide
+
+## Prerequisites
+
+- This guide assumes the network is using the **cnMaestro Cloud Controller**.
+- The Cambium system has AP(s) linked to the cnMaestro Controller.
+- The Cambium system already has basic traffic routing working with existing SSIDs.
+- An **Intel-based host** is required in the network to run the <a href="https://github.com/novalabsxyz/radsec-proxy" target="_blank">RadSecProxy</a> container.
+
+---
+
+# High Level Steps
+
+1. Deploy RadSecProxy container and record IP address of host
+2. Create AP Group
+3. Build WLAN Helium Passpoint SSID
+4. Configure AAA Servers
+5. Add the NAS-ID to the WLAN AAA Policy
+6. Configure Passpoint and 3GPP Carrier Info
+7. Assign APs to the new Group
+
+## Deploy RadSecProxy Container
+
+RADIUS messages used to authenticate users and for session accounting are transmitted unsecured and over UDP by default.
+By directing these messages internally within your secure network to a **RadSecProxy**, UDP traffic is converted to a **TLS-protected TCP connection** to the Helium Network core AAA servers.
+
+### Prerequisites
+- Intel-based machine with **Docker** installed.
+- The host has a **private IP address** reachable from your cnMaestro controller.
+- ACLs or firewalls allow cnMaestro and the Docker container to communicate via UDP on ports **1812** (auth) and **1813** (accounting).
+
+### Container Deployment
+
+Unzip and untar the Helium RadSec Docker package:
+
+```bash
+tar -xvzf Helium_RadSec_Docker.tar.gz
+```
+
+This will unpack:
+- `Dockerfile` — Docker build instructions
+- `radsecproxy.conf` — preconfigured to connect to Helium AAA servers
+- `docker-compose.yml` — to start/stop the container as a daemon
+
+Copy the three Helium-provided certificates into the same directory:
+- `ca.pem` — root CA certificate
+- `cert.pem` — user certificate
+- `key.pem` — private key paired with the certificate
+
+Start the container:
+```bash
+sudo docker compose up -d
+```
+
+To stop the container:
+```bash
+sudo docker compose down
+```
+
+---
+
+## Create AP Group
+
+1. From the **home** view of your cnMaestro controller, go to
+   **Configuration → Wi-Fi Profiles**
+2. In *Wi-Fi Profiles*, select **AP Groups** → **Add New**.
+3. Under **Basic Settings**, scroll down and click **Create WLAN**.
+
+<figure className="screensnippet-wrapper">
+  <img
+    src={useBaseUrl('img/network-mobile/cambium-ap-group.png')}
+    style={{ maxHeight: '500px' }}
+    className="add-border-radius add-shadow add-shadow-margin"
+  />
+</figure>
+
+---
+
+## Build WLAN
+
+1. In **WLAN settings**, under *Basic Information*, set:
+   - **Name:** `Helium Enterprise` (or your preferred name)
+   - **SSID:** `Helium`
+   - **Security:** `WPA3 Enterprise`
+   - **Client Isolation:** `Network Wide`
+
+2. On the left panel, go to **AAA Servers**.
+
+3. Under **Authentication Server**:
+   - **Host:** IP of your RadSecProxy host (e.g., `192.168.1.203`)
+   - **Secret:** `mysecret` (must match `radsecproxy.conf`)
+   - **Port:** `1812`
+
+4. Under **Accounting Server**, repeat the steps above but set **Port = 1813**.
+
+5. At the bottom, set **Interim Update Interval = 300**.
+
+6. Under **Advanced Settings → NAS-Identifier**, select **Custom** and enter the **NAS ID** provided by the Helium team for carrier offload approval.
+
+7. Click **Save**.
+
+<figure className="screensnippet-wrapper">
+  <img
+    src={useBaseUrl('img/network-mobile/cambium-aaa-settings.png')}
+    style={{ maxHeight: '500px' }}
+    className="add-border-radius add-shadow add-shadow-margin"
+  />
+</figure>
+
+---
+
+## Configure Passpoint
+
+1. Go to the **Passpoint** tab and enable it under *Basic Settings*.
+2. Set **Access Network Type:** `Chargeable Public`
+3. Fill in **Venue Group** and **Venue Type** with your venue details.
+
+4. Under **Domain Names**, click **Add New** and enter:
+   - `freedomfi.com`
+
+5. Under **NAI Realm List**, click **Add New**:
+   - **Name:** `freedomfi.com`
+   - **Method:** `EAP-TLS`
+   - **Authentication:** `Credential Type → Certificate`
+   - Click **Save**
+
+6. Repeat the process for:
+   - **Domain:** `hellohelium.com`
+   - **EAP:** `2`
+   - **Method:** `EAP-TLS`
+   - **Authentication 1:** `Credential Type → Certificate`
+
+7. Save the configuration again.
+
+<figure className="screensnippet-wrapper">
+  <img
+    src={useBaseUrl('img/network-mobile/cambium-passpoint.png')}
+    style={{ maxHeight: '500px' }}
+    className="add-border-radius add-shadow add-shadow-margin"
+  />
+</figure>
+
+8. Scroll down to **IP Address Type Information**:
+   - **IPv4 Type:** `Double NAT`
+   - **IPv6 Type:** `Not Available`
+
+---
+
+## Assign APs to the New Group
+
+1. Go to **Monitor and Manage → AP Groups**
+2. Select your new AP group (`Helium`)
+3. Click on an AP under this group.
+4. Go to the **Configuration** tab.
+5. Scroll to **Device Configuration** and assign it to the AP group `Helium`.
+
+<figure className="screensnippet-wrapper">
+  <img
+    src={useBaseUrl('img/network-mobile/cambium-ap-assignment.png')}
+    style={{ maxHeight: '500px' }}
+    className="add-border-radius add-shadow add-shadow-margin"
+  />
+</figure>
+
+---
+
+## After Carrier Approval
+
+Once carrier approval is received, Helium will provide:
+- **MCC/MNC codes** for AT&T
+- **NAI realms** for T-Mobile
+
+To add them:
+1. Edit the WLAN you created inside your AP group.
+2. Open the **Passpoint** tab.
+3. Under **3GPP Cellular Network Information**, add the MCC/MNC codes for AT&T.
+4. Under **NAI Realm List**, add the T-Mobile NAI realms.
+
+<figure className="screensnippet-wrapper">
+  <img
+    src={useBaseUrl('img/network-mobile/cambium-carrier-config.png')}
+    style={{ maxHeight: '500px' }}
+    className="add-border-radius add-shadow add-shadow-margin"
+  />
+</figure>
+
+---
+
+### Final Notes
+
+After completing these steps:
+- Your Cambium APs are correctly configured to communicate with the Helium network via the RadSec proxy.
+- Verify connection success by checking RADIUS logs in the proxy and confirming AAA session establishment.


### PR DESCRIPTION
Adds a new guide under /docs/network-mobile/data-only-guides for Cambium cnMaestro configuration.