### PR TITLE
Add static llms-full.txt redirect

### DIFF
--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,0 +1,8 @@
+# Helium Documentation
+
+> This file is intentionally minimal. Helium docs span multiple distinct domains (IoT/LoRaWAN, Mobile/5G/WiFi, tokens, wallets, network data) and a single concatenated file would be difficult to navigate.
+
+## How to use these docs
+
+- Start with [llms.txt](https://docs.helium.com/llms.txt) for a structured index of all documentation pages with descriptions.
+- Each page listed in llms.txt links to an individual markdown file you can fetch directly.


### PR DESCRIPTION
## Summary
- Adds a static `llms-full.txt` that directs LLMs to use `llms.txt` instead
- Prevents 404s when LLMs look for `llms-full.txt` by default (observed in testing)
- A concatenated full file would confusingly mash together unrelated domains (IoT, Mobile, tokens, wallets), so we intentionally skip generating one and point to the structured index instead

## Test plan
- [x] `/llms-full.txt` returns 200 with instructions to use `llms.txt`
- [x] No interference with the plugin-generated `/llms.txt` or per-page `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)