### PR TITLE
Helium+ guides: correct the RadSecProxy archive filename

### DIFF
--- a/docs/network-mobile/helium-plus-guides/helium-plus-Cisco-WLC-5520.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-Cisco-WLC-5520.mdx
@@ -47,15 +47,15 @@ the UDP is then converted to a TLS protected TCP connection to the Helium Networ
 
 ## Container Deployment
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into the directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into the directory of your choice on the
    host machine. This will unpack the following items:
    1. `Dockerfile` \- The docker instructions on how to build the container
-   2. `Radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
+   2. `radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
       Network AAA servers
    3. `docker-compose.yml` \- File to start and stop the container as a daemon.
 
 ```bash
-tar -xvzf Helium_RadSec_Docker.tar.gz
+tar -xvzf radsec-proxy-main.tar.gz
 ```
 
 2. Into the same directory copy the 3 certificates obtained from Helium Network

--- a/docs/network-mobile/helium-plus-guides/helium-plus-Cisco-WLC-9800.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-Cisco-WLC-9800.mdx
@@ -51,15 +51,15 @@ the UDP is then converted to a TLS protected TCP connection to the Helium Networ
 
 ## Container Deployment
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into the directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into the directory of your choice on the
    host machine. This will unpack the following items:
    1. `Dockerfile` \- The docker instructions on how to build the container
-   2. `Radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
+   2. `radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
       Network AAA servers
    3. `docker-compose.yml` \- File to start and stop the container as a daemon.
 
 ```bash
-tar -xvzf Helium_RadSec_Docker.tar.gz
+tar -xvzf radsec-proxy-main.tar.gz
 ```
 
 2. Into the same directory copy the 3 certificates obtained from Helium Network

--- a/docs/network-mobile/helium-plus-guides/helium-plus-aruba.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-aruba.mdx
@@ -54,15 +54,15 @@ the UDP is then converted to a TLS protected TCP connection to the Helium Networ
 
 ## Container Deployment
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into the directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into the directory of your choice on the
    host machine. This will unpack the following items:
    1. `Dockerfile` \- The docker instructions on how to build the container
-   2. `Radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
+   2. `radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
       Network AAA servers
    3. `docker-compose.yml` \- File to start and stop the container as a daemon.
 
 ```bash
-tar -xvzf  Helium_RadSec_Docker.tar.gz
+tar -xvzf  radsec-proxy-main.tar.gz
 ```
 
 2. Into the same directory copy the 3 certificates obtained from Helium Network

--- a/docs/network-mobile/helium-plus-guides/helium-plus-cambium-cnmaestro.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-cambium-cnmaestro.mdx
@@ -48,7 +48,7 @@ Network core AAA servers.
 Unzip and untar the Helium RadSec Docker package:
 
 ```bash
-tar -xvzf Helium_RadSec_Docker.tar.gz
+tar -xvzf radsec-proxy-main.tar.gz
 ```
 
 This will unpack:

--- a/docs/network-mobile/helium-plus-guides/helium-plus-extreme.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-extreme.mdx
@@ -49,14 +49,14 @@ the UDP is then converted to a TLS protected TCP connection to the Helium Networ
 
 ### RadSecProxy Container Deployment
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into a directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into a directory of your choice on the
    host machine. This will unpack:
    - `Dockerfile` - The Docker instructions to build the container
-   - `Radsecproxy.conf` - Pre-populated to connect to Helium Network AAA servers
+   - `radsecproxy.conf` - Pre-populated to connect to Helium Network AAA servers
    - `docker-compose.yml` - File to start and stop the container as a daemon
 
    ```bash
-   tar -xvzf Helium_RadSec_Docker.tar.gz
+   tar -xvzf radsec-proxy-main.tar.gz
    ```
 
 2. Into the same directory, copy the 3 certificates obtained from Helium Network:

--- a/docs/network-mobile/helium-plus-guides/helium-plus-fortinet.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-fortinet.mdx
@@ -23,17 +23,17 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 
 #### RadSecProxy Container Deployment
 
-1. Un-zip and untar the [`Helium_RadSec_Docker.tar.gz`](https://github.com/novalabsxyz/radsec-proxy)
+1. Un-zip and untar the [`radsec-proxy-main.tar.gz`](https://github.com/novalabsxyz/radsec-proxy)
    file into the directory of your choice on the host machine.
 
 ```shell
-tar -xvzf  Helium_RadSec_Docker.tar.gz
+tar -xvzf  radsec-proxy-main.tar.gz
 ```
 
 This will unpack the following items:
 
     1. Dockerfile - The docker instructions on how to build the container
-    1. Radsecproxy.conf - The radsecproxy config file is pre-populated to connect to Helium Network AAA servers
+    1. radsecproxy.conf - The radsecproxy config file is pre-populated to connect to Helium Network AAA servers
     1. docker-compose.yml - File to start and stop the container as a daemon.
 
 Into the same directory, copy the 3 certificates obtained from Helium

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
@@ -47,15 +47,15 @@ the UDP is then converted to a TLS protected TCP connection to the Helium Networ
 
 ## Container Deployment
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into the directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into the directory of your choice on the
    host machine. This will unpack the following items:
    1. `Dockerfile` \- The docker instructions on how to build the container
-   2. `Radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
+   2. `radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
       Network AAA servers
    3. `docker-compose.yml` \- File to start and stop the container as a daemon.
 
 ```bash
-tar -xvzf Helium_RadSec_Docker.tar.gz
+tar -xvzf radsec-proxy-main.tar.gz
 ```
 
 2. Into the same directory copy the 3 certificates obtained from Helium Network

--- a/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-mikrotik.mdx
@@ -35,15 +35,15 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 At time of writing, RouterOS does not support RadSec natively, download the
 [RadSecProxy](https://github.com/novalabsxyz/radsec-proxy) container and run it in a Docker.
 
-1. Un-zip and untar the `Helium_RadSec_Docker.tar.gz` file into the directory of your choice on the
+1. Un-zip and untar the `radsec-proxy-main.tar.gz` file into the directory of your choice on the
    host machine. This will unpack the following items:
    1. `Dockerfile` \- The docker instructions on how to build the container
-   2. `Radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
+   2. `radsecproxy.conf` \- The radsecproxy config file is pre-populated to connect to Helium
       Network AAA servers
    3. `docker-compose.yml` \- File to start and stop the container as a daemon.
 
 ```bash
-tar -xvzf  Helium_RadSec_Docker.tar.gz
+tar -xvzf  radsec-proxy-main.tar.gz
 ```
 
 2. Into the same directory copy the 3 certificates obtained from Helium Network


### PR DESCRIPTION
## Problem

Eight Helium+ vendor guides tell operators to un-tar `Helium_RadSec_Docker.tar.gz`. That filename isn't published anywhere, so there's nothing to download.

Raised in [#deployment-support](https://novaxyz.slack.com/archives/C073ML27GUU/p1785951895409159?thread_ts=1766162232.511269) — flagged in Dec 2025, still live.

## Fix

Just the filename. Downloading the archive from [`novalabsxyz/radsec-proxy`](https://github.com/novalabsxyz/radsec-proxy) gives `radsec-proxy-main.tar.gz` (GitHub names it after the repo and branch), so the guides now say that:

```bash
tar -xvzf radsec-proxy-main.tar.gz
```

Everything else is untouched — same un-tar step, same file list, same certificate and `docker compose up -d` steps, same prerequisites.

Also corrects `Radsecproxy.conf` → `radsecproxy.conf` in the file lists, since that's what the repo actually ships and the capitalized spelling breaks on a case-sensitive filesystem.

## Guides updated

Aruba · Cambium cnMaestro · Cisco WLC 5520 · Cisco WLC 9800 · Extreme · Fortinet · Meraki · MikroTik

## Not fixed here

The **radsec-proxy README has the same stale reference**, spelled `Helium_RadSec_Docker.tag.gz` (note `.tag.gz` — a second typo). [novalabsxyz/radsec-proxy#5](https://github.com/novalabsxyz/radsec-proxy/pull/5) has been open since 2025-12-19 and would fix it. Different repo, so out of scope here.

## Verification

- `rg 'Helium_RadSec_Docker|Radsecproxy\.conf'` over `docs/` → no matches
- Confirmed against GitHub: `content-disposition: attachment; filename=radsec-proxy-main.tar.gz`
- No line-length change; the one 111-char line in the Fortinet guide is pre-existing and identical in length

🤖 Generated with [Claude Code](https://claude.com/claude-code)