### PR TITLE
Add llms.txt and per-page markdown for LLM accessibility

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,6 +150,18 @@ module.exports = {
         authorsMapPath: 'authors.yaml',
       },
     ],
+    [
+      'docusaurus-plugin-llms',
+      {
+        generateLLMsFullTxt: false,
+        generateMarkdownFiles: true,
+        excludeImports: true,
+        title: 'Helium Documentation',
+        description:
+          'Documentation for the Helium Network — covering IoT (LoRaWAN), Mobile (5G/WiFi), tokens (HNT, DC, SOL), wallets, and network data.',
+        includeBlog: false,
+      },
+    ],
   ],
   markdown: {
     mermaid: true,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@solana/web3.js": "^1.98.4",
     "axios": "^1.13.5",
     "docslab-docusaurus": "^0.2.10",
+    "docusaurus-plugin-llms": "^0.3.0",
     "mdx-embed": "^1.1.2",
     "prism-react-renderer": "^2.3.1",
     "process": "^0.11.10",

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,0 +1,8 @@
+# Helium Documentation
+
+> This file is intentionally minimal. Helium docs span multiple distinct domains (IoT/LoRaWAN, Mobile/5G/WiFi, tokens, wallets, network data) and a single concatenated file would be difficult to navigate.
+
+## How to use these docs
+
+- Start with [llms.txt](https://docs.helium.com/llms.txt) for a structured index of all documentation pages with descriptions.
+- Each page listed in llms.txt links to an individual markdown file you can fetch directly.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4673,6 +4673,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -5971,6 +5978,15 @@ docslab@^0.3.12:
     xterm "^5.2.1"
     xterm-addon-attach "^0.8.0"
     xterm-addon-fit "^0.7.0"
+
+docusaurus-plugin-llms@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.3.0.tgz#de4dc96c1cfd460eb92eb5f1a09a63df94e43804"
+  integrity sha512-JuADAJA2fjTv1U4XQUoIu1LyjISDzxFhRK5HbCZiHum4HlmdPwyx8NBXsi+LfdUyjK9acbZgazGsHPhdwEZs0g==
+  dependencies:
+    gray-matter "^4.0.3"
+    minimatch "^9.0.3"
+    yaml "^2.8.1"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -8807,6 +8823,13 @@ minimatch@3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0:
   version "1.2.8"
@@ -11925,6 +11948,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
+  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
 
 yargs-parser@^18.1.2:
   version "18.1.3"


### PR DESCRIPTION
## Summary
- Installs `docusaurus-plugin-llms` to auto-generate `/llms.txt` (structured index) and per-page `.md` files at build time from existing MDX source — no dual maintenance for contributors
- Skips `llms-full.txt` generation since concatenating IoT, Mobile, token, and wallet docs into one file would confuse LLMs
- Adds a static `llms-full.txt` that redirects LLMs to `llms.txt` to avoid 404s (LLMs often look for this file by default)
- Excludes devblog content from LLM output

## What gets served
| URL | Content |
|---|---|
| `/llms.txt` | Auto-generated structured markdown index with descriptions for all ~64 doc pages |
| `/llms-full.txt` | Static file pointing LLMs to use `llms.txt` instead |
| `/<any-doc-page>.md` | Per-page clean markdown (e.g., `/tokens/hnt-token.md`) |

## Test plan
- [ ] `yarn build` completes without errors
- [ ] `/llms.txt` is well-structured with all doc pages listed
- [ ] Per-page `.md` files are accessible (e.g., `/tokens/hnt-token.md`)
- [ ] `/llms-full.txt` returns a 200 with redirect instructions
- [ ] Devblog content is excluded from output
- [ ] Main HTML docs still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)