### PR TITLE
Remove stray yarn dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "react-icons": "^5.4.0",
     "react-table": "^7.8.0",
     "rehype-katex": "^7.0.1",
-    "remark-math": "6.0.0",
-    "yarn": "^1.22.21"
+    "remark-math": "6.0.0"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11979,11 +11979,6 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yarn@^1.22.21:
-  version "1.22.22"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
-  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==
-
 yocto-queue@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"


### PR DESCRIPTION
## What

Removes the `yarn` package from `dependencies` in `package.json` (and prunes its `yarn.lock` entry).

## Why

`yarn` was listed under `dependencies`, which installed the yarn CLI into `node_modules` for no reason. yarn is the **package manager** — already pinned via the `packageManager` field (`yarn@1.22.21`) and `.nvmrc` — not a library the project imports. Nothing in the codebase references it:

```
$ grep -rn -E "from 'yarn'|require\('yarn'\)|require(\"yarn\")" . (excluding node_modules/build)
# no matches
```

## Changes

- `package.json`: drop `"yarn": "^1.22.21"` from `dependencies`.
- `yarn.lock`: prune the corresponding `yarn@^1.22.21` entry (5 lines). No other dependencies bumped — the lockfile diff is limited to removing this single package.

## Verification

Done via `yarn remove yarn` (not a full reinstall), then a production build under the pinned toolchain (Node 20.19.5, Yarn 1.22.21):

```
$ yarn build   # node scripts/build-redirects.mjs && docusaurus build
build-redirects: wrote 96 lines to static/_redirects from 48 source rules
[webpackbar] ✔ Server: Compiled successfully
[webpackbar] ✔ Client: Compiled successfully
[SUCCESS] Generated static files in "build".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)