### PR TITLE
Update contributor docs for Yarn 4 + Corepack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,14 @@ Docusaurus documentation site for the Helium Network.
 
 ## Local Development
 
+This repo uses **Yarn 4 (Berry)** (managed by Corepack) and the Node version pinned in `.nvmrc`:
+
 ```sh
-npm install
-npm run start          # starts on port 3000
-npm run build          # production build
+nvm use                # Node version from .nvmrc
+corepack enable        # one-time: activates the pinned Yarn (yarn@4.x)
+yarn install
+yarn start             # starts on port 3000
+yarn build             # production build
 ```
 
 ## Project Structure
@@ -22,13 +26,13 @@ npm run build          # production build
 All `.mdx` files are formatted with **Prettier** on save. Before committing, run:
 
 ```sh
-npx prettier --check 'docs/**/*.mdx'
+yarn dlx prettier --check 'docs/**/*.mdx'
 ```
 
 To auto-fix:
 
 ```sh
-npx prettier --write 'docs/**/*.mdx'
+yarn dlx prettier --write 'docs/**/*.mdx'
 ```
 
 Prettier config (`.prettierrc`):

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Documentation for the Helium network.
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/en/download) version >= 10.15.1
+- [Node.js](https://nodejs.org/en/download) — use the version pinned in [`.nvmrc`](.nvmrc) (run `nvm use`)
 
-- [Yarn](https://yarnpkg.com/getting-started/install) version >= 1.5
+- [Yarn](https://yarnpkg.com/) 4 (Berry) — managed automatically by [Corepack](https://nodejs.org/api/corepack.html), which ships with Node. Run `corepack enable` once; no separate Yarn install needed.
 
 ## Helium Documentation Installation Guide
 
@@ -21,7 +21,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more instructions.
 ## Creating a New Doc
 
 When authoring a new doc, be sure to apply `prettier` to it during review. For example:
-`npx prettier --write --prose-wrap always docs/blockchain/new_doc.mdx`
+`yarn dlx prettier --write --prose-wrap always docs/blockchain/new_doc.mdx`
 
 It will apply appropriate line wraps and other formatting niceties.
 


### PR DESCRIPTION
## What

The repo migrated to **Yarn 4 (Berry)** via Corepack (#2069), so the contributor setup docs were stale (they still said `npm` / "Yarn >= 1.5" / "Node >= 10.15.1").

- **CLAUDE.md** Local Development: `npm install` / `npm run …` → `nvm use` + `corepack enable` + `yarn install` / `yarn start` / `yarn build`; Prettier invoked via `yarn dlx`.
- **README.md** Requirements: replace `Node >= 10.15.1` / `Yarn >= 1.5` with a pointer to `.nvmrc` for Node and Corepack-managed Yarn 4; the `npx prettier` example → `yarn dlx prettier`.

## Note

The README points at **`.nvmrc`** rather than hardcoding a Node version, so it stays accurate across Node bumps (e.g. a separate Node-24 PR needs no doc change here).

Docs-only — no build/toolchain impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)