### PR TITLE
MikroTik guide: document full Passpoint / Interworking profile

### DIFF
--- a/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
@@ -135,7 +135,10 @@ the NAS-ID provided during Helium Plus onboarding.
 
 #### Interworking Tab
 
-Fill in as shown:
+The Interworking (Passpoint / Hotspot 2.0) profile is what advertises the Helium
+realms and carrier network identifiers over ANQP. If this profile is incomplete, handsets
+will see the SSID but silently fail to associate — so make sure the domain names, NAI realms,
+and 3GPP cellular network information below are all present.
 
 <figure className="screensnippet-wrapper">
   <img
@@ -144,6 +147,78 @@ Fill in as shown:
     className="add-border-radius add-shadow add-shadow-margin"
   />
 </figure>
+
+Fill in the profile as follows:
+
+| Field                       | Value                                                     |
+| --------------------------- | --------------------------------------------------------- |
+| **ANQP Domain ID**          | `0`                                                       |
+| **Network Type**            | `2` (chargeable public network), access to internet       |
+| **Operator Name**           | `Helium-Operator` (language code `eng`)                   |
+| **IP Address Type**         | IPv4 available (`ip-type ipv4 2`), IPv6 not available      |
+| **Domain Names**            | `freedomfi.com`, `hellohelium.com`                        |
+
+**NAI Realms** — the Helium-issued credentials use EAP-TLS (`13`); the SIM-based carrier
+realms use EAP-AKA (`23`):
+
+| Realm                                  | EAP method   |
+| -------------------------------------- | ------------ |
+| `freedomfi.com`                        | `13` EAP-TLS |
+| `hellohelium.com`                      | `13` EAP-TLS |
+| `wlan.mnc260.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
+| `wlan.mnc530.mcc312.3gppnetwork.org`   | `23` EAP-AKA |
+| `wlan.mnc120.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
+| `wlan.mnc240.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
+
+**3GPP Cellular Network Information** (PLMN, MCC / MNC):
+
+| MCC   | MNC   |
+| ----- | ----- |
+| `310` | `410` |
+| `310` | `280` |
+| `310` | `150` |
+| `313` | `100` |
+
+##### Equivalent RouterOS CLI
+
+The same profile can be applied from the CLI. This is a known-good Helium Passpoint profile —
+substitute your onboarding `NAS-Identifier` on the `aaa attribute` line:
+
+```
+hotspot profile Helium-profile
+hotspot profile Helium-profile anqp-domain-id 0
+hotspot profile Helium-profile network-type 2 access-internet
+hotspot profile Helium-profile operator-name Helium-Operator language-code eng
+hotspot profile Helium-profile ip-type ipv4 2 ipv6 0
+hotspot profile Helium-profile domain-name freedomfi.com
+hotspot profile Helium-profile domain-name hellohelium.com
+hotspot profile Helium-profile nai-realm freedomfi.com encoding-type 0
+hotspot profile Helium-profile nai-realm freedomfi.com eap-method 13
+hotspot profile Helium-profile nai-realm hellohelium.com encoding-type 0
+hotspot profile Helium-profile nai-realm hellohelium.com eap-method 13
+hotspot profile Helium-profile nai-realm wlan.mnc260.mcc310.3gppnetwork.org encoding-type 0
+hotspot profile Helium-profile nai-realm wlan.mnc260.mcc310.3gppnetwork.org eap-method 23
+hotspot profile Helium-profile nai-realm wlan.mnc530.mcc312.3gppnetwork.org encoding-type 0
+hotspot profile Helium-profile nai-realm wlan.mnc530.mcc312.3gppnetwork.org eap-method 23
+hotspot profile Helium-profile nai-realm wlan.mnc120.mcc310.3gppnetwork.org encoding-type 0
+hotspot profile Helium-profile nai-realm wlan.mnc120.mcc310.3gppnetwork.org eap-method 23
+hotspot profile Helium-profile nai-realm wlan.mnc240.mcc310.3gppnetwork.org encoding-type 0
+hotspot profile Helium-profile nai-realm wlan.mnc240.mcc310.3gppnetwork.org eap-method 23
+hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 410
+hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 280
+hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 150
+hotspot profile Helium-profile 3gpp-plmn mcc 313 mnc 100
+security-object Helium security protocol-suite wpa3-aes-8021x
+aaa attribute NAS-Identifier <your-nas-id>
+ssid Helium hotspot-profile Helium-profile
+save configuration
+```
+
+:::note Native RadSec + Orion Wi-Fi
+Newer RouterOS releases support RadSec natively (removing the need for the RadSecProxy
+container in step 1) and document the matching Passpoint / Orion Wi-Fi setup. See MikroTik's
+[Interworking Profiles — Configuration guide using native RadSec and Orion Wi-Fi](https://help.mikrotik.com/docs/spaces/ROS/pages/7962628/Interworking+Profiles#InterworkingProfiles-ConfigurationguideusingnativeRadSecandOrionWifi).
+:::
 
 ### 4. Attach the Profile to an Interface
 

--- a/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
@@ -135,10 +135,10 @@ the NAS-ID provided during Helium Plus onboarding.
 
 #### Interworking Tab
 
-The Interworking (Passpoint / Hotspot 2.0) profile is what advertises the Helium
-realms and carrier network identifiers over ANQP. If this profile is incomplete, handsets
-will see the SSID but silently fail to associate — so make sure the domain names, NAI realms,
-and 3GPP cellular network information below are all present.
+The Interworking (Passpoint / Hotspot 2.0) profile is what advertises the Helium realms and carrier
+network identifiers over ANQP. If this profile is incomplete, handsets will see the SSID but
+silently fail to associate — so make sure the domain names, NAI realms, and 3GPP cellular network
+information are all present.
 
 <figure className="screensnippet-wrapper">
   <img
@@ -150,39 +150,35 @@ and 3GPP cellular network information below are all present.
 
 Fill in the profile as follows:
 
-| Field                       | Value                                                     |
-| --------------------------- | --------------------------------------------------------- |
-| **ANQP Domain ID**          | `0`                                                       |
-| **Network Type**            | `2` (chargeable public network), access to internet       |
-| **Operator Name**           | `Helium-Operator` (language code `eng`)                   |
-| **IP Address Type**         | IPv4 available (`ip-type ipv4 2`), IPv6 not available      |
-| **Domain Names**            | `freedomfi.com`, `hellohelium.com`                        |
+| Field               | Value                                                 |
+| ------------------- | ----------------------------------------------------- |
+| **ANQP Domain ID**  | `0`                                                   |
+| **Network Type**    | `2` (chargeable public network), access to internet   |
+| **Operator Name**   | `Helium-Operator` (language code `eng`)               |
+| **IP Address Type** | IPv4 available (`ip-type ipv4 2`), IPv6 not available |
+| **Domain Names**    | `freedomfi.com`, `hellohelium.com`                    |
 
-**NAI Realms** — the Helium-issued credentials use EAP-TLS (`13`); the SIM-based carrier
-realms use EAP-AKA (`23`):
+**NAI Realms** — the Helium-issued credentials use EAP-TLS (`13`):
 
-| Realm                                  | EAP method   |
-| -------------------------------------- | ------------ |
-| `freedomfi.com`                        | `13` EAP-TLS |
-| `hellohelium.com`                      | `13` EAP-TLS |
-| `wlan.mnc260.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
-| `wlan.mnc530.mcc312.3gppnetwork.org`   | `23` EAP-AKA |
-| `wlan.mnc120.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
-| `wlan.mnc240.mcc310.3gppnetwork.org`   | `23` EAP-AKA |
+| Realm             | EAP method   |
+| ----------------- | ------------ |
+| `freedomfi.com`   | `13` EAP-TLS |
+| `hellohelium.com` | `13` EAP-TLS |
+
+Add a further realm for each carrier your site is approved to offload. Those are SIM-based, so they
+use EAP-AKA (`23`) and take the form `wlan.mnc<mnc>.mcc<mcc>.3gppnetwork.org`. The realms and their
+MCC / MNC values are provided to you during Helium Plus onboarding.
 
 **3GPP Cellular Network Information** (PLMN, MCC / MNC):
 
-| MCC   | MNC   |
-| ----- | ----- |
-| `310` | `410` |
-| `310` | `280` |
-| `310` | `150` |
-| `313` | `100` |
+Add one PLMN entry per approved carrier, using the same MCC / MNC pairs as the realms above. Reach
+out to your Helium Plus contact if you do not have them.
 
 ##### Equivalent RouterOS CLI
 
 The same profile can be applied from the CLI. This is a known-good Helium Passpoint profile —
-substitute your onboarding `NAS-Identifier` on the `aaa attribute` line:
+substitute your onboarding `NAS-Identifier` on the `aaa attribute` line, and your onboarding carrier
+realms and MCC / MNC pairs on the `nai-realm` and `3gpp-plmn` lines:
 
 ```
 hotspot profile Helium-profile
@@ -196,18 +192,10 @@ hotspot profile Helium-profile nai-realm freedomfi.com encoding-type 0
 hotspot profile Helium-profile nai-realm freedomfi.com eap-method 13
 hotspot profile Helium-profile nai-realm hellohelium.com encoding-type 0
 hotspot profile Helium-profile nai-realm hellohelium.com eap-method 13
-hotspot profile Helium-profile nai-realm wlan.mnc260.mcc310.3gppnetwork.org encoding-type 0
-hotspot profile Helium-profile nai-realm wlan.mnc260.mcc310.3gppnetwork.org eap-method 23
-hotspot profile Helium-profile nai-realm wlan.mnc530.mcc312.3gppnetwork.org encoding-type 0
-hotspot profile Helium-profile nai-realm wlan.mnc530.mcc312.3gppnetwork.org eap-method 23
-hotspot profile Helium-profile nai-realm wlan.mnc120.mcc310.3gppnetwork.org encoding-type 0
-hotspot profile Helium-profile nai-realm wlan.mnc120.mcc310.3gppnetwork.org eap-method 23
-hotspot profile Helium-profile nai-realm wlan.mnc240.mcc310.3gppnetwork.org encoding-type 0
-hotspot profile Helium-profile nai-realm wlan.mnc240.mcc310.3gppnetwork.org eap-method 23
-hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 410
-hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 280
-hotspot profile Helium-profile 3gpp-plmn mcc 310 mnc 150
-hotspot profile Helium-profile 3gpp-plmn mcc 313 mnc 100
+# Then, per approved carrier, using the realm and MCC / MNC from your onboarding:
+hotspot profile Helium-profile nai-realm wlan.mnc<mnc>.mcc<mcc>.3gppnetwork.org encoding-type 0
+hotspot profile Helium-profile nai-realm wlan.mnc<mnc>.mcc<mcc>.3gppnetwork.org eap-method 23
+hotspot profile Helium-profile 3gpp-plmn mcc <mcc> mnc <mnc>
 security-object Helium security protocol-suite wpa3-aes-8021x
 aaa attribute NAS-Identifier <your-nas-id>
 ssid Helium hotspot-profile Helium-profile
@@ -215,9 +203,11 @@ save configuration
 ```
 
 :::note Native RadSec + Orion Wi-Fi
-Newer RouterOS releases support RadSec natively (removing the need for the RadSecProxy
-container in step 1) and document the matching Passpoint / Orion Wi-Fi setup. See MikroTik's
+
+Newer RouterOS releases support RadSec natively (removing the need for the RadSecProxy container in
+step 1) and document the matching Passpoint / Orion Wi-Fi setup. See MikroTik's
 [Interworking Profiles — Configuration guide using native RadSec and Orion Wi-Fi](https://help.mikrotik.com/docs/spaces/ROS/pages/7962628/Interworking+Profiles#InterworkingProfiles-ConfigurationguideusingnativeRadSecandOrionWifi).
+
 :::
 
 ### 4. Attach the Profile to an Interface


### PR DESCRIPTION
## What

Expands the **Interworking Tab** section of the MikroTik Helium Plus conversion guide (`docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx`).

Previously this section said only *"Fill in as shown"* next to a screenshot, and never listed the ANQP domain names, NAI realms, or 3GPP PLMN (MCC/MNC) values that the Passpoint / Hotspot 2.0 profile has to advertise.

## Why

An incomplete Interworking profile lets a handset discover the `Helium` SSID but then **silently fail to associate**. This showed up in the field as Google Orion / WeFi devices not connecting on MikroTik H+ deployments that were otherwise working for Helium Mobile hotspots — the profile was missing the required realms/PLMNs.

## Changes

- Document the known-good profile as a set of GUI field tables:
  - ANQP domain ID, network type, operator name, IP address type, domain names
  - NAI realms with their EAP method (EAP-TLS `13` for the Helium-issued credentials, EAP-AKA `23` for the SIM-based carrier realms)
  - 3GPP cellular network information (PLMN MCC/MNC)
- Add the **equivalent RouterOS CLI** for the same profile (operators just substitute their onboarding `NAS-Identifier`).
- Add a note that newer RouterOS supports **RadSec natively** and link MikroTik's [Interworking Profiles — native RadSec and Orion Wi-Fi guide](https://help.mikrotik.com/docs/spaces/ROS/pages/7962628/Interworking+Profiles#InterworkingProfiles-ConfigurationguideusingnativeRadSecandOrionWifi).

No other sections changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)