### PR TITLE
Update Mobile data-transfer rate to $0.10/GB

### DIFF
--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -67,12 +67,11 @@ cannot be redelegated.
 ## Data Credits and Mobile {#dc-and-mobile}
 
 The Helium Mobile Network leverages DCs as the sole mechanism of billing and fee management. The
-Mobile Network charges data at a rate of **$0.50 per 1 gigabyte** (50,000 DC).
+Mobile Network charges data at a rate of **$0.10 per 1 gigabyte** (10,000 DC).
 
 On cellular networks, it is customary that network operators bill for bulk data rather than for
-individual packets. By setting the data cost to \$0.50 per gigabyte, the Helium Mobile network
-positions itself competitively in the marketplace while preserving valuable rewards for the Mobile
-Hotspot operator.
+individual packets. The \$0.10 per gigabyte rate reflects current commercial offload rates and
+positions the Helium Mobile network competitively in the marketplace.
 
 ### Mobile Protocol Fees
 


### PR DESCRIPTION
Updates the documented Mobile data-transfer rate from $0.50/GB to $0.10/GB to match helium/oracles#1204.