### PR TITLE
Read HNT oracle price on-chain in the HNT-to-DC simulator

### DIFF
--- a/docs/tokens/data-credit.mdx
+++ b/docs/tokens/data-credit.mdx
@@ -29,8 +29,8 @@ For further reading on DCs place in the overall mechanics of the Helium network,
 **One Data Credit equals $0.00001 USD.**
 
 The amount of DC produced by burning one HNT will fluctuate based on the USD price of HNT as
-reported by the price provider, [Pyth](https://pyth.network). The tool below demonstrates the
-HNT-to-DC conversion rate based on the price of HNT.
+reported by the on-chain [Pyth](https://pyth.network) price feed used by the Data Credits program.
+The tool below demonstrates the HNT-to-DC conversion rate based on the price of HNT.
 
 import { HntToDcSimulator } from '@theme/HntToDcSimulator'
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@helium/helium-sub-daos-sdk": "^0.6.42",
     "@helium/spl-utils": "^0.6.31",
     "@mdx-js/react": "^3.1.1",
-    "@pythnetwork/price-service-client": "^1.11.0",
     "@solana/spl-token": "^0.3.7",
     "@solana/wallet-adapter-base": "^0.9.27",
     "@solana/wallet-adapter-ledger": "^0.9.29",

--- a/src/theme/HntToDcSimulator.jsx
+++ b/src/theme/HntToDcSimulator.jsx
@@ -1,10 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { PriceServiceConnection } from '@pythnetwork/price-service-client'
+import './bufferFill'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import { Connection, PublicKey } from '@solana/web3.js'
+import { dataCreditsKey } from '@helium/data-credits-sdk'
+import { DC_MINT } from '@helium/spl-utils'
 import styles from './HntToDcSimulator.module.css'
 
 const DC_PRICE = 0.00001 // 1 DC = $0.00001
-const HNT_PRICE_ID = '0x649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756'
-const HERMES_ENDPOINT = 'https://hermes.pyth.network'
+const HNT_PRICE_FEED_ID = '649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756'
+const POLL_INTERVAL_MS = 30_000
+
+// DataCreditsV0 layout: 8-byte discriminator, dc_mint (32), hnt_mint (32),
+// authority (32), then hnt_price_oracle at bytes 104..136.
+const HNT_PRICE_ORACLE_OFFSET = 104
 
 function calculateDc(price) {
   return price / DC_PRICE
@@ -13,36 +21,89 @@ function getRoundedPrice(price) {
   return Math.round(price * 100) / 100
 }
 
+// Parses a Pyth PriceUpdateV2 account: 8-byte discriminator, write_authority (32),
+// verification_level (borsh enum: tag 0 = Partial + u8, tag 1 = Full), then the
+// price message: feed_id (32), price (i64 LE), conf (u64), exponent (i32 LE).
+// Returns the scaled USD price, or null on any mismatch so failures stay silent.
+function parsePriceUpdateV2(data) {
+  try {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+    let offset = 8 + 32
+    const verificationTag = view.getUint8(offset)
+    offset += 1
+    if (verificationTag === 0) {
+      offset += 1
+    } else if (verificationTag !== 1) {
+      return null
+    }
+    const feedId = Array.from(data.subarray(offset, offset + 32))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('')
+    if (feedId !== HNT_PRICE_FEED_ID) {
+      return null
+    }
+    offset += 32
+    const price = view.getBigInt64(offset, true)
+    offset += 8 + 8 // skip conf
+    const exponent = view.getInt32(offset, true)
+    const scaledPrice = Number(price) * 10 ** exponent
+    return Number.isFinite(scaledPrice) && scaledPrice > 0 ? scaledPrice : null
+  } catch {
+    return null
+  }
+}
+
+// Reads the oracle account address from the on-chain DataCreditsV0 account on
+// every poll, so the widget keeps working if the oracle is rotated again.
+async function fetchOracleHntPrice(endpoint) {
+  try {
+    const connection = new Connection(endpoint)
+    const dataCredits = await connection.getAccountInfo(dataCreditsKey(DC_MINT)[0])
+    if (!dataCredits || dataCredits.data.length < HNT_PRICE_ORACLE_OFFSET + 32) {
+      return null
+    }
+    const oracleKey = new PublicKey(
+      dataCredits.data.subarray(HNT_PRICE_ORACLE_OFFSET, HNT_PRICE_ORACLE_OFFSET + 32),
+    )
+    const oracle = await connection.getAccountInfo(oracleKey)
+    return oracle ? parsePriceUpdateV2(oracle.data) : null
+  } catch {
+    return null
+  }
+}
+
 export const HntToDcSimulator = () => {
+  const { siteConfig } = useDocusaurusContext()
   const [liveHntPrice, setLiveHntPrice] = useState(0)
   const [simulatedHntPrice, setSimulatedHntPrice] = useState(1)
   const [sliderRange, setSliderRange] = useState({ min: 0, max: 5 })
   const initialPriceSetRef = useRef(false)
 
   useEffect(() => {
-    const connection = new PriceServiceConnection(HERMES_ENDPOINT, {
-      priceFeedRequestConfig: { binary: false },
-    })
+    const endpoint = siteConfig.customFields.SOLANA_URL
+    if (!endpoint) {
+      return
+    }
+    let cancelled = false
 
-    const handlePriceUpdate = (priceFeed) => {
-      const { price, expo } = priceFeed.price
-      const rawPrice = parseInt(price, 10)
-      const scaledPrice = rawPrice * 10 ** expo
-
-      if (scaledPrice > 0) {
-        setLiveHntPrice(scaledPrice)
-
-        if (!initialPriceSetRef.current) {
-          setInitialSliderValues(scaledPrice)
-          initialPriceSetRef.current = true
-        }
+    const poll = async () => {
+      const price = await fetchOracleHntPrice(endpoint)
+      if (cancelled || price === null) {
+        return
+      }
+      setLiveHntPrice(price)
+      if (!initialPriceSetRef.current) {
+        setInitialSliderValues(price)
+        initialPriceSetRef.current = true
       }
     }
 
-    connection.subscribePriceFeedUpdates([HNT_PRICE_ID], handlePriceUpdate)
+    poll()
+    const interval = setInterval(poll, POLL_INTERVAL_MS)
 
     return () => {
-      connection.closeWebSocket()
+      cancelled = true
+      clearInterval(interval)
     }
   }, [])
 

--- a/src/theme/HntToDcSimulator.jsx
+++ b/src/theme/HntToDcSimulator.jsx
@@ -8,7 +8,10 @@ import styles from './HntToDcSimulator.module.css'
 
 const DC_PRICE = 0.00001 // 1 DC = $0.00001
 const HNT_PRICE_FEED_ID = '649fdd7ec08e8e2a20f425729854e90293dcbe2376abc47197a14da6ff339756'
-const POLL_INTERVAL_MS = 30_000
+
+// Streams the on-chain oracle price (snapshot on connect, then a frame only when
+// the price changes). EventSource reconnects on its own per the server's retry hint.
+const STREAM_URL = 'https://api.heliumtools.org/hnt-price/sse'
 
 // DataCreditsV0 layout: 8-byte discriminator, dc_mint (32), hnt_mint (32),
 // authority (32), then hnt_price_oracle at bytes 104..136.
@@ -53,10 +56,14 @@ function parsePriceUpdateV2(data) {
   }
 }
 
-// Reads the oracle account address from the on-chain DataCreditsV0 account on
-// every poll, so the widget keeps working if the oracle is rotated again.
+// Fallback for when the stream never delivers a price: a single read of the same
+// oracle straight from the chain. Resolves the oracle address from the on-chain
+// DataCreditsV0 account so it stays correct if the oracle is rotated again.
 async function fetchOracleHntPrice(endpoint) {
   try {
+    if (!endpoint) {
+      return null
+    }
     const connection = new Connection(endpoint)
     const dataCredits = await connection.getAccountInfo(dataCreditsKey(DC_MINT)[0])
     if (!dataCredits || dataCredits.data.length < HNT_PRICE_ORACLE_OFFSET + 32) {
@@ -81,14 +88,11 @@ export const HntToDcSimulator = () => {
 
   useEffect(() => {
     const endpoint = siteConfig.customFields.SOLANA_URL
-    if (!endpoint) {
-      return
-    }
     let cancelled = false
+    let fallbackFired = false
 
-    const poll = async () => {
-      const price = await fetchOracleHntPrice(endpoint)
-      if (cancelled || price === null) {
+    const applyPrice = (price) => {
+      if (cancelled || typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
         return
       }
       setLiveHntPrice(price)
@@ -98,12 +102,34 @@ export const HntToDcSimulator = () => {
       }
     }
 
-    poll()
-    const interval = setInterval(poll, POLL_INTERVAL_MS)
+    const source = new EventSource(STREAM_URL)
+    source.onmessage = (event) => {
+      try {
+        // Full /current-shaped snapshot; spot can be null, so read oracle defensively.
+        applyPrice(JSON.parse(event.data)?.oracle?.usd)
+      } catch {
+        // Ignore malformed frames; the next snapshot or the fallback covers us.
+      }
+    }
+    source.onerror = () => {
+      // EventSource reconnects on its own after network-level failures (a fatal
+      // HTTP response closes it for good). Either way, the one-time on-chain read
+      // covers the case where the stream has never delivered a price at all.
+      if (fallbackFired || initialPriceSetRef.current) {
+        return
+      }
+      fallbackFired = true
+      fetchOracleHntPrice(endpoint).then((price) => {
+        // A reconnected stream may have delivered a fresher price in the meantime.
+        if (!initialPriceSetRef.current) {
+          applyPrice(price)
+        }
+      })
+    }
 
     return () => {
       cancelled = true
-      clearInterval(interval)
+      source.close()
     }
   }, [])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,30 +3850,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pythnetwork/price-service-client@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@pythnetwork/price-service-client@npm:1.11.0"
-  dependencies:
-    "@pythnetwork/price-service-sdk": "npm:1.9.0"
-    "@types/ws": "npm:^8.5.3"
-    axios: "npm:^1.5.1"
-    axios-retry: "npm:^4.0.0"
-    isomorphic-ws: "npm:^4.0.1"
-    ts-log: "npm:^2.2.4"
-    ws: "npm:^8.6.0"
-  checksum: 10c0/5e748a5db737a79fffb4d1893e5d8801d39fea3e9cef68870dc9d01667a5c45af2e8022b4aa8da12a7c0e7a49bfd4f6d7467c0dd8f6ee5ac294e95482d3c00e6
-  languageName: node
-  linkType: hard
-
-"@pythnetwork/price-service-sdk@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@pythnetwork/price-service-sdk@npm:1.9.0"
-  dependencies:
-    bn.js: "npm:^5.2.1"
-  checksum: 10c0/4c31dcd133e1e6d35aa7968d1f94833c51fbc6eda77df4f517431ec2378cb775a09f1142795fff621248f529f8a67571d382e06f9ccb91eefb9fd7fe72631b64
-  languageName: node
-  linkType: hard
-
 "@react-native-async-storage/async-storage@npm:^1.17.7":
   version: 1.24.0
   resolution: "@react-native-async-storage/async-storage@npm:1.24.0"
@@ -5864,7 +5840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.2.2, @types/ws@npm:^8.5.3":
+"@types/ws@npm:^8.2.2":
   version: 8.5.14
   resolution: "@types/ws@npm:8.5.14"
   dependencies:
@@ -6509,17 +6485,6 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
-  languageName: node
-  linkType: hard
-
-"axios-retry@npm:^4.0.0":
-  version: 4.5.0
-  resolution: "axios-retry@npm:4.5.0"
-  dependencies:
-    is-retry-allowed: "npm:^2.2.0"
-  peerDependencies:
-    axios: 0.x || 1.x
-  checksum: 10c0/574e7b1bf24aad99b560042d232a932d51bfaa29b5a6d4612d748ed799a6f11a5afb2582792492c55d95842200cbdfbe3454027a8c1b9a2d3e895d13c3d03c10
   languageName: node
   linkType: hard
 
@@ -8582,7 +8547,6 @@ __metadata:
     "@helium/helium-sub-daos-sdk": "npm:^0.6.42"
     "@helium/spl-utils": "npm:^0.6.31"
     "@mdx-js/react": "npm:^3.1.1"
-    "@pythnetwork/price-service-client": "npm:^1.11.0"
     "@solana/spl-token": "npm:^0.3.7"
     "@solana/wallet-adapter-base": "npm:^0.9.27"
     "@solana/wallet-adapter-ledger": "npm:^0.9.29"
@@ -10729,13 +10693,6 @@ __metadata:
   version: 1.0.0
   resolution: "is-regexp@npm:1.0.0"
   checksum: 10c0/34cacda1901e00f6e44879378f1d2fa96320ea956c1bec27713130aaf1d44f6e7bd963eed28945bfe37e600cb27df1cf5207302680dad8bdd27b9baff8ecf611
-  languageName: node
-  linkType: hard
-
-"is-retry-allowed@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "is-retry-allowed@npm:2.2.0"
-  checksum: 10c0/013be4f8a0a06a49ed1fe495242952e898325d496202a018f6f9fb3fb9ac8fe3b957a9bd62463d68299ae35dbbda680473c85a9bcefca731b49d500d3ccc08ff
   languageName: node
   linkType: hard
 
@@ -15936,13 +15893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-log@npm:^2.2.4":
-  version: 2.2.7
-  resolution: "ts-log@npm:2.2.7"
-  checksum: 10c0/2c63a7ccdea6dad774f51ba031d9b8d7242833733a1122e20be7e2817556f8e5691bd589860940068073c3859f8cdd8b99e2f65934b95a3552e97a60066ea7f3
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
@@ -16796,7 +16746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.5.0, ws@npm:^8.6.0":
+"ws@npm:^8.5.0":
   version: 8.18.0
   resolution: "ws@npm:8.18.0"
   peerDependencies:


### PR DESCRIPTION
## What

Rewrites the live-price source for the HNT→DC calculator on [/tokens/data-credit](https://docs.helium.com/tokens/data-credit):

- `src/theme/HntToDcSimulator.jsx` no longer opens a WebSocket to `hermes.pyth.network`. It now subscribes to the keyless [heliumtools.org HNT price stream](https://github.com/jthiller/heliumtools/blob/main/worker/src/tools/hnt-price/README.md) over SSE (`EventSource`, native reconnect): one snapshot on connect, then a frame only when the price changes. The widget displays the stream's `oracle.usd` — the on-chain Pyth price the Data Credits program reads.
- **Fallback:** if the stream errors before ever delivering a price, the widget does a single one-time Solana RPC read of the same oracle — it resolves the current oracle address from the on-chain `DataCreditsV0` account and parses the Pyth `PriceUpdateV2` account directly — so the price still renders with no standing third-party dependency beyond the stream.
- Removes `@pythnetwork/price-service-client` (this widget was its only consumer) and regenerates `yarn.lock`.
- One-sentence prose touch on `docs/tokens/data-credit.mdx` to say the price comes from the on-chain Pyth feed used by the Data Credits program.

UI, CSS, and labels are unchanged.

## Why

Pyth's unauthenticated Hermes endpoint stops serving keyless traffic on **2026-08-18**. After that date the widget's live price would silently die — `liveHntPrice` stays 0 and the "Set Live Oracle Price" button never renders, with no visible error.

Streaming keeps Solana RPC load at zero in the steady state (no per-tab polling), while the on-chain fallback keeps the widget self-sufficient if the stream is unreachable. Both paths track oracle rotations automatically: the stream serves whatever account `DataCreditsV0` points at, and the fallback resolves that pointer itself — which is how the widget already followed the [helium/helium-program-library#1207](https://github.com/helium/helium-program-library/pull/1207) cutover (old `4Ddm…J33` → new `He5m…89A5`, executed on mainnet) with no docs change.

## Notes for reviewers

- **Failure mode is unchanged:** if neither the stream nor the fallback yields a price, the live-price button stays hidden and the simulator slider still works — identical to today's degraded behavior.
- **The fallback parser fails closed:** it verifies the account's feed ID against the known HNT/USD feed (`0x649f…9756`) and rejects anything that doesn't match, so a layout drift can't render a garbage price.
- **Payloads are handled defensively:** the stream's `spot` block can be `null`; the widget type-checks `oracle.usd` before applying it, and a fallback response can't overwrite a fresher stream price that arrived while the RPC read was in flight.
- **Verified:** live-tested in a browser — stream path renders the price instantly with 0 RPC calls; pointing the stream at a dead URL fired exactly one 2-call RPC fallback that rendered the identical price (both paths read the same oracle account). Byte offsets confirmed empirically against mainnet. `yarn build` and Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)