### PR TITLE
Clarify that IoT DC billing is based on payload size only

### DIFF
--- a/docs/network-iot/run-an-lns/fund-an-oui.mdx
+++ b/docs/network-iot/run-an-lns/fund-an-oui.mdx
@@ -38,9 +38,11 @@ Several options are available for funding an OUI with Data Credits:
 
 <br />
 
-Data credits are charged per 1DC per 24b increment for each response of an uplink payload. For a
-helpful visualization of DC usage of devices for a given period, check out the
-[Data Credit calculator](/tokens/data-credit#data-transfer-calculator) on the DC documentation.
+Data credits are charged per 1DC per 24-byte increment for each response of an uplink payload. DC
+cost is based on the application payload size only. LoRaWAN protocol overhead (headers, MIC, etc.)
+does not count toward the DC cost. For a helpful visualization of DC usage of devices for a given
+period, check out the [Data Credit calculator](/tokens/data-credit#data-transfer-calculator) on the
+DC documentation.
 
 Only uplinks are charged on Helium. Downlinks and join requests are not billed.
 

--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -86,8 +86,9 @@ Fees related to onboarding and location assert were defined through community go
 ## Data Credits and IoT {#dc-and-iot}
 
 On the Helium IoT network, the primary utility of DCs is for network data transfer. Data transfer is
-billed in 24-byte increments, per message. Data transfer is only billed if the message is delivered
-through the Helium network.
+billed in 24-byte increments based on the application payload size only. LoRaWAN protocol overhead
+(headers, MIC, etc.) does not count toward the DC cost. Data transfer is only billed if the message
+is delivered through the Helium network.
 
 Network users also have the choice to purchase multiple reports of the same packet. These additional
 reports each account for their own cost. For instance, if three 24-byte copies are returned for a
@@ -124,9 +125,9 @@ In addition to network data transfer, DCs are also utilized for certain network-
 
 [^1]:
     DevAddrs must be purchased in slabs of 8.  
-    [HIP-116](https://github.com/helium/HIP/blob/main/0116-lorawan-device-address-price-adjustment.md)
-    reduced the fees for DevAddr purchasing and set a path to utilize the IOT token for DevAddr and
-    OUI purchases instead of DC.
+    [HIP-116](https://github.com/helium/HIP/blob/main/0116-lorawan-device-address-price-adjustment.md) reduced
+    the fees for DevAddr purchasing and set a path to utilize the IOT token for DevAddr and OUI
+    purchases instead of DC.
 
 ## Acquiring Data Credits
 


### PR DESCRIPTION
## Summary
- Clarify in IoT DC documentation that billing is based on application payload size only
- LoRaWAN protocol overhead (headers, MIC, etc.) does not count toward the DC cost
- Updated both `data-credit.mdx` and `fund-an-oui.mdx`

## Reference
[`hpr_packet_report.erl#L64`](https://github.com/helium/helium-packet-router/blob/main/src/grpc/packet_router/hpr_packet_report.erl#L64) — `payload_size` is derived from `hpr_packet_up:payload(Packet)` only.

## Test plan
- [ ] Verify docs site builds successfully
- [ ] Review rendered pages for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)