### PR TITLE
Meraki guides: flag Native RadSec as paid/not self-serve, document AP MAC NAS-ID formats

### DIFF
--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
@@ -35,10 +35,7 @@ RadSecProxy container on your own hardware.
 - Guide assumes the network is using an on-prem Meraki MX Controller.
 - Meraki system has AP(s) linked to the MX Controller.
 - Meraki system has basic traffic routing working with existing SSID(s).
-- Must have the Meraki specific certificate used for the Helium Plus Meraki onboarding process
-  (`helium_bfmeraki_ca.pem`, shown as `bf_meraki…` in the Meraki dashboard). This is a different
-  file from the general `ca.pem` used for all other Helium Plus deployments — request it from the
-  Helium team.
+- Must have the Meraki specific certificate used for the Helium Plus Meraki onboarding process.
 
 # High Level Steps
 
@@ -171,6 +168,23 @@ and RADIUS configurations to support Helium Mobile user offload.
       />
     </figure>
 11. Click **Save**
+
+:::warning
+
+The NAS-ID Meraki transmits must match the NAS-ID registered with Helium exactly, character for
+character. A difference in separators alone is enough to fail authentication, so leave the number 1
+drop down on **Custom** and enter the NAS-ID from onboarding.
+
+If you build the NAS ID from the AP MAC address instead, be aware that Meraki formats the MAC
+differently depending on how it is selected:
+
+- Used as part of a **template**, the MAC is sent dash-separated: `AA-BB-CC-DD-EE-FF`
+- Selected on its own, **not** as a template, the MAC is sent with no separators at all:
+  `AABBCCDDEEFF`
+
+Either format works, but whichever one you configure must be the one registered with Helium.
+
+:::
 
 ## Build Hotspot 2.0 Config
 

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
@@ -10,6 +10,23 @@ slug: /mobile/helium-plus-meraki-plus
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
+:::important
+
+**This method is not self-serve.** It does not apply to networks onboarded through self-serve
+tooling, and requires a Helium Plus agreement.
+
+Unlike vendors that connect straight to the Helium AAA, Meraki builds a CA certificate for each
+group of APs, and that certificate must be loaded on the Helium AAA by the Helium team. Because of
+this requirement, your APs authenticate through a FreeRADIUS instance that Helium hosts and operates
+on your behalf. **Extra charges apply for this service** — contact the Helium team to confirm terms
+before starting.
+
+If you would rather host the connection yourself and avoid these charges, follow the
+[Cisco Meraki RadSecProxy Conversion Guide](/mobile/helium-plus-meraki) instead, which runs the
+RadSecProxy container on your own hardware.
+
+:::
+
 ## Prerequisites
 
 - Meraki system must be running
@@ -18,7 +35,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 - Guide assumes the network is using an on-prem Meraki MX Controller.
 - Meraki system has AP(s) linked to the MX Controller.
 - Meraki system has basic traffic routing working with existing SSID(s).
-- Must have the Meraki specific certificate used for the Helium Plus Meraki onboarding process.
+- Must have the Meraki specific certificate used for the Helium Plus Meraki onboarding process
+  (`helium_bfmeraki_ca.pem`, shown as `bf_meraki…` in the Meraki dashboard). This is a different
+  file from the general `ca.pem` used for all other Helium Plus deployments — request it from the
+  Helium team.
 
 # High Level Steps
 

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
@@ -175,14 +175,17 @@ The NAS-ID Meraki transmits must match the NAS-ID registered with Helium exactly
 character. A difference in separators alone is enough to fail authentication, so leave the number 1
 drop down on **Custom** and enter the NAS-ID from onboarding.
 
-If you build the NAS ID from the AP MAC address instead, be aware that Meraki formats the MAC
-differently depending on how it is selected:
+If you select **AP MAC address** as the NAS ID instead, be aware that the format Meraki transmits
+depends on how the SSID itself was built:
 
-- Used as part of a **template**, the MAC is sent dash-separated: `AA-BB-CC-DD-EE-FF`
-- Selected on its own, **not** as a template, the MAC is sent with no separators at all:
-  `AABBCCDDEEFF`
+- On an SSID applied from a **template** across multiple sites, the MAC is sent dash-separated and
+  upper case: `E0-CB-BC-48-BC-76`
+- On a normal, single-site SSID, the same AP sends the MAC with no separators at all:
+  `E0CBBC48BC76`
 
-Either format works, but whichever one you configure must be the one registered with Helium.
+Either format works, but the one your SSID actually sends has to be the one registered with Helium.
+Moving an SSID between the two afterwards changes the NAS-ID, and the new value has to be
+re-registered before those APs will authenticate.
 
 :::
 

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki-plus.mdx
@@ -180,8 +180,7 @@ depends on how the SSID itself was built:
 
 - On an SSID applied from a **template** across multiple sites, the MAC is sent dash-separated and
   upper case: `E0-CB-BC-48-BC-76`
-- On a normal, single-site SSID, the same AP sends the MAC with no separators at all:
-  `E0CBBC48BC76`
+- On a normal, single-site SSID, the same AP sends the MAC with no separators at all: `E0CBBC48BC76`
 
 Either format works, but the one your SSID actually sends has to be the one registered with Helium.
 Moving an SSID between the two afterwards changes the NAS-ID, and the new value has to be

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
@@ -188,6 +188,23 @@ Meraki devices.
     </figure>
 11. Click **Save**
 
+:::warning
+
+The NAS-ID Meraki transmits must match the NAS-ID registered with Helium exactly, character for
+character. A difference in separators alone is enough to fail authentication, so leave the number 1
+drop down on **Custom** and enter the NAS-ID from onboarding.
+
+If you build the NAS ID from the AP MAC address instead, be aware that Meraki formats the MAC
+differently depending on how it is selected:
+
+- Used as part of a **template**, the MAC is sent dash-separated: `AA-BB-CC-DD-EE-FF`
+- Selected on its own, **not** as a template, the MAC is sent with no separators at all:
+  `AABBCCDDEEFF`
+
+Either format works, but whichever one you configure must be the one registered with Helium.
+
+:::
+
 ## Build Hotspot 2.0 Config
 
 1. Click on **Wireless** and navigate to **Hotspot 2.0**

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
@@ -199,8 +199,7 @@ depends on how the SSID itself was built:
 
 - On an SSID applied from a **template** across multiple sites, the MAC is sent dash-separated and
   upper case: `E0-CB-BC-48-BC-76`
-- On a normal, single-site SSID, the same AP sends the MAC with no separators at all:
-  `E0CBBC48BC76`
+- On a normal, single-site SSID, the same AP sends the MAC with no separators at all: `E0CBBC48BC76`
 
 Either format works, but the one your SSID actually sends has to be the one registered with Helium.
 Moving an SSID between the two afterwards changes the NAS-ID, and the new value has to be

--- a/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
+++ b/docs/network-mobile/helium-plus-guides/helium-plus-meraki.mdx
@@ -194,14 +194,17 @@ The NAS-ID Meraki transmits must match the NAS-ID registered with Helium exactly
 character. A difference in separators alone is enough to fail authentication, so leave the number 1
 drop down on **Custom** and enter the NAS-ID from onboarding.
 
-If you build the NAS ID from the AP MAC address instead, be aware that Meraki formats the MAC
-differently depending on how it is selected:
+If you select **AP MAC address** as the NAS ID instead, be aware that the format Meraki transmits
+depends on how the SSID itself was built:
 
-- Used as part of a **template**, the MAC is sent dash-separated: `AA-BB-CC-DD-EE-FF`
-- Selected on its own, **not** as a template, the MAC is sent with no separators at all:
-  `AABBCCDDEEFF`
+- On an SSID applied from a **template** across multiple sites, the MAC is sent dash-separated and
+  upper case: `E0-CB-BC-48-BC-76`
+- On a normal, single-site SSID, the same AP sends the MAC with no separators at all:
+  `E0CBBC48BC76`
 
-Either format works, but whichever one you configure must be the one registered with Helium.
+Either format works, but the one your SSID actually sends has to be the one registered with Helium.
+Moving an SSID between the two afterwards changes the NAS-ID, and the new value has to be
+re-registered before those APs will authenticate.
 
 :::
 


### PR DESCRIPTION
Two fixes to the Cisco Meraki Helium Plus guides, both from partner onboarding confusion (Hudson House hit each of them).

### 1. Native RadSec is not self-serve and carries fees

Partners have been arriving at the **Meraki Native RadSec** guide expecting a self-serve, no-cost setup.

This path is different from every other Helium Plus vendor guide: Meraki builds a CA certificate for each group of APs, and that certificate has to be loaded onto the Helium AAA by the Helium team. That's why these APs authenticate through a **FreeRADIUS instance Helium hosts and operates**, which is a paid service and requires a Helium Plus agreement.

`helium-plus-meraki-plus.mdx` now opens with an `:::important` admonition stating this, and points readers who'd rather host it themselves at the [Cisco Meraki RadSecProxy Conversion Guide](https://docs.helium.com/mobile/helium-plus-meraki), which runs the RadSecProxy container on their own hardware at no charge.

Wording follows Claudio's suggested disclaimer from the internal thread.

### 2. NAS-ID format when the AP MAC is used

The **NAS ID** field under Advanced RADIUS settings can be set to the **AP MAC address**, and Meraki formats that MAC differently depending on how the SSID was built:

- SSID applied from a **template** across multiple sites → dash-separated, upper case: `E0-CB-BC-48-BC-76`
- normal single-site SSID → no separators at all: `E0CBBC48BC76`

Either is fine, but the NAS-ID registered with Helium has to match the one the SSID actually sends — a difference in separators alone fails authentication, and moving an SSID between the two changes the NAS-ID and requires re-registration. This is what Hudson House hit, and it forced a NAS resubmission.

Both guides now carry a warning to this effect after the Advanced RADIUS settings steps. It's dashboard behavior rather than anything transport-specific, so it applies to the RadSecProxy guide equally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
