### PR TITLE
Point editUrl at main after master→main rename

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebarsDocs.js'),
           routeBasePath: '/',
           // Please change this to your repo.
-          editUrl: 'https://github.com/helium/docs/edit/master',
+          editUrl: 'https://github.com/helium/docs/edit/main',
           remarkPlugins: [math],
           rehypePlugins: [katex],
         },


### PR DESCRIPTION
Renaming the default branch `master` → `main` left `editUrl` pointing at `…/edit/master` — a branch that no longer exists — so every "Edit this page" link in the docs now 404s.

This updates the branch segment to `main`. One-line change in `docusaurus.config.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)