### PR TITLE
README: fix the 404 Installation Guide link + other dead/stale refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ Documentation for the Helium network.
 
 - [Yarn](https://yarnpkg.com/) 4 (Berry) — managed automatically by [Corepack](https://nodejs.org/api/corepack.html), which ships with Node. Run `corepack enable` once; no separate Yarn install needed.
 
-## Helium Documentation Installation Guide
+## Running the docs locally
 
-- [Installation Guide](https://docs.helium.com/faq/docs-installation/)
+```sh
+git clone https://github.com/helium/docs.git
+cd docs
+nvm use                # Node version from .nvmrc
+corepack enable        # one-time: activates the pinned Yarn (yarn@4.x)
+yarn install
+yarn start             # dev server at http://localhost:3000
+yarn build             # production build
+```
 
 ## Contributing
 
@@ -21,7 +29,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more instructions.
 ## Creating a New Doc
 
 When authoring a new doc, be sure to apply `prettier` to it during review. For example:
-`yarn dlx prettier --write --prose-wrap always docs/blockchain/new_doc.mdx`
+`yarn dlx prettier --write --prose-wrap always docs/network-iot/new-doc.mdx`
 
 It will apply appropriate line wraps and other formatting niceties.
 
@@ -34,10 +42,10 @@ changes and make review more difficult.
 Instead, from time to time, `prettier` will be run against the documents and those unimportant
 commits will be added to `.git-blame-ignore-revs`
 
-Use the style guide found [here](docs/style-guide.md) to learn what markdown syntax is available.
+Use the style guide found [here](docs/home/style-guide.mdx) to learn what markdown syntax is available.
 
 For more advanced content consider using
-[JSX](https://v2.docusaurus.io/docs/markdown-features/#embedding-react-components-with-mdx).
+[JSX](https://docusaurus.io/docs/markdown-features/#embedding-react-components-with-mdx).
 
 ## Linking to Other Docs
 
@@ -115,7 +123,7 @@ slug: network-iot/devices
 ## Sidebar Links
 
 Learn how to create sidebar links
-[here](https://v2.docusaurus.io/docs/docs-introduction/#sidebar-object).
+[here](https://docusaurus.io/docs/docs-introduction/#sidebar-object).
 
 ### Category Type
 
@@ -123,5 +131,5 @@ When adding items use the raw id path, slug paths will not work.
 
 ## Attribution
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website
 generator.


### PR DESCRIPTION
## What

Fixes the reported **404** and the other dead/stale references the earlier docs pass (#2070) missed. These slipped through because `onBrokenLinks: 'throw'` only validates *internal* doc links — README external links and file paths are never checked.

| Issue | Before | After |
|---|---|---|
| **Reported 404** | `[Installation Guide](https://docs.helium.com/faq/docs-installation/)` → **HTTP 404** (page removed, no redirect) | replaced with a real **`## Running the docs locally`** block (clone + `nvm use` + `corepack enable` + `yarn install`/`start`/`build`) |
| Wrong style-guide path | `docs/style-guide.md` (missing) | `docs/home/style-guide.mdx` (actual file) |
| Stale Docusaurus links ×3 | `v2.docusaurus.io/…` (301→docusaurus.io) | `docusaurus.io/…` |
| Stale version label | "Docusaurus 2" | "Docusaurus" (site runs 3.9.2) |
| Bad example path | `docs/blockchain/new_doc.mdx` (no such section) | `docs/network-iot/new-doc.mdx` |

## Why inline setup steps

`/faq/docs-installation/` is gone with no redirect, and `CONTRIBUTING.md` covers only *how* to contribute (fork/PR/issues), not local setup — so the "install the docs locally" content didn't exist anywhere. Inlining the steps makes the README self-sufficient and kills the dead link for good.

## Verification

- `https://docs.helium.com/faq/docs-installation/` → confirmed **HTTP 404** (WebFetch).
- `v2.docusaurus.io` → confirmed **301 → docusaurus.io**.
- Repo grep confirms **0** remaining `v2.docusaurus` / `docs-installation` / `docs/style-guide.md` / "Docusaurus 2" references.
- Docs-only; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)