### PR TITLE
Rename onboarding page slug from helium-plus to wifi-conversion

### DIFF
--- a/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
@@ -16,7 +16,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 - **RouterOS v7** device running CAPsMAN 2 (tested on **7.18.1**)
 - [RadSecProxy](https://github.com/novalabsxyz/radsec-proxy) container running in your network.
 - For self-serve, CLI wallet prepared for onboarding:
-  [https://docs.helium.com/mobile/helium-plus-onboarding/](https://docs.helium.com/mobile/helium-plus-onboarding/)
+  [https://docs.helium.com/mobile/wifi-conversion-onboarding/](https://docs.helium.com/mobile/wifi-conversion-onboarding/)
 - For Helium Plus, certificates ( `ca.pem`, `cert.pem`, `key.pem` ) supplied by the Helium Plus team
   and copied into the RadSecProxy directory.
 - UDP ports **1812/1813** open between MikroTik and the RadSecProxy host.

--- a/docs/network-mobile/helium-plus-guides/helium-plus-onboarding.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-onboarding.mdx
@@ -7,7 +7,7 @@ description:
   Self-serve onboarding of a converted Wi-Fi network, including token fees, key generation, and
   RADIUS certificate setup.
 image: https://docs.helium.com/img/link-image.png
-slug: /mobile/helium-plus-onboarding
+slug: /mobile/wifi-conversion-onboarding
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'

--- a/docs/network-mobile/helium-plus-guides/helium-plus-ubiquiti.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-ubiquiti.mdx
@@ -48,8 +48,8 @@ Navigate to **UniFi Devices**, choose your **Network Controller** and copy the *
 </figure>
 <br />
 
-Use this NAS-ID in the [WiFi Conversion Onboarding](/mobile/helium-plus-onboarding) flow and return
-to this guide after the network is onboarded and certificates have been delivered.
+Use this NAS-ID in the [WiFi Conversion Onboarding](/mobile/wifi-conversion-onboarding) flow and
+return to this guide after the network is onboarded and certificates have been delivered.
 
 :::important If updating from older RadSec certificates:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -144,8 +144,13 @@
   status = 301
   force = true
 [[redirects]]
+  from = "/mobile/helium-plus-onboarding"
+  to = "/mobile/wifi-conversion-onboarding"
+  status = 301
+  force = true
+[[redirects]]
   from = "/mobile/data-only-onboarding"
-  to = "/mobile/helium-plus-onboarding"
+  to = "/mobile/wifi-conversion-onboarding"
   status = 301
   force = true
 [[redirects]]


### PR DESCRIPTION
## Summary

- Renames slug `/mobile/helium-plus-onboarding` to `/mobile/wifi-conversion-onboarding` to reflect that this is a self-serve flow, not a "Helium Plus" feature
- Adds 301 redirect from the old slug in `netlify.toml` (existing `data-only-onboarding` redirect also updated to point to the new slug)
- Updates internal cross-references in `helium-plus-mikrotik.mdx` and `helium-plus-ubiquiti.mdx`