### PR TITLE
docs: fix gateway_key.bin filename in on-device onboarding

### DIFF
--- a/docs/network-iot/hotspots-iot/on-device-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/on-device-onboarding.mdx
@@ -147,7 +147,8 @@ onboarding process.
 
 ### First Run
 
-With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the gateway_key.bin in /etc/helium_gateway/,`sudo` may be required on first run to create the key file.
+With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the
+gateway_key.bin in /etc/helium_gateway/,`sudo` may be required on first run to create the key file.
 
 ```sh title="Generate a swarm_key by running gateway-rs."
 sudo helium_gateway server

--- a/docs/network-iot/hotspots-iot/on-device-onboarding.mdx
+++ b/docs/network-iot/hotspots-iot/on-device-onboarding.mdx
@@ -147,8 +147,7 @@ onboarding process.
 
 ### First Run
 
-With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the
-gateway_key in /etc/helium_gateway/, `sudo` may be required on first run to create the key file.
+With gateway-rs installed on the gateway, initialize the key for the Hotspot. If creating the gateway_key.bin in /etc/helium_gateway/,`sudo` may be required on first run to create the key file.
 
 ```sh title="Generate a swarm_key by running gateway-rs."
 sudo helium_gateway server


### PR DESCRIPTION
First contribution - spotted this inconsistency while following the onboarding guide. The .bin extension appears consistently elsewhere on the page (settings.toml example, Prepare Gateway-rs section), so this aligns the documentation. Happy to help with any other docs cleanup!